### PR TITLE
feat: retry on failure with Slack button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ internal/
   config/config.go           # YAML config: agents, channels, prompt, rate limits
   bot/
     workflow.go              # Orchestrator: trigger → interact → spawn agent → parse → issue
-    agent.go                 # AgentRunner: spawn CLI agent with fallback chain
+    agent.go                 # AgentRunner: spawn CLI agent with provider chain
     parser.go                # Parse agent output (===TRIAGE_RESULT=== CREATED/REJECTED/ERROR)
     prompt.go                # Build minimal user prompt for CLI agent
     enrich.go                # Expand Mantis URLs in messages
@@ -48,8 +48,8 @@ This is a **structuring tool**, not a diagnosis tool. The core value is turning 
 ### CLI Agent Delegation (v2)
 Instead of implementing a custom agent loop with tools, the bot spawns external CLI agents (claude, opencode, codex, gemini) that use their own built-in tools to explore the codebase. The bot sends a minimal prompt with thread context and repo path, and parses the structured output.
 
-### Multi-Agent Fallback
-Agents are configured in YAML. If the active agent fails (timeout, not found, error), the bot tries the next agent in the fallback chain.
+### Multi-Agent Providers
+Agents are configured in YAML with a `providers` list. If the active provider fails (timeout, not found, error), the bot tries the next provider in the chain.
 
 ### Output Format
 Agent creates the GitHub issue directly via `gh issue create` and outputs a result marker. The parser looks for `===TRIAGE_RESULT===` followed by `CREATED: {url}`, `REJECTED: {reason}`, or `ERROR: {message}`. If the marker is missing, the parser falls back to extracting a GitHub issue URL from the output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ internal/
     agent.go                 # AgentRunner: spawn CLI agent with provider chain
     parser.go                # Parse agent output (===TRIAGE_RESULT=== CREATED/REJECTED/ERROR)
     prompt.go                # Build minimal user prompt for CLI agent
+    result_listener.go       # ResultBus → create issue / retry button → Slack
+    retry_handler.go         # Retry button interaction → re-submit job
     enrich.go                # Expand Mantis URLs in messages
   slack/
     client.go                # PostMessage/PostSelector/FetchThreadContext/DownloadAttachments

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx ./bot worker
 
 自訂 agent：
 ```bash
-REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx FALLBACK=codex ./bot worker
+REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx PROVIDERS=codex ./bot worker
 ```
 
 Worker 內建三個 agent 的預設 config（claude/codex/opencode），不需要 YAML。Redis 地址和 token 透過環境變數傳入。
@@ -334,7 +334,7 @@ docker run -e SLACK_BOT_TOKEN=xoxb-... \
 # Worker 模式（Redis，獨立消費 job）
 docker run -e REDIS_ADDR=redis:6379 \
            -e GITHUB_TOKEN=ghp_... \
-           -e FALLBACK=claude \
+           -e PROVIDERS=claude \
            -e ANTHROPIC_API_KEY=sk-ant-... \
            agentdock worker
 ```
@@ -354,7 +354,7 @@ Worker 透過 `PROVIDERS` 環境變數選擇要使用的 agent（逗號分隔，
 # 用 claude
 docker run -e PROVIDERS=claude -e ANTHROPIC_API_KEY=sk-ant-... ...
 
-# 用 codex，fallback 到 claude
+# 用 codex，fallback 到 claude（依序嘗試）
 docker run -e PROVIDERS=codex,claude -e OPENAI_API_KEY=sk-... -e ANTHROPIC_API_KEY=sk-ant-... ...
 
 # 用 opencode
@@ -432,7 +432,8 @@ internal/
     agent.go                 # AgentRunner: spawn CLI agent with RunOptions + stream
     parser.go                # parse ===TRIAGE_RESULT=== JSON (+ legacy fallback)
     prompt.go                # build user prompt for CLI agent
-    result_listener.go       # ResultBus → create issue → post Slack
+    result_listener.go       # ResultBus → create issue / retry button → post Slack
+    retry_handler.go         # Retry button interaction → re-submit job to queue
     status_listener.go       # StatusBus → update JobStore agent tracking
     enrich.go                # expand Mantis URLs in messages
   slack/

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ agents:
     skill_dir: ".opencode/skills"
 
 active_agent: claude
-fallback: [claude, opencode]
+providers: [claude, opencode]
 
 # Queue 設定
 queue:
@@ -348,17 +348,17 @@ docker run -e REDIS_ADDR=redis:6379 \
 
 #### Agent 選擇與 API Key
 
-Worker 透過 `FALLBACK` 環境變數選擇要使用的 agent（逗號分隔，依序 fallback），不需要修改 config 檔：
+Worker 透過 `PROVIDERS` 環境變數選擇要使用的 agent（逗號分隔，依序嘗試），不需要修改 config 檔：
 
 ```bash
 # 用 claude
-docker run -e FALLBACK=claude -e ANTHROPIC_API_KEY=sk-ant-... ...
+docker run -e PROVIDERS=claude -e ANTHROPIC_API_KEY=sk-ant-... ...
 
 # 用 codex，fallback 到 claude
-docker run -e FALLBACK=codex,claude -e OPENAI_API_KEY=sk-... -e ANTHROPIC_API_KEY=sk-ant-... ...
+docker run -e PROVIDERS=codex,claude -e OPENAI_API_KEY=sk-... -e ANTHROPIC_API_KEY=sk-ant-... ...
 
 # 用 opencode
