### PR TITLE
perf: cache goreleaser docker builds via GHA buildx cache

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
+      - --cache-from=type=gha,scope=amd64
+      - --cache-to=type=gha,mode=max,scope=amd64
       - --label=org.opencontainers.image.source=https://github.com/Ivantseng123/agentdock
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.version={{ .Version }}
@@ -63,6 +65,8 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
+      - --cache-from=type=gha,scope=arm64
+      - --cache-to=type=gha,mode=max,scope=arm64
       - --label=org.opencontainers.image.source=https://github.com/Ivantseng123/agentdock
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.version={{ .Version }}


### PR DESCRIPTION
## Summary

Adds `--cache-from=type=gha` / `--cache-to=type=gha` to both docker entries in `.goreleaser.yaml`, scoped per-arch (`scope=amd64` / `scope=arm64`) to prevent cross-arch cache pollution.

Motivation: [v0.2.3 release run](https://github.com/Ivantseng123/agentdock/actions/runs/24383909082/job/71213241396) took 7m, broken down:

| stage | time | % |
|---|---|---|
| docker push to ghcr | 3m35s | 54% |
| binary build (5 targets) | 1m54s | 29% |
| docker build (2 arches) | 1m1s | 15% |
| archives + manifests | ~7s | 2% |

This PR targets the **docker build** segment. Unchanged layers (apk packages, `npm install -g @anthropic-ai/claude-code @openai/codex`, opencode binary download, gh binary download) are cached in GHA storage and replayed on subsequent runs.

## Expected impact

- **First release after merge**: no change (cache cold)
- **Subsequent releases**: docker build should drop from ~1m to ~15-20s
- **Push time (3m35s)**: unchanged — this requires splitting a base image, which is deferred

## Not in this PR

- Splitting `Dockerfile.release` into a base image + thin release image (would cut push time ~80% but adds a separate workflow to maintain). Revisit if push stays the dominant bottleneck after cache is in.
- `parallelism: 5` for Go builds — the yaml field doesn't exist in goreleaser v2 schema (only CLI `--parallelism`); the ~20s win isn't worth plumbing the flag through both call sites (`release.yml` + `release-validate.yml`).

## Test plan

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` succeeds locally
- [ ] `release-validate.yml` PR CI passes (this PR touches `.goreleaser.yaml`)
- [ ] After merge, next release: inspect `release / goreleaser` run; docker build stage should complete in <30s (was 1m1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)