### PR TITLE
feat: add latest and major-only docker tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,14 @@ docker_manifests:
     image_templates:
       - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-amd64'
       - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-arm64'
+  - name_template: 'ghcr.io/ivantseng123/agentdock:{{ .Major }}'
+    image_templates:
+      - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-amd64'
+      - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-arm64'
+  - name_template: 'ghcr.io/ivantseng123/agentdock:latest'
+    image_templates:
+      - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-amd64'
+      - 'ghcr.io/ivantseng123/agentdock:{{ .Version }}-arm64'
 
 release:
   github:


### PR DESCRIPTION
## Summary
- Add two multi-arch docker manifests to `.goreleaser.yaml`: `:latest` and major-only `:X`
- Complements existing `:X.Y.Z` and `:X.Y` tags so users can pin at whichever floating level suits them

## Test plan
- [ ] Trigger a release (or `workflow_dispatch` the `Release` workflow with an existing tag) and confirm the new manifests appear on `ghcr.io/ivantseng123/agentdock`
- [ ] Verify `docker pull ghcr.io/ivantseng123/agentdock:latest` resolves to the newly released version
- [ ] Verify `docker pull ghcr.io/ivantseng123/agentdock:0` (major-only) resolves to the same digest

> Heads up: `:latest` will track whatever tag is released next, including pre-releases unless we gate that later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)