-docker run -e FALLBACK=opencode -e ANTHROPIC_API_KEY=sk-ant-... ...
+docker run -e PROVIDERS=opencode -e ANTHROPIC_API_KEY=sk-ant-... ...
 ```
 
 | Agent | API Key 環境變數 | 取得方式 |
@@ -367,7 +367,7 @@ docker run -e FALLBACK=opencode -e ANTHROPIC_API_KEY=sk-ant-... ...
 | codex | `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com) |
 | opencode | `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com) |
 
-只需要傳 `FALLBACK` 裡列出的 agent 的 API key。
+只需要傳 `PROVIDERS` 裡列出的 agent 的 API key。
 
 #### 所有環境變數
 
@@ -378,7 +378,7 @@ docker run -e FALLBACK=opencode -e ANTHROPIC_API_KEY=sk-ant-... ...
 | `GITHUB_TOKEN` | GitHub token（App: read+write, Worker: read） | 是 |
 | `REDIS_ADDR` | Redis 連線地址 | Redis 模式 |
 | `REDIS_PASSWORD` | Redis 密碼 | 有密碼時 |
-| `FALLBACK` | Agent fallback 順序（逗號分隔） | 否（預設用 config） |
+| `PROVIDERS` | Agent provider 順序（逗號分隔） | 否（預設用 config） |
 | `ACTIVE_AGENT` | 主要 agent | 否（預設用 config） |
 | `CLAUDE_AUTH_TOKEN` | Claude CLI auth | 用 claude 時 |
 | `OPENAI_API_KEY` | Codex CLI auth | 用 codex 時 |

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -400,6 +400,10 @@ func (a *slackPosterAdapter) UpdateMessage(channelID, messageTS, text string) {
 	}
 }
 
+func (a *slackPosterAdapter) PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error) {
+	return a.client.PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value)
+}
+
 func parseLogLevel(level string) slog.Level {
 	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "debug":

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -178,7 +178,11 @@ func main() {
 	wf.SetHandler(handler)
 
 	issueClient := ghclient.NewIssueClient(cfg.GitHub.Token)
-	resultListener := bot.NewResultListener(bundle.Results, jobStore, bundle.Attachments, &slackPosterAdapter{client: slackClient}, issueClient)
+	resultListener := bot.NewResultListener(bundle.Results, jobStore, bundle.Attachments,
+		&slackPosterAdapter{client: slackClient}, issueClient,
+		func(channelID, threadTS string) {
+			handler.ClearThreadDedup(channelID, threadTS)
+		})
 	go resultListener.Listen(context.Background())
 
 	statusListener := bot.NewStatusListener(bundle.Status, jobStore)

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -118,10 +118,10 @@ func main() {
 		slog.Info("using in-memory transport")
 	}
 
-	// Collect skill dirs from all agents in fallback chain.
+	// Collect skill dirs from all agents in provider chain.
 	seen := make(map[string]bool)
 	var skillDirs []string
-	for _, name := range cfg.Fallback {
+	for _, name := range cfg.Providers {
 		if agent, ok := cfg.Agents[name]; ok && agent.SkillDir != "" && !seen[agent.SkillDir] {
 			skillDirs = append(skillDirs, agent.SkillDir)
 			seen[agent.SkillDir] = true

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -184,17 +184,11 @@ func main() {
 	statusListener := bot.NewStatusListener(bundle.Status, jobStore)
 	go statusListener.Listen(context.Background())
 
-	// Job watchdog — detect stuck jobs and notify Slack.
-	slackAdapter := &slackPosterAdapter{client: slackClient}
-	watchdog := queue.NewWatchdog(jobStore, bundle.Commands, queue.WatchdogConfig{
+	// Job watchdog — detect stuck jobs and publish failures to ResultBus.
+	watchdog := queue.NewWatchdog(jobStore, bundle.Commands, bundle.Results, queue.WatchdogConfig{
 		JobTimeout:     cfg.Queue.JobTimeout,
 		IdleTimeout:    cfg.Queue.AgentIdleTimeout,
 		PrepareTimeout: cfg.Queue.PrepareTimeout,
-	}, func(job *queue.Job, status queue.JobStatus, reason string) {
-		msg := queue.FormatStuckMessage(job, status, reason)
-		slackAdapter.PostMessage(job.ChannelID, msg, job.ThreadTS)
-		// Also clear dedup so user can re-trigger.
-		handler.ClearThreadDedup(job.ChannelID, job.ThreadTS)
 	})
 	go watchdog.Start(make(chan struct{})) // runs until process exits
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -185,6 +185,8 @@ func main() {
 		})
 	go resultListener.Listen(context.Background())
 
+	retryHandler := bot.NewRetryHandler(jobStore, coordinator, &slackPosterAdapter{client: slackClient})
+
 	statusListener := bot.NewStatusListener(bundle.Status, jobStore)
 	go statusListener.Listen(context.Background())
 
@@ -317,6 +319,9 @@ func main() {
 
 					case strings.HasPrefix(action.ActionID, "description_action"):
 						wf.HandleDescriptionAction(cb.Channel.ID, action.Value, selectorTS, cb.TriggerID)
+
+					case action.ActionID == "retry_job":
+						retryHandler.Handle(cb.Channel.ID, action.Value, selectorTS)
 
 					case strings.HasPrefix(action.ActionID, "cancel_job"):
 						jobID := action.Value

--- a/cmd/bot/worker.go
+++ b/cmd/bot/worker.go
@@ -60,7 +60,7 @@ func runWorker() {
 	// Collect skill dirs.
 	var skillDirs []string
 	seen := make(map[string]bool)
-	for _, name := range cfg.Fallback {
+	for _, name := range cfg.Providers {
 		if agent, ok := cfg.Agents[name]; ok && agent.SkillDir != "" && !seen[agent.SkillDir] {
 			skillDirs = append(skillDirs, agent.SkillDir)
 			seen[agent.SkillDir] = true

--- a/cmd/bot/worker.go
+++ b/cmd/bot/worker.go
@@ -67,6 +67,11 @@ func runWorker() {
 		}
 	}
 
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
+	}
+
 	pool := worker.NewPool(worker.Config{
 		Queue:          bundle.Queue,
 		Attachments:    bundle.Attachments,
@@ -75,6 +80,7 @@ func runWorker() {
 		Runner:         &agentRunnerAdapter{runner: agentRunner},
 		RepoCache:      &repoCacheAdapter{cache: repoCache},
 		WorkerCount:    cfg.Workers.Count,
+		Hostname:       hostname,
 		SkillDirs:      skillDirs,
 		Commands:       bundle.Commands,
 		Status:         bundle.Status,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,7 +28,7 @@ github:
   token: "ghp_your-token"
 
 # === Agents ===
-# CLI agents are spawned as subprocesses. Tried in fallback order.
+# CLI agents are spawned as subprocesses. Tried in provider order.
 agents:
   claude:
     command: claude
@@ -52,7 +52,7 @@ agents:
   #   timeout: 5m
 
 active_agent: claude
-fallback: [claude, opencode]
+providers: [claude, opencode]
 
 # === Prompt ===
 prompt:

--- a/docs/superpowers/plans/2026-04-14-retry-on-failure.md
+++ b/docs/superpowers/plans/2026-04-14-retry-on-failure.md
@@ -1,0 +1,1408 @@
+# Retry on Failure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Slack retry button on job failure, with max 1 retry, unified failure handling through ResultBus, and visible worker identity.
+
+**Architecture:** Watchdog stops posting to Slack directly and instead publishes failed results to ResultBus. ResultListener becomes the single exit point for all job outcomes — it decides whether to show a retry button based on RetryCount. A new RetryHandler struct handles button clicks by creating a new job and submitting it to the queue.
+
+**Tech Stack:** Go, Slack Block Kit (buttons), Redis Streams / InMem transport (no new deps)
+
+**Spec:** `docs/superpowers/specs/2026-04-14-retry-on-failure-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `internal/queue/job.go` | Modify | Add `RetryCount`, `RetryOfJobID` fields to `Job` |
+| `internal/queue/watchdog.go` | Modify | Remove `StuckNotifier`; add `ResultBus`; publish failed result |
+| `internal/bot/result_listener.go` | Modify | `processedJobs` dedup; retry button logic; conditional dedup clear; WorkerID display |
+| `internal/bot/result_listener_test.go` | Modify | Update mock; add dedup/button/no-button tests |
+| `internal/bot/retry_handler.go` | Create | `RetryHandler` struct — handles retry button interaction |
+| `internal/bot/retry_handler_test.go` | Create | Tests for RetryHandler |
+| `internal/bot/workflow.go` | Modify | Bug fix: set `UserID` on Job |
+| `internal/worker/pool.go` | Modify | Hostname in worker ID; call `SetWorker()` after Ack |
+| `cmd/bot/main.go` | Modify | Watchdog wiring; slackPosterAdapter; retry_job routing |
+| `cmd/bot/worker.go` | Modify | Pass hostname to Pool |
+
+---
+
+### Task 1: Add RetryCount and RetryOfJobID to Job
+
+**Files:**
+- Modify: `internal/queue/job.go:18-35`
+
+- [ ] **Step 1: Add fields to Job struct**
+
+In `internal/queue/job.go`, add two fields to the `Job` struct after `TaskType`:
+
+```go
+TaskType    string            `json:"task_type,omitempty"`
+RetryCount  int               `json:"retry_count,omitempty"`
+RetryOfJobID string           `json:"retry_of_job_id,omitempty"`
+SubmittedAt time.Time         `json:"submitted_at"`
+```
+
+- [ ] **Step 2: Run tests to verify nothing breaks**
+
+Run: `go test ./...`
+Expected: All 114 tests pass (fields are zero-valued by default, no existing code references them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/queue/job.go
+git commit -m "feat: add RetryCount and RetryOfJobID to Job struct"
+```
+
+---
+
+### Task 2: Fix UserID bug in workflow.go
+
+**Files:**
+- Modify: `internal/bot/workflow.go:137-144` and `internal/bot/workflow.go:414-427`
+
+- [ ] **Step 1: Add UserID to pendingTriage**
+
+In `internal/bot/workflow.go`, the `HandleTrigger` method creates a `pendingTriage` at line 137. Add `UserID` from the event. Change the `pendingTriage` initialization:
+
+```go
+pt := &pendingTriage{
+    ChannelID:   event.ChannelID,
+    ThreadTS:    event.ThreadTS,
+    TriggerTS:   event.TriggerTS,
+    Reporter:    reporter,
+    ChannelName: channelName,
+    CmdArgs:     parseTriggerArgs(event.Text),
+}
+```
+
+to:
+
+```go
+pt := &pendingTriage{
+    ChannelID:   event.ChannelID,
+    ThreadTS:    event.ThreadTS,
+    TriggerTS:   event.TriggerTS,
+    UserID:      event.UserID,
+    Reporter:    reporter,
+    ChannelName: channelName,
+    CmdArgs:     parseTriggerArgs(event.Text),
+}
+```
+
+This requires adding `UserID string` to the `pendingTriage` struct (after `TriggerTS`):
+
+```go
+type pendingTriage struct {
+    ChannelID      string
+    ThreadTS       string
+    TriggerTS      string
+    UserID         string
+    Attachments    []string
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 2: Set UserID on Job in runTriage**
+
+In `runTriage()` at line 414, add `UserID` to the Job:
+
+```go
+job := &queue.Job{
+    ID:          pt.RequestID,
+    Priority:    w.channelPriority(pt.ChannelID),
+    ChannelID:   pt.ChannelID,
+    ThreadTS:    pt.ThreadTS,
+    UserID:      pt.UserID,
+    Repo:        pt.SelectedRepo,
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./...`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/bot/workflow.go
+git commit -m "fix: set UserID on Job in workflow submission"
+```
+
+---
+
+### Task 3: Promote PostMessageWithButton to SlackPoster interface
+
+**Files:**
+- Modify: `internal/bot/result_listener.go:12-16`
+- Modify: `internal/bot/result_listener_test.go:13-28`
+- Modify: `cmd/bot/main.go:385-401`
+
+- [ ] **Step 1: Add PostMessageWithButton to SlackPoster interface**
+
+In `internal/bot/result_listener.go`, update the `SlackPoster` interface:
+
+```go
+type SlackPoster interface {
+	PostMessage(channelID, text, threadTS string)
+	UpdateMessage(channelID, messageTS, text string)
+	PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
+}
+```
+
+- [ ] **Step 2: Update mockSlackPoster in tests**
+
+In `internal/bot/result_listener_test.go`, add the method to `mockSlackPoster`:
+
+```go
+type mockSlackPoster struct {
+	mu       sync.Mutex
+	messages []string
+	buttons  []string // track button posts
+}
+
+func (m *mockSlackPoster) PostMessage(channelID, text, threadTS string) {
+	m.mu.Lock()
+	m.messages = append(m.messages, text)
+	m.mu.Unlock()
+}
+
+func (m *mockSlackPoster) UpdateMessage(channelID, messageTS, text string) {
+	m.mu.Lock()
+	m.messages = append(m.messages, text)
+	m.mu.Unlock()
+}
+
+func (m *mockSlackPoster) PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error) {
+	m.mu.Lock()
+	m.buttons = append(m.buttons, actionID+":"+value)
+	m.messages = append(m.messages, text)
+	m.mu.Unlock()
+	return "msg-ts-mock", nil
+}
+```
+
+- [ ] **Step 3: Add PostMessageWithButton to slackPosterAdapter**
+
+In `cmd/bot/main.go`, add the method to `slackPosterAdapter`:
+
+```go
+func (a *slackPosterAdapter) PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error) {
+	return a.client.PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./...`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/bot/result_listener.go internal/bot/result_listener_test.go cmd/bot/main.go
+git commit -m "refactor: promote PostMessageWithButton to SlackPoster interface"
+```
+
+---
+
+### Task 4: Refactor Watchdog to publish to ResultBus
+
+**Files:**
+- Modify: `internal/queue/watchdog.go`
+- Create: `internal/queue/watchdog_test.go`
+- Modify: `cmd/bot/main.go:187-199`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/queue/watchdog_test.go`:
+
+```go
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWatchdog_PublishesFailedResultOnTimeout(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-10 * time.Minute)})
+	store.UpdateStatus("j1", JobRunning)
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{
+		JobTimeout:     1 * time.Minute,
+		IdleTimeout:    0,
+		PrepareTimeout: 0,
+	})
+
+	wd.check()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ch, _ := results.Subscribe(ctx)
+	select {
+	case result := <-ch:
+		if result.JobID != "j1" {
+			t.Errorf("jobID = %q, want j1", result.JobID)
+		}
+		if result.Status != "failed" {
+			t.Errorf("status = %q, want failed", result.Status)
+		}
+		if result.Error == "" {
+			t.Error("error should contain timeout reason")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for result on ResultBus")
+	}
+
+	// Verify job marked as failed in store (prevents re-tick).
+	state, _ := store.Get("j1")
+	if state.Status != JobFailed {
+		t.Errorf("store status = %q, want failed", state.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/queue/ -run TestWatchdog_PublishesFailedResultOnTimeout -v`
+Expected: FAIL — `NewWatchdog` signature mismatch (still expects `StuckNotifier`).
+
+- [ ] **Step 3: Refactor Watchdog**
+
+Replace the full content of `internal/queue/watchdog.go`:
+
+```go
+package queue
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+type WatchdogConfig struct {
+	JobTimeout     time.Duration
+	IdleTimeout    time.Duration
+	PrepareTimeout time.Duration
+}
+
+type Watchdog struct {
+	store          JobStore
+	commands       CommandBus
+	results        ResultBus
+	jobTimeout     time.Duration
+	idleTimeout    time.Duration
+	prepareTimeout time.Duration
+	interval       time.Duration
+}
+
+func NewWatchdog(store JobStore, commands CommandBus, results ResultBus, cfg WatchdogConfig) *Watchdog {
+	interval := cfg.JobTimeout / 3
+	if interval < 30*time.Second {
+		interval = 30 * time.Second
+	}
+	return &Watchdog{
+		store:          store,
+		commands:       commands,
+		results:        results,
+		jobTimeout:     cfg.JobTimeout,
+		idleTimeout:    cfg.IdleTimeout,
+		prepareTimeout: cfg.PrepareTimeout,
+		interval:       interval,
+	}
+}
+
+func (w *Watchdog) Start(stop <-chan struct{}) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	slog.Info("job watchdog started",
+		"job_timeout", w.jobTimeout,
+		"idle_timeout", w.idleTimeout,
+		"prepare_timeout", w.prepareTimeout,
+		"check_interval", w.interval,
+	)
+
+	for {
+		select {
+		case <-ticker.C:
+			w.check()
+		case <-stop:
+			slog.Info("job watchdog stopped")
+			return
+		}
+	}
+}
+
+func (w *Watchdog) check() {
+	all, err := w.store.ListAll()
+	if err != nil {
+		slog.Warn("watchdog: failed to list jobs", "error", err)
+		return
+	}
+
+	now := time.Now()
+	for _, state := range all {
+		if state.Status == JobCompleted || state.Status == JobFailed {
+			continue
+		}
+
+		// 1. Job-level timeout (all jobs)
+		if now.Sub(state.Job.SubmittedAt) > w.jobTimeout {
+			w.killAndPublish(state, "job timeout")
+			continue
+		}
+
+		// 2. Prepare timeout (stuck in preparing stage)
+		if state.Status == JobPreparing && w.prepareTimeout > 0 {
+			if state.AgentStatus == nil || state.AgentStatus.LastEventAt.IsZero() {
+				if !state.StartedAt.IsZero() && now.Sub(state.StartedAt) > w.prepareTimeout {
+					w.killAndPublish(state, "prepare timeout")
+					continue
+				}
+			}
+		}
+
+		// 3. Agent idle timeout (stream-json agents only)
+		if w.idleTimeout > 0 && state.AgentStatus != nil && !state.AgentStatus.LastEventAt.IsZero() {
+			if now.Sub(state.AgentStatus.LastEventAt) > w.idleTimeout {
+				w.killAndPublish(state, "agent idle timeout")
+				continue
+			}
+		}
+	}
+}
+
+func (w *Watchdog) killAndPublish(state *JobState, reason string) {
+	slog.Warn("watchdog: killing stuck job",
+		"job_id", state.Job.ID, "status", state.Status, "reason", reason)
+
+	if w.commands != nil {
+		w.commands.Send(context.Background(), Command{JobID: state.Job.ID, Action: "kill"})
+	}
+
+	// Mark failed in store to prevent re-processing on next tick.
+	w.store.UpdateStatus(state.Job.ID, JobFailed)
+
+	// Publish to ResultBus — ResultListener handles Slack notification.
+	if w.results != nil {
+		w.results.Publish(context.Background(), &JobResult{
+			JobID:      state.Job.ID,
+			Status:     "failed",
+			Error:      fmt.Sprintf("job terminated: %s", reason),
+			FinishedAt: time.Now(),
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/queue/ -run TestWatchdog_PublishesFailedResultOnTimeout -v`
+Expected: PASS
+
+- [ ] **Step 5: Update Watchdog wiring in main.go**
+
+In `cmd/bot/main.go`, replace the watchdog block (lines 187-199):
+
+```go
+	// Job watchdog — detect stuck jobs and notify Slack.
+	slackAdapter := &slackPosterAdapter{client: slackClient}
+	watchdog := queue.NewWatchdog(jobStore, bundle.Commands, queue.WatchdogConfig{
+		JobTimeout:     cfg.Queue.JobTimeout,
+		IdleTimeout:    cfg.Queue.AgentIdleTimeout,
+		PrepareTimeout: cfg.Queue.PrepareTimeout,
+	}, func(job *queue.Job, status queue.JobStatus, reason string) {
+		msg := queue.FormatStuckMessage(job, status, reason)
+		slackAdapter.PostMessage(job.ChannelID, msg, job.ThreadTS)
+		// Also clear dedup so user can re-trigger.
+		handler.ClearThreadDedup(job.ChannelID, job.ThreadTS)
+	})
+```
+
+with:
+
+```go
+	// Job watchdog — detect stuck jobs, publish failed results via ResultBus.
+	watchdog := queue.NewWatchdog(jobStore, bundle.Commands, bundle.Results, queue.WatchdogConfig{
+		JobTimeout:     cfg.Queue.JobTimeout,
+		IdleTimeout:    cfg.Queue.AgentIdleTimeout,
+		PrepareTimeout: cfg.Queue.PrepareTimeout,
+	})
+```
+
+Remove the `slackAdapter` variable if it is no longer used elsewhere. (Check: it was only used here and for `resultListener` at line 181. The `resultListener` at line 181 creates its own `&slackPosterAdapter{client: slackClient}` inline, so this local `slackAdapter` is safe to remove.)
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test ./...`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/queue/watchdog.go internal/queue/watchdog_test.go cmd/bot/main.go
+git commit -m "refactor: watchdog publishes to ResultBus instead of StuckNotifier"
+```
+
+---
+
+### Task 5: ResultListener unified failure handling with retry button
+
+**Files:**
+- Modify: `internal/bot/result_listener.go`
+- Modify: `internal/bot/result_listener_test.go`
+
+- [ ] **Step 1: Write failing test — retry button shown when RetryCount == 0**
+
+Add to `internal/bot/result_listener_test.go`:
+
+```go
+func TestResultListener_FailedShowsRetryButton(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1", RetryCount: 0})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	dedupCleared := false
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) { dedupCleared = true })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID:  "j1",
+		Status: "failed",
+		Error:  "agent crashed",
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	if len(slackMock.buttons) != 1 {
+		t.Fatalf("expected 1 button post, got %d", len(slackMock.buttons))
+	}
+	if slackMock.buttons[0] != "retry_job:j1" {
+		t.Errorf("button = %q, want retry_job:j1", slackMock.buttons[0])
+	}
+	if dedupCleared {
+		t.Error("dedup should NOT be cleared when retry button is shown")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/bot/ -run TestResultListener_FailedShowsRetryButton -v`
+Expected: FAIL — `NewResultListener` signature mismatch.
+
+- [ ] **Step 3: Write failing test — no button when RetryCount >= 1**
+
+Add to `internal/bot/result_listener_test.go`:
+
+```go
+func TestResultListener_FailedNoButtonAfterRetry(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1", RetryCount: 1})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	dedupCleared := false
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) { dedupCleared = true })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID:  "j1",
+		Status: "failed",
+		Error:  "still broken",
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	if len(slackMock.buttons) != 0 {
+		t.Errorf("expected 0 button posts, got %d", len(slackMock.buttons))
+	}
+	found := false
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "重試後仍失敗") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected retry-exhausted message, got %v", slackMock.messages)
+	}
+	if !dedupCleared {
+		t.Error("dedup should be cleared when no retry button")
+	}
+}
+```
+
+- [ ] **Step 4: Write failing test — processedJobs dedup drops duplicate**
+
+Add to `internal/bot/result_listener_test.go`:
+
+```go
+func TestResultListener_DedupDropsDuplicateResult(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1"})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	// Publish two failed results for same job (simulates watchdog + worker race).
+	bundle.Results.Publish(ctx, &queue.JobResult{JobID: "j1", Status: "failed", Error: "timeout"})
+	bundle.Results.Publish(ctx, &queue.JobResult{JobID: "j1", Status: "failed", Error: "context cancelled"})
+
+	time.Sleep(300 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	// Should only see one button post, not two.
+	if len(slackMock.buttons) != 1 {
+		t.Errorf("expected 1 button post (dedup), got %d", len(slackMock.buttons))
+	}
+}
+```
+
+- [ ] **Step 5: Implement ResultListener changes**
+
+Replace `internal/bot/result_listener.go` entirely:
+
+```go
+package bot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"agentdock/internal/queue"
+)
+
+// SlackPoster abstracts Slack message posting for testing.
+type SlackPoster interface {
+	PostMessage(channelID, text, threadTS string)
+	UpdateMessage(channelID, messageTS, text string)
+	PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
+}
+
+// IssueCreator abstracts GitHub issue creation for testing.
+type IssueCreator interface {
+	CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (string, error)
+}
+
+type ResultListener struct {
+	results       queue.ResultBus
+	store         queue.JobStore
+	attachments   queue.AttachmentStore
+	slack         SlackPoster
+	github        IssueCreator
+	onDedupClear  func(channelID, threadTS string)
+
+	mu            sync.Mutex
+	processedJobs map[string]bool
+}
+
+func NewResultListener(
+	results queue.ResultBus,
+	store queue.JobStore,
+	attachments queue.AttachmentStore,
+	slack SlackPoster,
+	github IssueCreator,
+	onDedupClear func(channelID, threadTS string),
+) *ResultListener {
+	return &ResultListener{
+		results:       results,
+		store:         store,
+		attachments:   attachments,
+		slack:         slack,
+		github:        github,
+		onDedupClear:  onDedupClear,
+		processedJobs: make(map[string]bool),
+	}
+}
+
+func (r *ResultListener) Listen(ctx context.Context) {
+	ch, err := r.results.Subscribe(ctx)
+	if err != nil {
+		slog.Error("failed to subscribe to results", "error", err)
+		return
+	}
+
+	for {
+		select {
+		case result, ok := <-ch:
+			if !ok {
+				return
+			}
+			r.handleResult(ctx, result)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResult) {
+	// Dedup guard: drop duplicate results for same job.
+	r.mu.Lock()
+	if r.processedJobs[result.JobID] {
+		r.mu.Unlock()
+		slog.Debug("dropping duplicate result", "job_id", result.JobID)
+		return
+	}
+	r.processedJobs[result.JobID] = true
+	r.mu.Unlock()
+
+	state, err := r.store.Get(result.JobID)
+	if err != nil {
+		slog.Error("job not found for result", "job_id", result.JobID, "error", err)
+		return
+	}
+
+	job := state.Job
+	owner, repo := splitRepo(job.Repo)
+
+	switch {
+	case result.Status == "failed":
+		r.handleFailure(job, state, result)
+
+	case result.Confidence == "low":
+		r.updateStatus(job, ":warning: 判斷不屬於此 repo，已跳過")
+		r.clearDedup(job)
+
+	case result.FilesFound == 0 || result.Questions >= 5:
+		r.createAndPostIssue(ctx, job, owner, repo, result, true)
+		r.clearDedup(job)
+
+	default:
+		r.createAndPostIssue(ctx, job, owner, repo, result, false)
+		r.clearDedup(job)
+	}
+
+	// Cleanup attachments.
+	r.attachments.Cleanup(ctx, result.JobID)
+}
+
+func (r *ResultListener) handleFailure(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
+	r.store.UpdateStatus(job.ID, queue.JobFailed)
+
+	workerID := ""
+	if state.AgentStatus != nil {
+		workerID = state.AgentStatus.WorkerID
+	}
+	if workerID == "" {
+		workerID = state.WorkerID
+	}
+
+	workerInfo := ""
+	if workerID != "" {
+		workerInfo = fmt.Sprintf(" | worker: %s", workerID)
+	}
+
+	if job.RetryCount < 1 {
+		// Show retry button.
+		text := fmt.Sprintf(":x: 分析失敗: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		r.slack.PostMessageWithButton(job.ChannelID, text, job.ThreadTS,
+			"retry_job", "🔄 重試", job.ID)
+		// Do NOT clear dedup — user should use retry button.
+	} else {
+		// Retry exhausted, no button.
+		text := fmt.Sprintf(":x: 分析失敗（重試後仍失敗）: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		r.updateStatus(job, text)
+		r.clearDedup(job)
+	}
+}
+
+func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job, owner, repo string, result *queue.JobResult, degraded bool) {
+	if r.github == nil {
+		r.slack.PostMessage(job.ChannelID,
+			":warning: GitHub client not configured", job.ThreadTS)
+		return
+	}
+
+	body := result.Body
+	if degraded {
+		body = stripTriageSection(body)
+	}
+
+	branchInfo := ""
+	if job.Branch != "" {
+		branchInfo = fmt.Sprintf(" (branch: `%s`)", job.Branch)
+	}
+
+	url, err := r.github.CreateIssue(ctx, owner, repo, result.Title, body, result.Labels)
+	if err != nil {
+		r.updateStatus(job, fmt.Sprintf(":warning: Triage 完成但建立 issue 失敗: %v", err))
+		return
+	}
+
+	r.updateStatus(job, fmt.Sprintf(":white_check_mark: Issue created%s: %s", branchInfo, url))
+}
+
+// updateStatus updates the original status message if possible, otherwise posts a new message.
+func (r *ResultListener) updateStatus(job *queue.Job, text string) {
+	if job.StatusMsgTS != "" {
+		r.slack.UpdateMessage(job.ChannelID, job.StatusMsgTS, text)
+	} else {
+		r.slack.PostMessage(job.ChannelID, text, job.ThreadTS)
+	}
+}
+
+func (r *ResultListener) clearDedup(job *queue.Job) {
+	if r.onDedupClear != nil {
+		r.onDedupClear(job.ChannelID, job.ThreadTS)
+	}
+}
+
+func splitRepo(repo string) (string, string) {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return repo, ""
+	}
+	return parts[0], parts[1]
+}
+
+func stripTriageSection(body string) string {
+	for _, marker := range []string{"## Root Cause Analysis", "## TDD Fix Plan"} {
+		if idx := strings.Index(body, marker); idx > 0 {
+			body = strings.TrimSpace(body[:idx])
+		}
+	}
+	return body
+}
+```
+
+- [ ] **Step 6: Update existing tests to pass new constructor arg**
+
+In `internal/bot/result_listener_test.go`, update the three existing test functions to pass `nil` as the `onDedupClear` callback:
+
+For `TestResultListener_CompletedCreatesIssue`:
+```go
+listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, githubMock, nil)
+```
+
+For `TestResultListener_FailedPostsError`:
+```go
+listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil)
+```
+
+For `TestResultListener_LowConfidenceRejects`:
+```go
+listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil)
+```
+
+- [ ] **Step 7: Update main.go to pass onDedupClear**
+
+In `cmd/bot/main.go`, update the `resultListener` construction (around line 181):
+
+```go
+resultListener := bot.NewResultListener(bundle.Results, jobStore, bundle.Attachments,
+    &slackPosterAdapter{client: slackClient}, issueClient,
+    func(channelID, threadTS string) {
+        handler.ClearThreadDedup(channelID, threadTS)
+    })
+```
+
+- [ ] **Step 8: Run all tests**
+
+Run: `go test ./...`
+Expected: All tests pass, including the three new tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/bot/result_listener.go internal/bot/result_listener_test.go cmd/bot/main.go
+git commit -m "feat: ResultListener unified failure handling with retry button"
+```
+
+---
+
+### Task 6: Create RetryHandler
+
+**Files:**
+- Create: `internal/bot/retry_handler.go`
+- Create: `internal/bot/retry_handler_test.go`
+
+- [ ] **Step 1: Write failing test — successful retry**
+
+Create `internal/bot/retry_handler_test.go`:
+
+```go
+package bot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agentdock/internal/queue"
+)
+
+type mockJobQueue struct {
+	submitted []*queue.Job
+}
+
+func (m *mockJobQueue) Submit(ctx context.Context, job *queue.Job) error {
+	m.submitted = append(m.submitted, job)
+	return nil
+}
+
+func TestRetryHandler_CreatesNewJob(t *testing.T) {
+	store := queue.NewMemJobStore()
+	original := &queue.Job{
+		ID:        "j1",
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		UserID:    "U1",
+		Repo:      "owner/repo",
+		CloneURL:  "https://github.com/owner/repo.git",
+		Branch:    "main",
+		Prompt:    "test prompt",
+		Priority:  50,
+		Skills:    map[string]string{"s1": "content"},
+	}
+	store.Put(original)
+	store.UpdateStatus("j1", queue.JobFailed)
+
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "j1", "msg-ts-1")
+
+	// Verify new job was submitted.
+	if len(q.submitted) != 1 {
+		t.Fatalf("expected 1 submitted job, got %d", len(q.submitted))
+	}
+
+	newJob := q.submitted[0]
+	if newJob.ID == "j1" {
+		t.Error("new job should have a different ID")
+	}
+	if newJob.RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", newJob.RetryCount)
+	}
+	if newJob.RetryOfJobID != "j1" {
+		t.Errorf("RetryOfJobID = %q, want j1", newJob.RetryOfJobID)
+	}
+	if newJob.Prompt != "test prompt" {
+		t.Errorf("Prompt = %q, want test prompt", newJob.Prompt)
+	}
+	if newJob.UserID != "U1" {
+		t.Errorf("UserID = %q, want U1", newJob.UserID)
+	}
+	if newJob.Priority != 50 {
+		t.Errorf("Priority = %d, want 50", newJob.Priority)
+	}
+
+	// Verify old message was updated.
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	foundUpdate := false
+	for _, msg := range slackMock.messages {
+		if msg == ":arrows_counterclockwise: 已重新排入佇列" {
+			foundUpdate = true
+		}
+	}
+	if !foundUpdate {
+		t.Errorf("expected update message, got %v", slackMock.messages)
+	}
+
+	// Verify new status message with cancel button was posted.
+	if len(slackMock.buttons) != 1 {
+		t.Fatalf("expected 1 button post, got %d", len(slackMock.buttons))
+	}
+}
+```
+
+- [ ] **Step 2: Write failing test — job not found (TTL expired)**
+
+Add to `internal/bot/retry_handler_test.go`:
+
+```go
+func TestRetryHandler_JobNotFound(t *testing.T) {
+	store := queue.NewMemJobStore()
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "nonexistent", "msg-ts-1")
+
+	if len(q.submitted) != 0 {
+		t.Error("should not submit when job not found")
+	}
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	if len(slackMock.messages) == 0 {
+		t.Error("should post error message when job not found")
+	}
+}
+```
+
+- [ ] **Step 3: Write failing test — job not in failed state (stale button)**
+
+Add to `internal/bot/retry_handler_test.go`:
+
+```go
+func TestRetryHandler_IgnoresNonFailedJob(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", ChannelID: "C1", ThreadTS: "T1"})
+	store.UpdateStatus("j1", queue.JobCompleted)
+
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "j1", "msg-ts-1")
+
+	if len(q.submitted) != 0 {
+		t.Error("should not submit when job is not failed")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./internal/bot/ -run TestRetryHandler -v`
+Expected: FAIL — `NewRetryHandler` not defined.
+
+- [ ] **Step 5: Implement RetryHandler**
+
+Create `internal/bot/retry_handler.go`:
+
+```go
+package bot
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"agentdock/internal/logging"
+	"agentdock/internal/queue"
+)
+
+// JobSubmitter abstracts queue submission for testing.
+type JobSubmitter interface {
+	Submit(ctx context.Context, job *queue.Job) error
+}
+
+type RetryHandler struct {
+	store queue.JobStore
+	queue JobSubmitter
+	slack SlackPoster
+}
+
+func NewRetryHandler(store queue.JobStore, q JobSubmitter, slack SlackPoster) *RetryHandler {
+	return &RetryHandler{store: store, queue: q, slack: slack}
+}
+
+func (h *RetryHandler) Handle(channelID, jobID, messagTS string) {
+	state, err := h.store.Get(jobID)
+	if err != nil {
+		slog.Warn("retry: job not found", "job_id", jobID, "error", err)
+		h.slack.UpdateMessage(channelID, messagTS, ":warning: 此任務已過期，請重新觸發")
+		return
+	}
+
+	if state.Status != queue.JobFailed {
+		slog.Info("retry: job not in failed state, ignoring", "job_id", jobID, "status", state.Status)
+		return
+	}
+
+	original := state.Job
+
+	// Update old message to indicate retry is queued.
+	h.slack.UpdateMessage(channelID, messagTS, ":arrows_counterclockwise: 已重新排入佇列")
+
+	// Create new job copying relevant fields.
+	newJob := &queue.Job{
+		ID:           logging.NewRequestID(),
+		Priority:     original.Priority,
+		ChannelID:    original.ChannelID,
+		ThreadTS:     original.ThreadTS,
+		UserID:       original.UserID,
+		Repo:         original.Repo,
+		Branch:       original.Branch,
+		CloneURL:     original.CloneURL,
+		Prompt:       original.Prompt,
+		Skills:       original.Skills,
+		RequestID:    logging.NewRequestID(),
+		Attachments:  original.Attachments,
+		RetryCount:   original.RetryCount + 1,
+		RetryOfJobID: original.ID,
+		SubmittedAt:  time.Now(),
+	}
+
+	// Put in store before posting button (so cancel_job can find it).
+	h.store.Put(newJob)
+
+	ctx := context.Background()
+	if err := h.queue.Submit(ctx, newJob); err != nil {
+		slog.Error("retry: failed to submit", "job_id", newJob.ID, "error", err)
+		h.slack.PostMessage(channelID, ":x: 重試失敗: "+err.Error(), original.ThreadTS)
+		return
+	}
+
+	// Post new status message with cancel button.
+	msgTS, err := h.slack.PostMessageWithButton(original.ChannelID,
+		":hourglass_flowing_sand: 重試中，正在處理你的請求...",
+		original.ThreadTS, "cancel_job", "取消", newJob.ID)
+	if err == nil {
+		newJob.StatusMsgTS = msgTS
+		h.store.Put(newJob) // update with StatusMsgTS
+	}
+
+	slog.Info("retry: new job submitted",
+		"original_job_id", original.ID,
+		"new_job_id", newJob.ID,
+		"retry_count", newJob.RetryCount)
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/bot/ -run TestRetryHandler -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/bot/retry_handler.go internal/bot/retry_handler_test.go
+git commit -m "feat: add RetryHandler for retry button interaction"
+```
+
+---
+
+### Task 7: Route retry_job action in main.go
+
+**Files:**
+- Modify: `cmd/bot/main.go:310-334`
+
+- [ ] **Step 1: Create and wire RetryHandler**
+
+In `cmd/bot/main.go`, after the `resultListener` construction (around line 182), add:
+
+```go
+retryHandler := bot.NewRetryHandler(jobStore, coordinator, &slackPosterAdapter{client: slackClient})
+```
+
+- [ ] **Step 2: Add retry_job case to the block_actions switch**
+
+In the `InteractionTypeBlockActions` switch (around line 310), add a new case before the `cancel_job` case:
+
+```go
+					case action.ActionID == "retry_job":
+						retryHandler.Handle(cb.Channel.ID, action.Value, selectorTS)
+```
+
+The full switch block should look like:
+
+```go
+					switch {
+					case action.ActionID == "repo_search" && action.SelectedOption.Value != "":
+						wf.HandleSelection(cb.Channel.ID, action.ActionID, action.SelectedOption.Value, selectorTS)
+
+					case strings.HasPrefix(action.ActionID, "repo_select"):
+						wf.HandleSelection(cb.Channel.ID, action.ActionID, action.Value, selectorTS)
+
+					case strings.HasPrefix(action.ActionID, "branch_select"):
+						wf.HandleSelection(cb.Channel.ID, action.ActionID, action.Value, selectorTS)
+
+					case strings.HasPrefix(action.ActionID, "description_action"):
+						wf.HandleDescriptionAction(cb.Channel.ID, action.Value, selectorTS, cb.TriggerID)
+
+					case action.ActionID == "retry_job":
+						retryHandler.Handle(cb.Channel.ID, action.Value, selectorTS)
+
+					case strings.HasPrefix(action.ActionID, "cancel_job"):
+						// ... existing cancel_job code unchanged
+					}
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test ./...`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/bot/main.go
+git commit -m "feat: route retry_job button action to RetryHandler"
+```
+
+---
+
+### Task 8: Worker identity (hostname + index)
+
+**Files:**
+- Modify: `internal/worker/pool.go:33-36` and `103-110` and `139-141`
+- Modify: `cmd/bot/worker.go:70-82`
+- Modify: `internal/worker/pool_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/worker/pool_test.go`:
+
+```go
+func TestPool_WorkerIDIncludesHostname(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	agentOutput := "Analysis done.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "Bug fix",
+  "body": "## Problem\nSomething broke",
+  "labels": ["bug"],
+  "confidence": "high",
+  "files_found": 3,
+  "open_questions": 0
+}`
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      &mockRunner{output: agentOutput},
+		RepoCache:   &mockRepo{path: "/tmp/test-repo"},
+		WorkerCount: 1,
+		Hostname:    "test-host",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool.Start(ctx)
+	bundle.Attachments.Prepare(ctx, "j1", nil)
+	bundle.Queue.Submit(ctx, &queue.Job{ID: "j1", Priority: 50, Prompt: "test"})
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case <-ch:
+		// Job completed, check worker ID was set.
+		state, _ := store.Get("j1")
+		if state.WorkerID == "" {
+			t.Error("WorkerID should be set after execution")
+		}
+		if state.WorkerID != "test-host/worker-0" {
+			t.Errorf("WorkerID = %q, want test-host/worker-0", state.WorkerID)
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/worker/ -run TestPool_WorkerIDIncludesHostname -v`
+Expected: FAIL — `Config` has no `Hostname` field.
+
+- [ ] **Step 3: Add Hostname to Config and update Pool**
+
+In `internal/worker/pool.go`, add `Hostname` to the `Config` struct:
+
+```go
+type Config struct {
+	Queue          queue.JobQueue
+	Attachments    queue.AttachmentStore
+	Results        queue.ResultBus
+	Store          queue.JobStore
+	Runner         Runner
+	RepoCache      RepoProvider
+	WorkerCount    int
+	Hostname       string
+	SkillDirs      []string
+	Commands       queue.CommandBus
+	Status         queue.StatusBus
+	StatusInterval time.Duration
+}
+```
+
+In `executeWithTracking`, change the `statusAccumulator` init (line 110):
+
+```go
+	workerID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, workerID)
+
+	status := &statusAccumulator{
+		jobID:    job.ID,
+		workerID: workerID,
+		alive:    true,
+	}
+```
+
+Note: the method parameter is also called `workerID int` — rename it to `workerIndex` to avoid collision with the string ID. Update ALL references in the method signature and the logger line:
+
+```go
+func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *queue.Job) {
+	logger := slog.With("worker_id", workerIndex, "job_id", job.ID)
+	jobCtx, jobCancel := context.WithCancel(ctx)
+	defer jobCancel()
+
+	wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, workerIndex)
+
+	status := &statusAccumulator{
+		jobID:    job.ID,
+		workerID: wID,
+		alive:    true,
+	}
+```
+
+The call site in `runWorker` (`p.executeWithTracking(ctx, id, job)`) doesn't change — `id` is already `int`.
+
+- [ ] **Step 4: Call SetWorker after Ack**
+
+In `executeWithTracking`, after the `Ack` call (around line 139-149), add `SetWorker`:
+
+```go
+	// Ack.
+	if err := p.cfg.Queue.Ack(jobCtx, job.ID); err != nil {
+		logger.Error("ack failed", "error", err)
+		p.cfg.Results.Publish(ctx, &queue.JobResult{
+			JobID: job.ID, Status: "failed", Error: fmt.Sprintf("ack failed: %v", err),
+		})
+		if stopReporter != nil {
+			close(stopReporter)
+		}
+		return
+	}
+
+	p.cfg.Store.SetWorker(job.ID, wID)
+```
+
+- [ ] **Step 5: Pass Hostname in worker.go**
+
+In `cmd/bot/worker.go`, get hostname and pass to Pool. Add to imports:
+
+```go
+import (
+	"os"
+	// ... existing imports
+)
+```
+
+Before the `pool := worker.NewPool(...)` call, add:
+
+```go
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
+	}
+```
+
+Add `Hostname` to the Config:
+
+```go
+	pool := worker.NewPool(worker.Config{
+		Queue:          bundle.Queue,
+		Attachments:    bundle.Attachments,
+		Results:        bundle.Results,
+		Store:          jobStore,
+		Runner:         &agentRunnerAdapter{runner: agentRunner},
+		RepoCache:      &repoCacheAdapter{cache: repoCache},
+		WorkerCount:    cfg.Workers.Count,
+		Hostname:       hostname,
+		SkillDirs:      skillDirs,
+		Commands:       bundle.Commands,
+		Status:         bundle.Status,
+		StatusInterval: cfg.Queue.StatusInterval,
+	})
+```
+
+- [ ] **Step 6: Also pass Hostname in main.go (app mode)**
+
+Check if main.go creates a Pool. Search for `worker.NewPool` in main.go:
+
+In `cmd/bot/main.go`, if the app mode also creates a pool (it uses `bundle` and may have workers), find the same pattern and add `Hostname`. If not, this step is a no-op.
+
+(In this codebase, the app mode in `main.go` does NOT create a `worker.Pool` — workers only run in `worker.go`. So this step is a no-op.)
+
+- [ ] **Step 7: Run all tests**
+
+Run: `go test ./...`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/worker/pool.go internal/worker/pool_test.go cmd/bot/worker.go
+git commit -m "feat: include hostname in worker ID for visibility"
+```
+
+---
+
+### Task 9: Final integration verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./... -count=1`
+Expected: All tests pass.
+
+- [ ] **Step 2: Build**
+
+Run: `go build -o bot ./cmd/bot/`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Verify no leftover references**
+
+Run: `grep -r 'StuckNotifier\|FormatStuckMessage' --include='*.go' internal/ cmd/`
+Expected: No matches (these were removed in Task 4).
+
+Run: `grep -r 'cfg\.Fallback' --include='*.go' internal/ cmd/`
+Expected: No matches (renamed to Providers earlier).
+
+- [ ] **Step 4: Commit (if any fixups needed)**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for retry-on-failure feature"
+```

--- a/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
+++ b/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
@@ -1,0 +1,165 @@
+# Retry on Failure Design
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Problem
+
+When a worker crashes, times out, or an agent fails mid-execution, the app relies on watchdog timeout detection to notify the user via Slack. The user must then manually re-tag the bot to retry. This is slow (waits for full timeout) and friction-heavy (requires re-triggering the entire workflow).
+
+## Goals
+
+1. All failure types (watchdog kill, agent error, infra error) are retryable via a Slack button.
+2. Failure reason is visible in the Slack message.
+3. Maximum 1 retry per job. Second failure shows error only, no button.
+4. Re-tagging the bot remains an independent path (re-reads thread context, re-selects repo).
+5. Worker identity (hostname + index) is visible in status and failure messages.
+
+## Non-Goals
+
+- Automatic retry without user action.
+- Retry count > 1.
+- `WORKER_NAME` environment variable override.
+- Re-queuing via Redis pending entry list (PEL) recovery.
+
+## Design
+
+### 1. Job Model Changes
+
+Add two fields to `Job`:
+
+```go
+type Job struct {
+    // ... existing fields
+    RetryCount   int    `json:"retry_count"`      // 0 = first attempt, 1 = retried
+    RetryOfJobID string `json:"retry_of_job_id"`  // original job ID for tracing
+}
+```
+
+Retry creates a **new Job** (new ID) copying the original job's prompt, repo, thread context, branch, and attachments. `RetryCount` is set to `original + 1`.
+
+### 2. Watchdog Publishes to ResultBus
+
+Current flow: Watchdog detects timeout → kills agent → calls `StuckNotifier` callback → callback posts directly to Slack.
+
+New flow: Watchdog detects timeout → kills agent → publishes a `failed` result to `ResultBus`.
+
+Changes to `Watchdog`:
+- Remove `StuckNotifier` type and the `notifier` field.
+- Add `ResultBus` dependency.
+- `killAndNotify()` publishes a `JobResult{Status: "failed", Error: "job terminated: <reason>"}` instead of calling the notifier.
+
+This means all failures — whether from agent execution, infra errors, or watchdog kills — are routed through `ResultListener`.
+
+### 3. ResultListener Unified Failure Handling
+
+`ResultListener.handleResult()` on `status == "failed"`:
+
+```
+if job.RetryCount < 1:
+    post failure message WITH retry button
+else:
+    post failure message WITHOUT button (text indicates retry was attempted)
+```
+
+Message format with button:
+```
+:x: 分析失敗: <error reason>
+repo: owner/repo | worker: Ivans-MacBook-Pro/worker-0
+
+[🔄 重試]   ← Slack button (action_id: "retry_job", value: job.ID)
+```
+
+Message format after retry exhausted:
+```
+:x: 分析失敗（重試後仍失敗）: <error reason>
+repo: owner/repo | worker: a1b2c3d4/worker-0
+```
+
+`SlackPoster` interface gains a new method:
+
+```go
+PostBlocks(channelID, threadTS string, blocks []slack.Block) (string, error)
+```
+
+`ResultListener` reads `JobState.WorkerID` from `JobStore` to include worker identity in the message.
+
+### 4. Retry Button Interaction Handler
+
+New file: `internal/bot/retry_handler.go`
+
+Handles `block_actions` interaction with `action_id: "retry_job"`:
+
+1. Look up original job from `JobStore` using `value` (job ID).
+2. Update the original failure message to `:arrows_counterclockwise: 重試中，已重新排入佇列...` (button removed).
+3. Create new `Job` copying: `Prompt`, `Repo`, `CloneURL`, `Branch`, `ChannelID`, `ThreadTS`, `Attachments`, `Skills`, `Priority`. Set `RetryCount = original + 1`, `RetryOfJobID = original.ID`.
+4. Submit new job to queue.
+5. Set `StatusMsgTS` on the new job to the same message timestamp, so subsequent status updates overwrite it.
+
+Routing: `internal/slack/handler.go` routes `block_actions` with `action_id == "retry_job"` to the retry handler.
+
+### 5. Coexistence with Re-tag Bot
+
+Re-tagging the bot in the same thread triggers the full workflow: re-reads all thread messages, presents repo/branch selector, creates a brand new job. This is completely independent of the retry mechanism.
+
+No conflict because:
+- Retry creates a new job with a new ID.
+- Thread dedup in `handler.go` checks for running/pending jobs. The original failed job is already in `JobFailed` status, so it won't block a new trigger.
+
+### 6. Worker Identity
+
+Worker ID format: `<hostname>/worker-<index>`
+
+- Native: `Ivans-MacBook-Pro/worker-0`
+- Docker: `a1b2c3d4/worker-0` (container short ID from `os.Hostname()`)
+
+Where it's used:
+- `StatusReport.WorkerID` — already exists, currently only `worker-0`. Change to include hostname.
+- `JobState.WorkerID` — already exists. Pool calls `SetWorker()` after Ack.
+- Failure messages in Slack — `ResultListener` reads from `JobState.WorkerID`.
+
+Implementation: `Pool` receives hostname at construction. Each worker goroutine uses `<hostname>/worker-<index>`.
+
+## Data Flow
+
+```
+First attempt:
+  trigger → workflow → Submit(Job{RetryCount:0}) → worker executes
+    → success: ResultListener → create issue → post URL
+    → failure: ResultListener → post error + retry button
+
+Watchdog timeout:
+  watchdog → kill + publish failed result to ResultBus
+    → ResultListener → post error + retry button
+
+User clicks retry:
+  interaction handler → update message to "retrying..."
+    → Submit(Job{RetryCount:1, RetryOfJobID:original}) → worker executes
+      → success: ResultListener → update same message to issue URL
+      → failure: ResultListener → update same message to error (no button)
+
+User re-tags bot:
+  independent new workflow → new thread context → repo selection → new job
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/queue/job.go` | Add `RetryCount`, `RetryOfJobID` to `Job` |
+| `internal/queue/watchdog.go` | Remove `StuckNotifier`, add `ResultBus` dependency |
+| `cmd/bot/main.go` | Update Watchdog wiring: remove notifier, pass ResultBus |
+| `internal/bot/result_listener.go` | Unified failure handling: check RetryCount, post with/without button, show worker |
+| `internal/slack/client.go` | Add `PostBlocks` to `SlackPoster` interface |
+| `internal/bot/retry_handler.go` | New: retry button interaction handler |
+| `internal/slack/handler.go` | Route `block_actions` `retry_job` to retry handler |
+| `internal/worker/pool.go` | Worker ID uses hostname/index; call `SetWorker()` after Ack |
+| `cmd/bot/worker.go` | Pass `os.Hostname()` to Pool at startup |
+
+## Testing
+
+- Unit test: `ResultListener` posts button when `RetryCount == 0`, no button when `RetryCount == 1`.
+- Unit test: retry handler creates new job with correct fields and `RetryCount + 1`.
+- Unit test: Watchdog publishes failed result to ResultBus (no longer calls notifier).
+- Unit test: worker ID format includes hostname.
+- Integration: trigger failure → see button → click retry → job re-executes.

--- a/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
+++ b/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
@@ -36,42 +36,54 @@ type Job struct {
 }
 ```
 
