### PR TITLE
fix: allow skill .md files in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git/
 docs/
 *.md
+!agents/skills/**/*.md
 config.yaml
 config.local.yaml
 bot


### PR DESCRIPTION
## Summary
- `.dockerignore` had `*.md` which excluded `agents/skills/triage-issue/SKILL.md` from the Docker image
- Add `!agents/skills/**/*.md` exception so skill markdown files are included

## Context
Container logs showed:
```
level=WARN msg="skill not found, agents will run without skill"
path=agents/skills/triage-issue/SKILL.md
error="open agents/skills/triage-issue/SKILL.md: no such file or directory"
```

## Test plan
- [ ] Build image, exec into container, verify `/opt/agents/skills/triage-issue/SKILL.md` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)