### PR TITLE
build: add OCI labels to docker images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,10 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
+      - --label=org.opencontainers.image.source=https://github.com/Ivantseng123/agentdock
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ .Date }}
     extra_files:
       - agents/skills
       - config.example.yaml
@@ -57,6 +61,10 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
+      - --label=org.opencontainers.image.source=https://github.com/Ivantseng123/agentdock
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ .Date }}
     extra_files:
       - agents/skills
       - config.example.yaml


### PR DESCRIPTION
## Summary

Attach standard OCI image labels to the two goreleaser-built Docker images so that `ghcr.io/ivantseng123/agentdock` links back to this repo on GitHub Packages and exposes provenance metadata (source repo, commit SHA, version, build timestamp).

Without these labels, GHCR shows the package as an orphan not linked to any repository.

## Changes

`.goreleaser.yaml` — `dockers[].build_flag_templates` on both amd64 and arm64 entries add:

- `org.opencontainers.image.source=https://github.com/Ivantseng123/agentdock`
- `org.opencontainers.image.revision={{ .FullCommit }}`
- `org.opencontainers.image.version={{ .Version }}`
- `org.opencontainers.image.created={{ .Date }}`

`image.licenses` intentionally omitted — repo has no LICENSE file; claiming MIT would be a lie. Add back if a license is introduced.

## Verification

Local snapshot build inspected via `docker image inspect`:

```json
{
  "org.opencontainers.image.created": "2026-04-14T05:51:50Z",
  "org.opencontainers.image.revision": "4b660e1819bda792238daa0ef458687352eb215e",
  "org.opencontainers.image.source": "https://github.com/Ivantseng123/agentdock",
  "org.opencontainers.image.version": "0.2.1-SNAPSHOT-4b660e1"
}
```

## Test plan

- [ ] PR CI: `release-validate.yml` snapshot job passes
- [ ] After merge + next release: `ghcr.io/ivantseng123/agentdock:<version>` shows on repo's Packages tab linked to this repo
- [ ] `docker image inspect` on published image shows all four labels populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)