-Retry creates a **new Job** (new ID) copying the original job's prompt, repo, thread context, branch, attachments, user ID, and skills. `RetryCount` is set to `original + 1`.
+Retry creates a **new Job** (new ID via `logging.NewRequestID()`) copying the original job's prompt, repo, thread context, branch, user ID, attachments, and skills. `RetryCount` is set to `original + 1`.
+
+**Bug fix (included in scope):** `workflow.go` currently does not set `UserID` on the Job when submitting. Add `UserID` from `pendingTriage` (sourced from `TriggerEvent.UserID`).
 
 ### 2. Watchdog Publishes to ResultBus
 
 Current flow: Watchdog detects timeout → kills agent → calls `StuckNotifier` callback → callback posts directly to Slack.
 
-New flow: Watchdog detects timeout → kills agent → publishes a `failed` result to `ResultBus`.
+New flow: Watchdog detects timeout → kills agent → marks job as failed → publishes a `failed` result to `ResultBus`.
 
 Changes to `Watchdog`:
 - Remove `StuckNotifier` type and the `notifier` field.
 - Add `ResultBus` dependency.
-- `killAndNotify()` publishes a `JobResult{Status: "failed", Error: "job terminated: <reason>"}` instead of calling the notifier.
+- `killAndNotify()` does three things:
+  1. Send kill command via `CommandBus` (unchanged).
+  2. `store.UpdateStatus(jobID, JobFailed)` — prevents watchdog from re-processing on next tick.
+  3. Publish `JobResult{Status: "failed", Error: "job terminated: <reason>"}` to `ResultBus`.
 - Remove `FormatStuckMessage()` helper (dead code after this change).
 
