### PR TITLE
fix: release pipeline — drop gomod.proxy and chain via reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,22 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: rp
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+      packages: write
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -13,7 +16,7 @@ permissions:
   packages: write   # ghcr.io
 
 concurrency:
-  group: release-${{ github.event.inputs.tag || github.event.release.tag_name }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -21,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Validate workflow_dispatch tag format
+      - name: Validate tag format
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if [[ ! "${{ github.event.inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::tag input must match vMAJOR.MINOR.PATCH (got '${{ github.event.inputs.tag }}')"
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::tag input must match vMAJOR.MINOR.PATCH (got '${{ inputs.tag }}')"
             exit 1
           fi
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,10 @@
 version: 2
 project_name: agentdock
 
-gomod:
-  proxy: true   # resolve modules via GOPROXY for reproducible builds
+# gomod.proxy is intentionally disabled: go.mod declares `module agentdock`
+# (a bare local name, not a URL), which GOPROXY cannot resolve. If the module
+# path is ever changed to a full URL (e.g. github.com/Ivantseng123/agentdock),
+# add `gomod: { proxy: true }` back for reproducible builds.
 
 builds:
   - id: bot


### PR DESCRIPTION
## Summary

Two fixes rolled into one PR. Both surfaced from manually triggering ` release.yml` for v0.2.2 ([run #24383677481](https://github.com/Ivantseng123/agentdock/actions/runs/24383677481)) and from observing that release-please does not trigger downstream workflows.

## 1. Drop `gomod.proxy: true` from `.goreleaser.yaml`

goreleaser tried to proxy the module via GOPROXY and failed with:

```
failed to proxy module: exit status 1: go: agentdock@v0.2.2:
  malformed module path "agentdock": missing dot in first path element
```

`go.mod` declares `module agentdock` — a bare local name, not a URL. GOPROXY requires a URL-shaped path (e.g. `github.com/...`). Local `--snapshot` builds skipped the proxy path, so the issue only showed up on a real CI release.

Added a comment explaining why `gomod.proxy` is disabled, so a future contributor doesn't reintroduce it without also changing the module path.

## 2. Chain goreleaser as a reusable workflow from release-please.yml

`release.yml` previously triggered on `release: published`. GitHub's anti-loop policy means that when release-please creates a release using the default `GITHUB_TOKEN`, downstream workflows listening to `release: published` are silently skipped — which is why v0.2.2 got a tag + release but no binaries.

Converted `release.yml` into a reusable workflow (`on: workflow_call`) and wired it into `release-please.yml` as a dependent job guarded by `needs.release-please.outputs.release_created == 'true'`. Chained workflows via `uses:` + `secrets: inherit` work with `GITHUB_TOKEN` and don't require a PAT or GitHub App.

`workflow_dispatch` on `release.yml` is preserved — manual re-runs against any existing tag still work.

## Verification

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` succeeds locally (5 archives + 2 images)

## Test plan

- [ ] PR CI: `release-validate.yml` snapshot job passes (touches `.goreleaser.yaml` + `release.yml`)
- [ ] After merge: manually run `release.yml` with tag `v0.2.2` to back-fill the missing binaries
- [ ] Next release-please release: verify goreleaser job auto-fires via the chained `uses:` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)