-**Double-publish guard:** When watchdog kills a job, both the watchdog and the worker may publish a failed result to `ResultBus` (watchdog publishes immediately; worker publishes after context cancellation causes `executeJob` to return). `ResultListener` guards against this: on receiving a failed result, it checks `JobState.Status`. If the job is already in `JobFailed` or `JobCompleted` state, the result is silently dropped. This is set via `UpdateStatus(jobID, JobFailed)` on first processing.
-
-This same guard also prevents stale results from interfering after a retry button click (see Section 4).
+**Double-publish:** Both watchdog and the dying worker may publish a failed result for the same job. This is handled by `ResultListener`'s dedup guard (see Section 3).
 
 ### 3. ResultListener Unified Failure Handling
+
+**Dedup guard:** `ResultListener` maintains an in-memory `processedJobs map[string]bool`. When a result arrives, if the job ID is already in the map, drop it. This prevents double-processing from the watchdog + worker race without relying on store status (which the watchdog sets before publishing).
 
 `ResultListener.handleResult()` on `status == "failed"`:
 
 ```
-if job status already terminal (JobFailed/JobCompleted):
-    drop (duplicate result from watchdog + worker race)
+if processedJobs[jobID]:
+    drop (duplicate)
     return
 
-mark job as JobFailed in store
+processedJobs[jobID] = true
 
 if job.RetryCount < 1:
-    post failure message WITH retry button
+    post failure message WITH retry button (via PostMessageWithButton)
+    do NOT clear thread dedup (user can click retry; tag-bot is blocked while button exists)
 else:
     post failure message WITHOUT button (text indicates retry was attempted)
+    clear thread dedup (allow re-tag bot)
 
-clear thread dedup (allow re-tag bot in same thread)
+cleanup attachments
 ```
+
+**Thread dedup strategy:**
+- `RetryCount < 1` (button shown): Do NOT clear dedup. User either clicks retry or waits for dedup TTL to expire before re-tagging.
+- `RetryCount >= 1` (no button): Clear dedup immediately. User can only re-tag bot.
+- This prevents the race window between clear-dedup and retry-submit where a re-tag could sneak in.
 
 Message format with button:
 ```
@@ -87,52 +99,52 @@ Message format after retry exhausted:
 repo: owner/repo | worker: a1b2c3d4/worker-0
 ```
 
-**Interface changes:** `SlackPoster` gains a new method for posting messages with blocks:
+**Interface changes:** Promote existing `PostMessageWithButton` from `slack.Client` to `SlackPoster` interface:
 
 ```go
 type SlackPoster interface {
     PostMessage(channelID, text, threadTS string)
     UpdateMessage(channelID, messageTS, text string)
-    PostBlocks(channelID, threadTS string, blocks []slack.Block) (string, error)  // new
+    PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
 }
 ```
 
-This requires updates in three places:
-- `internal/bot/result_listener.go` — interface definition
-- `internal/slack/client.go` — concrete `Client` implementation
-- `cmd/bot/main.go` — `slackPosterAdapter` (if one exists) or wiring
+No new methods needed — `PostMessageWithButton` already exists on `slack.Client`. It must be added to the `SlackPoster` interface and the `slackPosterAdapter` in `main.go`.
 
-**Thread dedup:** `ResultListener` needs a `ClearThreadDedup` callback (or dependency on handler) to clear dedup on failure. Without this, re-tagging the bot after failure would be blocked. Currently `ClearThreadDedup` is called in the watchdog notifier callback in `main.go`; this responsibility moves to `ResultListener`.
+**Thread dedup callback:** `ResultListener` receives a `func(channelID, threadTS string)` callback for clearing dedup, rather than depending on `slack.Handler` directly.
 
-`ResultListener` reads `JobState.WorkerID` from `JobStore` to include worker identity in the message. In Redis mode, `WorkerID` reaches the bot's `JobStore` via the `StatusListener` path: worker sends `StatusReport` (with `WorkerID`) → `StatusBus` → `StatusListener` calls `SetAgentStatus()` which stores `WorkerID` in the `StatusReport` field of `JobState`. `ResultListener` reads it from `state.AgentStatus.WorkerID`.
+**Worker identity:** `ResultListener` reads `WorkerID` from `JobState`. In Redis mode, `WorkerID` reaches the bot's `JobStore` via `StatusReport` → `StatusBus` → `StatusListener` → `SetAgentStatus()`. The bot reads it from `state.AgentStatus.WorkerID`.
 
 ### 4. Retry Button Interaction Handler
 
-New file: `internal/bot/retry_handler.go`
+New file: `internal/bot/retry_handler.go` — a `RetryHandler` struct (not inline in main.go).
 
 **Dependencies:**
-- `JobStore` — lookup original job, `Put()` new job
+- `JobStore` — `Get()` original job, `Put()` new job
 - `JobQueue` (or `Coordinator`) — `Submit()` new job
-- `SlackPoster` — update message
+- `SlackPoster` — `UpdateMessage()` + `PostMessageWithButton()`
 
 Handles `block_actions` interaction with `action_id: "retry_job"`:
 
 1. Look up original job from `JobStore` using `value` (job ID). If not found (TTL expired), post error message and return.
-2. If original job is not in `JobFailed` state (e.g., user clicks stale button on a job that already completed), ignore.
-3. Update the original failure message to `:arrows_counterclockwise: 重試中，已重新排入佇列...` (button removed).
-4. Create new `Job` copying: `Prompt`, `Repo`, `CloneURL`, `Branch`, `ChannelID`, `ThreadTS`, `UserID`, `Attachments`, `Skills`, `Priority`. Set `RetryCount = original + 1`, `RetryOfJobID = original.ID`.
-5. Submit new job to queue.
-6. Set `StatusMsgTS` on the new job to the same message timestamp, so subsequent status updates overwrite it.
+2. If original job is not in `JobFailed` state (stale button), ignore.
+3. Update the original failure message to `:arrows_counterclockwise: 已重新排入佇列`.
+4. Create new `Job` with `logging.NewRequestID()`, copying: `Prompt`, `Repo`, `CloneURL`, `Branch`, `ChannelID`, `ThreadTS`, `UserID`, `Attachments`, `Skills`, `Priority`. Set `RetryCount = original + 1`, `RetryOfJobID = original.ID`, `SubmittedAt = time.Now()`.
+5. `store.Put(newJob)` — must happen before PostMessageWithButton so cancel_job can find the job.
+6. `queue.Submit(newJob)`.
+7. Post new status message via `PostMessageWithButton` with `cancel_job` button (retry job also gets a cancel button during execution).
+8. Update `newJob.StatusMsgTS` with the new message timestamp; `store.Put(newJob)` again.
 
-Routing: `internal/slack/handler.go` routes `block_actions` with `action_id == "retry_job"` to the retry handler.
+Routing: `main.go` switch case for `InteractionTypeBlockActions` routes `action_id == "retry_job"` to `retryHandler.Handle()`.
 
 ### 5. Coexistence with Re-tag Bot
 
 Re-tagging the bot in the same thread triggers the full workflow: re-reads all thread messages, presents repo/branch selector, creates a brand new job. This is completely independent of the retry mechanism.
 
 No conflict because:
-- Retry creates a new job with a new ID.
-- Thread dedup is cleared on failure (see Section 3). The original failed job is in `JobFailed` status, so it won't block a new trigger.
+- When retry button is shown (`RetryCount < 1`): dedup is NOT cleared. Re-tag is blocked. User must use the button.
+- When no button (`RetryCount >= 1`): dedup IS cleared. Re-tag works.
+- After dedup TTL expires (5 minutes): re-tag works regardless.
 
 ### 6. Worker Identity
 
@@ -143,8 +155,8 @@ Worker ID format: `<hostname>/worker-<index>`
 
 Where it's used:
 - `StatusReport.WorkerID` — already exists, currently only `worker-0`. Change to include hostname.
-- `JobState.WorkerID` — already exists but `SetWorker()` is never called today. Add call in pool after Ack.
-- In Redis mode, `WorkerID` propagates to the bot via `StatusReport` → `StatusBus` → `StatusListener` → `SetAgentStatus()`. The bot reads it from `state.AgentStatus.WorkerID`.
+- `JobState.WorkerID` — already exists but `SetWorker()` is never called today. Add call in pool after Ack (new behavior).
+- In Redis mode, `WorkerID` propagates to the bot via `StatusReport` → `StatusBus` → `StatusListener` → `SetAgentStatus()`.
 - Failure messages in Slack — `ResultListener` reads from `JobState`.
 
 Implementation: `Pool` receives hostname at construction time (`cmd/bot/worker.go` calls `os.Hostname()`). Each worker goroutine uses `<hostname>/worker-<index>`.
@@ -154,24 +166,26 @@ Implementation: `Pool` receives hostname at construction time (`cmd/bot/worker.g
 ```
 First attempt:
   trigger → workflow → Submit(Job{RetryCount:0}) → worker executes
-    → success: ResultListener → create issue → post URL
-    → failure: ResultListener → guard (first result wins) → post error + retry button + clear dedup
+    → success: ResultListener → create issue → post URL → clear dedup
+    → failure: ResultListener → dedup guard (first result wins)
+               → post error + retry button (dedup NOT cleared)
 
 Watchdog timeout:
-  watchdog → kill command + publish failed result to ResultBus
-  worker → context cancelled → also publishes failed result
-  ResultListener → first result processed, second dropped by terminal-state guard
+  watchdog → kill + UpdateStatus(JobFailed) + publish failed result
+  worker   → context cancelled → also publishes failed result
+  ResultListener → first result: processedJobs guard passes → post error + retry button
+                 → second result: processedJobs guard drops it
 
 User clicks retry:
-  interaction handler → check job is in JobFailed state
-    → update message to "retrying..."
-    → Submit(Job{RetryCount:1, RetryOfJobID:original}) → worker executes
-      → success: ResultListener → update same message to issue URL
-      → failure: ResultListener → update same message to error (no button) + clear dedup
+  retry handler → check job is JobFailed
+    → update old message to "已重新排入佇列"
+    → Put(newJob) → Submit(newJob) → PostMessageWithButton (with cancel button)
+    → worker executes
+      → success: ResultListener → create issue → update to issue URL → clear dedup
+      → failure: ResultListener → post error (no button) → clear dedup
 
-User re-tags bot:
+User re-tags bot (after dedup cleared or TTL expired):
   independent new workflow → new thread context → repo selection → new job
-  (works because dedup was cleared on failure)
 ```
 
 ## Files Changed
@@ -179,23 +193,24 @@ User re-tags bot:
 | File | Change |
 |------|--------|
 | `internal/queue/job.go` | Add `RetryCount`, `RetryOfJobID` to `Job` |
-| `internal/queue/watchdog.go` | Remove `StuckNotifier`, `FormatStuckMessage`; add `ResultBus`; `killAndNotify` publishes result |
-| `cmd/bot/main.go` | Update Watchdog wiring: remove notifier callback, pass ResultBus; update `slackPosterAdapter` if needed |
-| `internal/bot/result_listener.go` | Add terminal-state guard; failure handling with RetryCount; post blocks; clear thread dedup; read WorkerID |
-| `internal/slack/client.go` | Add `PostBlocks` concrete implementation |
-| `internal/bot/retry_handler.go` | New: retry button interaction handler (deps: JobStore, JobQueue, SlackPoster) |
-| `internal/slack/handler.go` | Route `block_actions` `retry_job` to retry handler |
+| `internal/queue/watchdog.go` | Remove `StuckNotifier`, `FormatStuckMessage`; add `ResultBus`; `killAndNotify` keeps `UpdateStatus` + publishes result |
+| `cmd/bot/main.go` | Update Watchdog wiring: remove notifier callback, pass ResultBus; add `PostMessageWithButton` to `slackPosterAdapter`; route `retry_job` action to `RetryHandler` |
+| `internal/bot/result_listener.go` | Add `processedJobs` map; unified failure handling with RetryCount; conditional dedup clear via callback; read WorkerID; promote `PostMessageWithButton` to `SlackPoster` interface |
+| `internal/bot/retry_handler.go` | New: `RetryHandler` struct (deps: JobStore, JobQueue, SlackPoster) |
+| `internal/bot/workflow.go` | Bug fix: set `UserID` on Job at submission |
+| `internal/slack/handler.go` | No change needed (routing is in main.go switch) |
 | `internal/worker/pool.go` | Worker ID uses hostname/index; call `SetWorker()` after Ack |
 | `cmd/bot/worker.go` | Pass `os.Hostname()` to Pool at startup |
 
 ## Testing
 
 - Unit test: `ResultListener` posts button when `RetryCount == 0`, no button when `RetryCount == 1`.
-- Unit test: `ResultListener` drops duplicate result for a job already in terminal state (double-publish guard).
-- Unit test: `ResultListener` calls `ClearThreadDedup` on failure.
-- Unit test: retry handler creates new job with correct fields (`UserID`, `RetryCount + 1`, etc.).
-- Unit test: retry handler ignores click if job is not in `JobFailed` state (stale button).
-- Unit test: retry handler returns graceful error if job not found (TTL expired).
-- Unit test: Watchdog publishes failed result to ResultBus (no longer calls notifier).
+- Unit test: `ResultListener` `processedJobs` guard drops duplicate result for same job ID.
+- Unit test: `ResultListener` does NOT clear dedup when button is shown; clears dedup when no button.
+- Unit test: `RetryHandler` creates new job with correct fields (`UserID`, `RetryCount + 1`, new ID, etc.).
+- Unit test: `RetryHandler` ignores click if job is not in `JobFailed` state (stale button).
+- Unit test: `RetryHandler` returns graceful error if job not found (TTL expired).
+- Unit test: `RetryHandler` posts new status message with cancel button.
+- Unit test: Watchdog publishes failed result to ResultBus and calls `UpdateStatus(JobFailed)`.
 - Unit test: worker ID format includes hostname.
-- Integration: trigger failure → see button → click retry → job re-executes.
+- Integration: trigger failure → see button → click retry → job re-executes with cancel button.

--- a/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
+++ b/docs/superpowers/specs/2026-04-14-retry-on-failure-design.md
@@ -36,7 +36,7 @@ type Job struct {
 }
 ```
 
-Retry creates a **new Job** (new ID) copying the original job's prompt, repo, thread context, branch, and attachments. `RetryCount` is set to `original + 1`.
+Retry creates a **new Job** (new ID) copying the original job's prompt, repo, thread context, branch, attachments, user ID, and skills. `RetryCount` is set to `original + 1`.
 
 ### 2. Watchdog Publishes to ResultBus
 
@@ -48,18 +48,29 @@ Changes to `Watchdog`:
 - Remove `StuckNotifier` type and the `notifier` field.
 - Add `ResultBus` dependency.
 - `killAndNotify()` publishes a `JobResult{Status: "failed", Error: "job terminated: <reason>"}` instead of calling the notifier.
+- Remove `FormatStuckMessage()` helper (dead code after this change).
 
-This means all failures — whether from agent execution, infra errors, or watchdog kills — are routed through `ResultListener`.
+**Double-publish guard:** When watchdog kills a job, both the watchdog and the worker may publish a failed result to `ResultBus` (watchdog publishes immediately; worker publishes after context cancellation causes `executeJob` to return). `ResultListener` guards against this: on receiving a failed result, it checks `JobState.Status`. If the job is already in `JobFailed` or `JobCompleted` state, the result is silently dropped. This is set via `UpdateStatus(jobID, JobFailed)` on first processing.
+
+This same guard also prevents stale results from interfering after a retry button click (see Section 4).
 
 ### 3. ResultListener Unified Failure Handling
 
 `ResultListener.handleResult()` on `status == "failed"`:
 
 ```
+if job status already terminal (JobFailed/JobCompleted):
+    drop (duplicate result from watchdog + worker race)
+    return
+
+mark job as JobFailed in store
+
 if job.RetryCount < 1:
     post failure message WITH retry button
 else:
     post failure message WITHOUT button (text indicates retry was attempted)
+
+clear thread dedup (allow re-tag bot in same thread)
 ```
 
 Message format with button:
@@ -76,25 +87,42 @@ Message format after retry exhausted:
 repo: owner/repo | worker: a1b2c3d4/worker-0
 ```
 
-`SlackPoster` interface gains a new method:
+**Interface changes:** `SlackPoster` gains a new method for posting messages with blocks:
 
 ```go
-PostBlocks(channelID, threadTS string, blocks []slack.Block) (string, error)
+type SlackPoster interface {
+    PostMessage(channelID, text, threadTS string)
+    UpdateMessage(channelID, messageTS, text string)
+    PostBlocks(channelID, threadTS string, blocks []slack.Block) (string, error)  // new
+}
 ```
 
-`ResultListener` reads `JobState.WorkerID` from `JobStore` to include worker identity in the message.
+This requires updates in three places:
+- `internal/bot/result_listener.go` — interface definition
+- `internal/slack/client.go` — concrete `Client` implementation
+- `cmd/bot/main.go` — `slackPosterAdapter` (if one exists) or wiring
+
+**Thread dedup:** `ResultListener` needs a `ClearThreadDedup` callback (or dependency on handler) to clear dedup on failure. Without this, re-tagging the bot after failure would be blocked. Currently `ClearThreadDedup` is called in the watchdog notifier callback in `main.go`; this responsibility moves to `ResultListener`.
+
+`ResultListener` reads `JobState.WorkerID` from `JobStore` to include worker identity in the message. In Redis mode, `WorkerID` reaches the bot's `JobStore` via the `StatusListener` path: worker sends `StatusReport` (with `WorkerID`) → `StatusBus` → `StatusListener` calls `SetAgentStatus()` which stores `WorkerID` in the `StatusReport` field of `JobState`. `ResultListener` reads it from `state.AgentStatus.WorkerID`.
 
 ### 4. Retry Button Interaction Handler
 
 New file: `internal/bot/retry_handler.go`
 
+**Dependencies:**
+- `JobStore` — lookup original job, `Put()` new job
+- `JobQueue` (or `Coordinator`) — `Submit()` new job
+- `SlackPoster` — update message
+
 Handles `block_actions` interaction with `action_id: "retry_job"`:
 
-1. Look up original job from `JobStore` using `value` (job ID).
-2. Update the original failure message to `:arrows_counterclockwise: 重試中，已重新排入佇列...` (button removed).
-3. Create new `Job` copying: `Prompt`, `Repo`, `CloneURL`, `Branch`, `ChannelID`, `ThreadTS`, `Attachments`, `Skills`, `Priority`. Set `RetryCount = original + 1`, `RetryOfJobID = original.ID`.
-4. Submit new job to queue.
-5. Set `StatusMsgTS` on the new job to the same message timestamp, so subsequent status updates overwrite it.
+1. Look up original job from `JobStore` using `value` (job ID). If not found (TTL expired), post error message and return.
+2. If original job is not in `JobFailed` state (e.g., user clicks stale button on a job that already completed), ignore.
+3. Update the original failure message to `:arrows_counterclockwise: 重試中，已重新排入佇列...` (button removed).
+4. Create new `Job` copying: `Prompt`, `Repo`, `CloneURL`, `Branch`, `ChannelID`, `ThreadTS`, `UserID`, `Attachments`, `Skills`, `Priority`. Set `RetryCount = original + 1`, `RetryOfJobID = original.ID`.
+5. Submit new job to queue.
+6. Set `StatusMsgTS` on the new job to the same message timestamp, so subsequent status updates overwrite it.
 
 Routing: `internal/slack/handler.go` routes `block_actions` with `action_id == "retry_job"` to the retry handler.
 
@@ -104,7 +132,7 @@ Re-tagging the bot in the same thread triggers the full workflow: re-reads all t
 
 No conflict because:
 - Retry creates a new job with a new ID.
-- Thread dedup in `handler.go` checks for running/pending jobs. The original failed job is already in `JobFailed` status, so it won't block a new trigger.
+- Thread dedup is cleared on failure (see Section 3). The original failed job is in `JobFailed` status, so it won't block a new trigger.
 
 ### 6. Worker Identity
 
@@ -115,10 +143,11 @@ Worker ID format: `<hostname>/worker-<index>`
 
 Where it's used:
 - `StatusReport.WorkerID` — already exists, currently only `worker-0`. Change to include hostname.
-- `JobState.WorkerID` — already exists. Pool calls `SetWorker()` after Ack.
-- Failure messages in Slack — `ResultListener` reads from `JobState.WorkerID`.
+- `JobState.WorkerID` — already exists but `SetWorker()` is never called today. Add call in pool after Ack.
+- In Redis mode, `WorkerID` propagates to the bot via `StatusReport` → `StatusBus` → `StatusListener` → `SetAgentStatus()`. The bot reads it from `state.AgentStatus.WorkerID`.
+- Failure messages in Slack — `ResultListener` reads from `JobState`.
 
-Implementation: `Pool` receives hostname at construction. Each worker goroutine uses `<hostname>/worker-<index>`.
+Implementation: `Pool` receives hostname at construction time (`cmd/bot/worker.go` calls `os.Hostname()`). Each worker goroutine uses `<hostname>/worker-<index>`.
 
 ## Data Flow
 
@@ -126,20 +155,23 @@ Implementation: `Pool` receives hostname at construction. Each worker goroutine 
 First attempt:
   trigger → workflow → Submit(Job{RetryCount:0}) → worker executes
     → success: ResultListener → create issue → post URL
-    → failure: ResultListener → post error + retry button
+    → failure: ResultListener → guard (first result wins) → post error + retry button + clear dedup
 
 Watchdog timeout:
-  watchdog → kill + publish failed result to ResultBus
-    → ResultListener → post error + retry button
+  watchdog → kill command + publish failed result to ResultBus
+  worker → context cancelled → also publishes failed result
+  ResultListener → first result processed, second dropped by terminal-state guard
 
 User clicks retry:
-  interaction handler → update message to "retrying..."
+  interaction handler → check job is in JobFailed state
+    → update message to "retrying..."
     → Submit(Job{RetryCount:1, RetryOfJobID:original}) → worker executes
       → success: ResultListener → update same message to issue URL
-      → failure: ResultListener → update same message to error (no button)
+      → failure: ResultListener → update same message to error (no button) + clear dedup
 
 User re-tags bot:
   independent new workflow → new thread context → repo selection → new job
+  (works because dedup was cleared on failure)
 ```
 
 ## Files Changed
@@ -147,11 +179,11 @@ User re-tags bot:
 | File | Change |
 |------|--------|
 | `internal/queue/job.go` | Add `RetryCount`, `RetryOfJobID` to `Job` |
-| `internal/queue/watchdog.go` | Remove `StuckNotifier`, add `ResultBus` dependency |
-| `cmd/bot/main.go` | Update Watchdog wiring: remove notifier, pass ResultBus |
-| `internal/bot/result_listener.go` | Unified failure handling: check RetryCount, post with/without button, show worker |
-| `internal/slack/client.go` | Add `PostBlocks` to `SlackPoster` interface |
-| `internal/bot/retry_handler.go` | New: retry button interaction handler |
+| `internal/queue/watchdog.go` | Remove `StuckNotifier`, `FormatStuckMessage`; add `ResultBus`; `killAndNotify` publishes result |
+| `cmd/bot/main.go` | Update Watchdog wiring: remove notifier callback, pass ResultBus; update `slackPosterAdapter` if needed |
+| `internal/bot/result_listener.go` | Add terminal-state guard; failure handling with RetryCount; post blocks; clear thread dedup; read WorkerID |
+| `internal/slack/client.go` | Add `PostBlocks` concrete implementation |
+| `internal/bot/retry_handler.go` | New: retry button interaction handler (deps: JobStore, JobQueue, SlackPoster) |
 | `internal/slack/handler.go` | Route `block_actions` `retry_job` to retry handler |
 | `internal/worker/pool.go` | Worker ID uses hostname/index; call `SetWorker()` after Ack |
 | `cmd/bot/worker.go` | Pass `os.Hostname()` to Pool at startup |
@@ -159,7 +191,11 @@ User re-tags bot:
 ## Testing
 
 - Unit test: `ResultListener` posts button when `RetryCount == 0`, no button when `RetryCount == 1`.
-- Unit test: retry handler creates new job with correct fields and `RetryCount + 1`.
+- Unit test: `ResultListener` drops duplicate result for a job already in terminal state (double-publish guard).
+- Unit test: `ResultListener` calls `ClearThreadDedup` on failure.
+- Unit test: retry handler creates new job with correct fields (`UserID`, `RetryCount + 1`, etc.).
+- Unit test: retry handler ignores click if job is not in `JobFailed` state (stale button).
+- Unit test: retry handler returns graceful error if job not found (TTL expired).
 - Unit test: Watchdog publishes failed result to ResultBus (no longer calls notifier).
 - Unit test: worker ID format includes hostname.
 - Integration: trigger failure → see button → click retry → job re-executes.

--- a/internal/bot/agent.go
+++ b/internal/bot/agent.go
@@ -33,12 +33,12 @@ func NewAgentRunner(agents []config.AgentConfig) *AgentRunner {
 
 func NewAgentRunnerFromConfig(cfg *config.Config) *AgentRunner {
 	var chain []config.AgentConfig
-	if len(cfg.Fallback) > 0 {
-		for _, name := range cfg.Fallback {
+	if len(cfg.Providers) > 0 {
+		for _, name := range cfg.Providers {
 			if agent, ok := cfg.Agents[name]; ok {
 				chain = append(chain, agent)
 			} else {
-				slog.Warn("fallback agent not found in agents config", "name", name)
+				slog.Warn("provider not found in agents config", "name", name)
 			}
 		}
 	} else if cfg.ActiveAgent != "" {

--- a/internal/bot/agent_test.go
+++ b/internal/bot/agent_test.go
@@ -40,7 +40,7 @@ echo '{"issue_type":"bug","confidence":"high","files":[],"open_questions":[],"su
 	}
 }
 
-func TestAgentRunner_Fallback(t *testing.T) {
+func TestAgentRunner_ProviderChain(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "good-agent")
 	os.WriteFile(script, []byte("#!/bin/sh\necho 'fallback output with enough characters to pass the minimum length check of fifty chars'\n"), 0755)
@@ -52,7 +52,7 @@ func TestAgentRunner_Fallback(t *testing.T) {
 
 	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
 	if err != nil {
-		t.Fatalf("Run with fallback failed: %v", err)
+		t.Fatalf("Run with provider chain failed: %v", err)
 	}
 	if !strings.Contains(output, "fallback output") {
 		t.Errorf("output = %q, want fallback output", output)

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -13,6 +13,7 @@ import (
 type SlackPoster interface {
 	PostMessage(channelID, text, threadTS string)
 	UpdateMessage(channelID, messageTS, text string)
+	PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
 }
 
 // IssueCreator abstracts GitHub issue creation for testing.

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"agentdock/internal/queue"
 )
@@ -22,11 +23,15 @@ type IssueCreator interface {
 }
 
 type ResultListener struct {
-	results     queue.ResultBus
-	store       queue.JobStore
-	attachments queue.AttachmentStore
-	slack       SlackPoster
-	github      IssueCreator
+	results       queue.ResultBus
+	store         queue.JobStore
+	attachments   queue.AttachmentStore
+	slack         SlackPoster
+	github        IssueCreator
+	onDedupClear  func(channelID, threadTS string)
+
+	mu            sync.Mutex
+	processedJobs map[string]bool
 }
 
 func NewResultListener(
@@ -35,13 +40,16 @@ func NewResultListener(
 	attachments queue.AttachmentStore,
 	slack SlackPoster,
 	github IssueCreator,
+	onDedupClear func(channelID, threadTS string),
 ) *ResultListener {
 	return &ResultListener{
-		results:     results,
-		store:       store,
-		attachments: attachments,
-		slack:       slack,
-		github:      github,
+		results:       results,
+		store:         store,
+		attachments:   attachments,
+		slack:         slack,
+		github:        github,
+		onDedupClear:  onDedupClear,
+		processedJobs: make(map[string]bool),
 	}
 }
 
@@ -66,6 +74,16 @@ func (r *ResultListener) Listen(ctx context.Context) {
 }
 
 func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResult) {
+	// Dedup guard: drop duplicate results for same job.
+	r.mu.Lock()
+	if r.processedJobs[result.JobID] {
+		r.mu.Unlock()
+		slog.Debug("dropping duplicate result", "job_id", result.JobID)
+		return
+	}
+	r.processedJobs[result.JobID] = true
+	r.mu.Unlock()
+
 	state, err := r.store.Get(result.JobID)
 	if err != nil {
 		slog.Error("job not found for result", "job_id", result.JobID, "error", err)
@@ -77,20 +95,53 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 
 	switch {
 	case result.Status == "failed":
-		r.updateStatus(job, fmt.Sprintf(":x: 分析失敗: %s", result.Error))
+		r.handleFailure(job, state, result)
 
 	case result.Confidence == "low":
 		r.updateStatus(job, ":warning: 判斷不屬於此 repo，已跳過")
+		r.clearDedup(job)
 
 	case result.FilesFound == 0 || result.Questions >= 5:
 		r.createAndPostIssue(ctx, job, owner, repo, result, true)
+		r.clearDedup(job)
 
 	default:
 		r.createAndPostIssue(ctx, job, owner, repo, result, false)
+		r.clearDedup(job)
 	}
 
-	// Cleanup attachments; keep job in store for status visibility (TTL cleanup handles removal).
+	// Cleanup attachments.
 	r.attachments.Cleanup(ctx, result.JobID)
+}
+
+func (r *ResultListener) handleFailure(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
+	r.store.UpdateStatus(job.ID, queue.JobFailed)
+
+	workerID := ""
+	if state.AgentStatus != nil {
+		workerID = state.AgentStatus.WorkerID
+	}
+	if workerID == "" {
+		workerID = state.WorkerID
+	}
+
+	workerInfo := ""
+	if workerID != "" {
+		workerInfo = fmt.Sprintf(" | worker: %s", workerID)
+	}
+
+	if job.RetryCount < 1 {
+		// Show retry button.
+		text := fmt.Sprintf(":x: 分析失敗: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		r.slack.PostMessageWithButton(job.ChannelID, text, job.ThreadTS,
+			"retry_job", "🔄 重試", job.ID)
+		// Do NOT clear dedup — user should use retry button.
+	} else {
+		// Retry exhausted, no button.
+		text := fmt.Sprintf(":x: 分析失敗（重試後仍失敗）: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		r.updateStatus(job, text)
+		r.clearDedup(job)
+	}
 }
 
 func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job, owner, repo string, result *queue.JobResult, degraded bool) {
@@ -119,12 +170,17 @@ func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job,
 	r.updateStatus(job, fmt.Sprintf(":white_check_mark: Issue created%s: %s", branchInfo, url))
 }
 
-// updateStatus updates the original status message if possible, otherwise posts a new message.
 func (r *ResultListener) updateStatus(job *queue.Job, text string) {
 	if job.StatusMsgTS != "" {
 		r.slack.UpdateMessage(job.ChannelID, job.StatusMsgTS, text)
 	} else {
 		r.slack.PostMessage(job.ChannelID, text, job.ThreadTS)
+	}
+}
+
+func (r *ResultListener) clearDedup(job *queue.Job) {
+	if r.onDedupClear != nil {
+		r.onDedupClear(job.ChannelID, job.ThreadTS)
 	}
 }
 

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -13,6 +13,7 @@ import (
 type mockSlackPoster struct {
 	mu       sync.Mutex
 	messages []string
+	buttons  []string
 }
 
 func (m *mockSlackPoster) PostMessage(channelID, text, threadTS string) {
@@ -25,6 +26,14 @@ func (m *mockSlackPoster) UpdateMessage(channelID, messageTS, text string) {
 	m.mu.Lock()
 	m.messages = append(m.messages, text)
 	m.mu.Unlock()
+}
+
+func (m *mockSlackPoster) PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error) {
+	m.mu.Lock()
+	m.buttons = append(m.buttons, actionID+":"+value)
+	m.messages = append(m.messages, text)
+	m.mu.Unlock()
+	return "msg-ts-mock", nil
 }
 
 type mockIssueCreator struct {

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -55,7 +55,7 @@ func TestResultListener_CompletedCreatesIssue(t *testing.T) {
 	slackMock := &mockSlackPoster{}
 	githubMock := &mockIssueCreator{url: "https://github.com/owner/repo/issues/1"}
 
-	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, githubMock)
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, githubMock, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -95,7 +95,7 @@ func TestResultListener_FailedPostsError(t *testing.T) {
 
 	slackMock := &mockSlackPoster{}
 
-	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil)
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -131,7 +131,7 @@ func TestResultListener_LowConfidenceRejects(t *testing.T) {
 
 	slackMock := &mockSlackPoster{}
 
-	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil)
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -155,5 +155,118 @@ func TestResultListener_LowConfidenceRejects(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected rejection in messages, got %v", slackMock.messages)
+	}
+}
+
+func TestResultListener_FailedShowsRetryButton(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1", RetryCount: 0})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	dedupCleared := false
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) { dedupCleared = true })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID:  "j1",
+		Status: "failed",
+		Error:  "agent crashed",
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	if len(slackMock.buttons) != 1 {
+		t.Fatalf("expected 1 button post, got %d", len(slackMock.buttons))
+	}
+	if slackMock.buttons[0] != "retry_job:j1" {
+		t.Errorf("button = %q, want retry_job:j1", slackMock.buttons[0])
+	}
+	if dedupCleared {
+		t.Error("dedup should NOT be cleared when retry button is shown")
+	}
+}
+
+func TestResultListener_FailedNoButtonAfterRetry(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1", RetryCount: 1})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	dedupCleared := false
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) { dedupCleared = true })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID:  "j1",
+		Status: "failed",
+		Error:  "still broken",
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	if len(slackMock.buttons) != 0 {
+		t.Errorf("expected 0 button posts, got %d", len(slackMock.buttons))
+	}
+	found := false
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "重試後仍失敗") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected retry-exhausted message, got %v", slackMock.messages)
+	}
+	if !dedupCleared {
+		t.Error("dedup should be cleared when no retry button")
+	}
+}
+
+func TestResultListener_DedupDropsDuplicateResult(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1"})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
+		func(channelID, threadTS string) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{JobID: "j1", Status: "failed", Error: "timeout"})
+	bundle.Results.Publish(ctx, &queue.JobResult{JobID: "j1", Status: "failed", Error: "context cancelled"})
+
+	time.Sleep(300 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	if len(slackMock.buttons) != 1 {
+		t.Errorf("expected 1 button post (dedup), got %d", len(slackMock.buttons))
 	}
 }

--- a/internal/bot/retry_handler.go
+++ b/internal/bot/retry_handler.go
@@ -1,0 +1,87 @@
+package bot
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"agentdock/internal/logging"
+	"agentdock/internal/queue"
+)
+
+// JobSubmitter abstracts queue submission for testing.
+type JobSubmitter interface {
+	Submit(ctx context.Context, job *queue.Job) error
+}
+
+type RetryHandler struct {
+	store queue.JobStore
+	queue JobSubmitter
+	slack SlackPoster
+}
+
+func NewRetryHandler(store queue.JobStore, q JobSubmitter, slack SlackPoster) *RetryHandler {
+	return &RetryHandler{store: store, queue: q, slack: slack}
+}
+
+func (h *RetryHandler) Handle(channelID, jobID, msgTS string) {
+	state, err := h.store.Get(jobID)
+	if err != nil {
+		slog.Warn("retry: job not found", "job_id", jobID, "error", err)
+		h.slack.UpdateMessage(channelID, msgTS, ":warning: 此任務已過期，請重新觸發")
+		return
+	}
+
+	if state.Status != queue.JobFailed {
+		slog.Info("retry: job not in failed state, ignoring", "job_id", jobID, "status", state.Status)
+		return
+	}
+
+	original := state.Job
+
+	// Update old message to indicate retry is queued.
+	h.slack.UpdateMessage(channelID, msgTS, ":arrows_counterclockwise: 已重新排入佇列")
+
+	// Create new job copying relevant fields.
+	newJob := &queue.Job{
+		ID:           logging.NewRequestID(),
+		Priority:     original.Priority,
+		ChannelID:    original.ChannelID,
+		ThreadTS:     original.ThreadTS,
+		UserID:       original.UserID,
+		Repo:         original.Repo,
+		Branch:       original.Branch,
+		CloneURL:     original.CloneURL,
+		Prompt:       original.Prompt,
+		Skills:       original.Skills,
+		RequestID:    logging.NewRequestID(),
+		Attachments:  original.Attachments,
+		RetryCount:   original.RetryCount + 1,
+		RetryOfJobID: original.ID,
+		SubmittedAt:  time.Now(),
+	}
+
+	// Put in store before posting button (so cancel_job can find it).
+	h.store.Put(newJob)
+
+	ctx := context.Background()
+	if err := h.queue.Submit(ctx, newJob); err != nil {
+		slog.Error("retry: failed to submit", "job_id", newJob.ID, "error", err)
+		h.slack.PostMessage(channelID, ":x: 重試失敗: "+err.Error(), original.ThreadTS)
+		return
+	}
+
+	// Post new status message with cancel button.
+	statusMsgTS, err := h.slack.PostMessageWithButton(original.ChannelID,
+		":hourglass_flowing_sand: 重試中，正在處理你的請求...",
+		original.ThreadTS, "cancel_job", "取消", newJob.ID)
+	if err == nil {
+		newJob.StatusMsgTS = statusMsgTS
+		h.store.Put(newJob) // update with StatusMsgTS
+	}
+
+	slog.Info("retry: new job submitted",
+		"original_job_id", original.ID,
+		"new_job_id", newJob.ID,
+		"retry_count", newJob.RetryCount)
+}

--- a/internal/bot/retry_handler_test.go
+++ b/internal/bot/retry_handler_test.go
@@ -1,0 +1,116 @@
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"agentdock/internal/queue"
+)
+
+type mockJobQueue struct {
+	submitted []*queue.Job
+}
+
+func (m *mockJobQueue) Submit(ctx context.Context, job *queue.Job) error {
+	m.submitted = append(m.submitted, job)
+	return nil
+}
+
+func TestRetryHandler_CreatesNewJob(t *testing.T) {
+	store := queue.NewMemJobStore()
+	original := &queue.Job{
+		ID:        "j1",
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		UserID:    "U1",
+		Repo:      "owner/repo",
+		CloneURL:  "https://github.com/owner/repo.git",
+		Branch:    "main",
+		Prompt:    "test prompt",
+		Priority:  50,
+		Skills:    map[string]string{"s1": "content"},
+	}
+	store.Put(original)
+	store.UpdateStatus("j1", queue.JobFailed)
+
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "j1", "msg-ts-1")
+
+	if len(q.submitted) != 1 {
+		t.Fatalf("expected 1 submitted job, got %d", len(q.submitted))
+	}
+
+	newJob := q.submitted[0]
+	if newJob.ID == "j1" {
+		t.Error("new job should have a different ID")
+	}
+	if newJob.RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", newJob.RetryCount)
+	}
+	if newJob.RetryOfJobID != "j1" {
+		t.Errorf("RetryOfJobID = %q, want j1", newJob.RetryOfJobID)
+	}
+	if newJob.Prompt != "test prompt" {
+		t.Errorf("Prompt = %q, want test prompt", newJob.Prompt)
+	}
+	if newJob.UserID != "U1" {
+		t.Errorf("UserID = %q, want U1", newJob.UserID)
+	}
+	if newJob.Priority != 50 {
+		t.Errorf("Priority = %d, want 50", newJob.Priority)
+	}
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	foundUpdate := false
+	for _, msg := range slackMock.messages {
+		if msg == ":arrows_counterclockwise: 已重新排入佇列" {
+			foundUpdate = true
+		}
+	}
+	if !foundUpdate {
+		t.Errorf("expected update message, got %v", slackMock.messages)
+	}
+
+	if len(slackMock.buttons) != 1 {
+		t.Fatalf("expected 1 button post, got %d", len(slackMock.buttons))
+	}
+}
+
+func TestRetryHandler_JobNotFound(t *testing.T) {
+	store := queue.NewMemJobStore()
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "nonexistent", "msg-ts-1")
+
+	if len(q.submitted) != 0 {
+		t.Error("should not submit when job not found")
+	}
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	if len(slackMock.messages) == 0 {
+		t.Error("should post error message when job not found")
+	}
+}
+
+func TestRetryHandler_IgnoresNonFailedJob(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1", ChannelID: "C1", ThreadTS: "T1"})
+	store.UpdateStatus("j1", queue.JobCompleted)
+
+	q := &mockJobQueue{}
+	slackMock := &mockSlackPoster{}
+
+	handler := NewRetryHandler(store, q, slackMock)
+	handler.Handle("C1", "j1", "msg-ts-1")
+
+	if len(q.submitted) != 0 {
+		t.Error("should not submit when job is not failed")
+	}
+}

--- a/internal/bot/workflow.go
+++ b/internal/bot/workflow.go
@@ -23,6 +23,7 @@ type pendingTriage struct {
 	ChannelID      string
 	ThreadTS       string
 	TriggerTS      string
+	UserID         string
 	Attachments    []string
 	SelectedRepo   string
 	SelectedBranch string
@@ -138,6 +139,7 @@ func (w *Workflow) HandleTrigger(event slackclient.TriggerEvent) {
 		ChannelID:   event.ChannelID,
 		ThreadTS:    event.ThreadTS,
 		TriggerTS:   event.TriggerTS,
+		UserID:      event.UserID,
 		Reporter:    reporter,
 		ChannelName: channelName,
 		CmdArgs:     parseTriggerArgs(event.Text),
@@ -416,6 +418,7 @@ func (w *Workflow) runTriage(pt *pendingTriage) {
 		Priority:    w.channelPriority(pt.ChannelID),
 		ChannelID:   pt.ChannelID,
 		ThreadTS:    pt.ThreadTS,
+		UserID:      pt.UserID,
 		Repo:        pt.SelectedRepo,
 		Branch:      pt.SelectedBranch,
 		CloneURL:    w.repoCache.ResolveURL(pt.SelectedRepo),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	GitHub            GitHubConfig             `yaml:"github"`
 	Agents            map[string]AgentConfig   `yaml:"agents"`
 	ActiveAgent       string                   `yaml:"active_agent"`
-	Fallback          []string                 `yaml:"fallback"`
+	Providers         []string                 `yaml:"providers"`
 	Prompt            PromptConfig             `yaml:"prompt"`
 	Channels          map[string]ChannelConfig `yaml:"channels"`
 	ChannelDefaults   ChannelConfig            `yaml:"channel_defaults"`
@@ -187,7 +187,7 @@ func LoadDefaults() (*Config, error) {
 				SkillDir: ".opencode/skills",
 			},
 		},
-		Fallback: []string{"claude"},
+		Providers: []string{"claude"},
 	}
 	applyDefaults(&cfg)
 	applyEnvOverrides(&cfg)
@@ -287,7 +287,7 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("ACTIVE_AGENT"); v != "" {
 		cfg.ActiveAgent = v
 	}
-	if v := os.Getenv("FALLBACK"); v != "" {
-		cfg.Fallback = strings.Split(v, ",")
+	if v := os.Getenv("PROVIDERS"); v != "" {
+		cfg.Providers = strings.Split(v, ",")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,7 +26,7 @@ agents:
     timeout: 3m
 
 active_agent: claude
-fallback: [claude, opencode]
+providers: [claude, opencode]
 
 prompt:
   language: zh-TW
@@ -99,8 +99,8 @@ repo_cache:
 	if cfg.ActiveAgent != "claude" {
 		t.Errorf("active_agent = %q", cfg.ActiveAgent)
 	}
-	if len(cfg.Fallback) != 2 || cfg.Fallback[0] != "claude" {
-		t.Errorf("fallback = %v", cfg.Fallback)
+	if len(cfg.Providers) != 2 || cfg.Providers[0] != "claude" {
+		t.Errorf("providers = %v", cfg.Providers)
 	}
 
 	// Prompt

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -30,8 +30,10 @@ type Job struct {
 	RequestID   string            `json:"request_id"`
 	Attachments []AttachmentMeta  `json:"attachments"`
 	StatusMsgTS string            `json:"status_msg_ts,omitempty"`
-	TaskType    string            `json:"task_type,omitempty"`
-	SubmittedAt time.Time         `json:"submitted_at"`
+	TaskType     string            `json:"task_type,omitempty"`
+	RetryCount   int               `json:"retry_count,omitempty"`
+	RetryOfJobID string            `json:"retry_of_job_id,omitempty"`
+	SubmittedAt  time.Time         `json:"submitted_at"`
 }
 
 type AttachmentMeta struct {

--- a/internal/queue/watchdog.go
+++ b/internal/queue/watchdog.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-type StuckNotifier func(job *Job, status JobStatus, reason string)
-
 type WatchdogConfig struct {
 	JobTimeout     time.Duration
 	IdleTimeout    time.Duration
@@ -18,14 +16,14 @@ type WatchdogConfig struct {
 type Watchdog struct {
 	store          JobStore
 	commands       CommandBus
+	results        ResultBus
 	jobTimeout     time.Duration
 	idleTimeout    time.Duration
 	prepareTimeout time.Duration
 	interval       time.Duration
-	notifier       StuckNotifier
 }
 
-func NewWatchdog(store JobStore, commands CommandBus, cfg WatchdogConfig, notifier StuckNotifier) *Watchdog {
+func NewWatchdog(store JobStore, commands CommandBus, results ResultBus, cfg WatchdogConfig) *Watchdog {
 	interval := cfg.JobTimeout / 3
 	if interval < 30*time.Second {
 		interval = 30 * time.Second
@@ -33,11 +31,11 @@ func NewWatchdog(store JobStore, commands CommandBus, cfg WatchdogConfig, notifi
 	return &Watchdog{
 		store:          store,
 		commands:       commands,
+		results:        results,
 		jobTimeout:     cfg.JobTimeout,
 		idleTimeout:    cfg.IdleTimeout,
 		prepareTimeout: cfg.PrepareTimeout,
 		interval:       interval,
-		notifier:       notifier,
 	}
 }
 
@@ -76,47 +74,45 @@ func (w *Watchdog) check() {
 			continue
 		}
 
-		// 1. Job-level timeout (all jobs)
 		if now.Sub(state.Job.SubmittedAt) > w.jobTimeout {
-			w.killAndNotify(state, "job timeout")
+			w.killAndPublish(state, "job timeout")
 			continue
 		}
 
-		// 2. Prepare timeout (stuck in preparing stage)
 		if state.Status == JobPreparing && w.prepareTimeout > 0 {
 			if state.AgentStatus == nil || state.AgentStatus.LastEventAt.IsZero() {
 				if !state.StartedAt.IsZero() && now.Sub(state.StartedAt) > w.prepareTimeout {
-					w.killAndNotify(state, "prepare timeout")
+					w.killAndPublish(state, "prepare timeout")
 					continue
 				}
 			}
 		}
 
-		// 3. Agent idle timeout (stream-json agents only)
 		if w.idleTimeout > 0 && state.AgentStatus != nil && !state.AgentStatus.LastEventAt.IsZero() {
 			if now.Sub(state.AgentStatus.LastEventAt) > w.idleTimeout {
-				w.killAndNotify(state, "agent idle timeout")
+				w.killAndPublish(state, "agent idle timeout")
 				continue
 			}
 		}
 	}
 }
 
-func (w *Watchdog) killAndNotify(state *JobState, reason string) {
+func (w *Watchdog) killAndPublish(state *JobState, reason string) {
 	slog.Warn("watchdog: killing stuck job",
 		"job_id", state.Job.ID, "status", state.Status, "reason", reason)
 
 	if w.commands != nil {
 		w.commands.Send(context.Background(), Command{JobID: state.Job.ID, Action: "kill"})
 	}
+
 	w.store.UpdateStatus(state.Job.ID, JobFailed)
 
-	if w.notifier != nil {
-		w.notifier(state.Job, state.Status, reason)
+	if w.results != nil {
+		w.results.Publish(context.Background(), &JobResult{
+			JobID:      state.Job.ID,
+			Status:     "failed",
+			Error:      fmt.Sprintf("job terminated: %s", reason),
+			FinishedAt: time.Now(),
+		})
 	}
-}
-
-func FormatStuckMessage(job *Job, status JobStatus, reason string) string {
-	return fmt.Sprintf(":warning: Job 已終止 (%s)，狀態停在 `%s`，repo: `%s`。請重新觸發。",
-		reason, status, job.Repo)
 }

--- a/internal/queue/watchdog_test.go
+++ b/internal/queue/watchdog_test.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWatchdog_PublishesFailedResultOnTimeout(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-10 * time.Minute)})
+	store.UpdateStatus("j1", JobRunning)
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{
+		JobTimeout:     1 * time.Minute,
+		IdleTimeout:    0,
+		PrepareTimeout: 0,
+	})
+
+	wd.check()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ch, _ := results.Subscribe(ctx)
+	select {
+	case result := <-ch:
+		if result.JobID != "j1" {
+			t.Errorf("jobID = %q, want j1", result.JobID)
+		}
+		if result.Status != "failed" {
+			t.Errorf("status = %q, want failed", result.Status)
+		}
+		if result.Error == "" {
+			t.Error("error should contain timeout reason")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for result on ResultBus")
+	}
+
+	state, _ := store.Get("j1")
+	if state.Status != JobFailed {
+		t.Errorf("store status = %q, want failed", state.Status)
+	}
+}

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -19,6 +19,7 @@ type Config struct {
 	Runner         Runner
 	RepoCache      RepoProvider
 	WorkerCount    int
+	Hostname       string
 	SkillDirs      []string
 	Commands       queue.CommandBus
 	Status         queue.StatusBus
@@ -100,14 +101,16 @@ func (p *Pool) runWorker(ctx context.Context, id int) {
 	}
 }
 
-func (p *Pool) executeWithTracking(ctx context.Context, workerID int, job *queue.Job) {
-	logger := slog.With("worker_id", workerID, "job_id", job.ID)
+func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *queue.Job) {
+	logger := slog.With("worker_id", workerIndex, "job_id", job.ID)
 	jobCtx, jobCancel := context.WithCancel(ctx)
 	defer jobCancel()
 
+	wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, workerIndex)
+
 	status := &statusAccumulator{
 		jobID:    job.ID,
-		workerID: fmt.Sprintf("worker-%d", workerID),
+		workerID: wID,
 		alive:    true,
 	}
 
@@ -147,6 +150,8 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerID int, job *queue
 		}
 		return
 	}
+
+	p.cfg.Store.SetWorker(job.ID, wID)
 
 	deps := executionDeps{
 		attachments: p.cfg.Attachments,

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -85,6 +85,54 @@ func TestPool_ExecutesJobAndPublishesResult(t *testing.T) {
 	}
 }
 
+func TestPool_WorkerIDIncludesHostname(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	agentOutput := "Analysis done.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "Bug fix",
+  "body": "## Problem\nSomething broke",
+  "labels": ["bug"],
+  "confidence": "high",
+  "files_found": 3,
+  "open_questions": 0
+}`
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      &mockRunner{output: agentOutput},
+		RepoCache:   &mockRepo{path: "/tmp/test-repo"},
+		WorkerCount: 1,
+		Hostname:    "test-host",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool.Start(ctx)
+	bundle.Attachments.Prepare(ctx, "j1", nil)
+	bundle.Queue.Submit(ctx, &queue.Job{ID: "j1", Priority: 50, Prompt: "test"})
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case <-ch:
+		state, _ := store.Get("j1")
+		if state.WorkerID == "" {
+			t.Error("WorkerID should be set after execution")
+		}
+		if state.WorkerID != "test-host/worker-0" {
+			t.Errorf("WorkerID = %q, want test-host/worker-0", state.WorkerID)
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout")
+	}
+}
+
 func TestPool_AgentFailurePublishesFailedResult(t *testing.T) {
 	store := queue.NewMemJobStore()
 	bundle := queue.NewInMemBundle(10, 3, store)


### PR DESCRIPTION
## Summary

- All job failure types (watchdog timeout, agent error, infra error) now show a retry button in Slack
- Max 1 retry per job — second failure shows error only, no button
- Watchdog refactored to publish to ResultBus instead of posting Slack directly (unified failure path)
- Worker identity (hostname/worker-index) visible in failure messages and status reports
- Bug fix: `UserID` now set on Job during workflow submission
- Leftover `FALLBACK` → `PROVIDERS` rename in README

## Test plan

- [ ] Verify `go test ./...` passes (122 tests, 8 new)
- [ ] Trigger a job failure → confirm retry button appears in Slack
- [ ] Click retry → confirm new job is submitted and executes
- [ ] Trigger failure on retried job → confirm no button, only error message
- [ ] Re-tag bot after failure → confirm it works (dedup cleared)
- [ ] Check worker identity shows hostname in failure message

🤖 Generated with [Claude Code](https://claude.com/claude-code)