### PR TITLE
fix: improve worker observability, security, and reliability

### DIFF
--- a/docs/operations.en.md
+++ b/docs/operations.en.md
@@ -13,12 +13,30 @@ Returns:
 ```json
 {
   "queue_depth": 1,
+  "workers": [
+    {
+      "worker_id": "my-host/worker-0",
+      "name": "my-host",
+      "connected_at": "2026-04-14T17:41:33+08:00",
+      "uptime": "5m30s",
+      "current_job": "req-abc123",
+      "status": "busy"
+    },
+    {
+      "worker_id": "my-host/worker-1",
+      "name": "my-host",
+      "connected_at": "2026-04-14T17:41:33+08:00",
+      "uptime": "5m30s",
+      "status": "idle"
+    }
+  ],
   "total": 2,
   "jobs": [
     {
       "id": "req-abc123",
       "status": "running",
       "repo": "org/backend",
+      "worker_id": "my-host/worker-0",
       "age": "45s",
       "agent": {
         "pid": 12345,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,11 +15,19 @@ curl localhost:8180/jobs | jq .
   "queue_depth": 1,
   "workers": [
     {
-      "worker_id": "worker-1713081693342",
+      "worker_id": "my-host/worker-0",
       "name": "my-host",
-      "agents": ["claude"],
       "connected_at": "2026-04-14T17:41:33+08:00",
-      "uptime": "5m30s"
+      "uptime": "5m30s",
+      "current_job": "req-abc123",
+      "status": "busy"
+    },
+    {
+      "worker_id": "my-host/worker-1",
+      "name": "my-host",
+      "connected_at": "2026-04-14T17:41:33+08:00",
+      "uptime": "5m30s",
+      "status": "idle"
     }
   ],
   "total": 2,
@@ -28,6 +36,7 @@ curl localhost:8180/jobs | jq .
       "id": "req-abc123",
       "status": "running",
       "repo": "org/backend",
+      "worker_id": "my-host/worker-0",
       "age": "45s",
       "agent": {
         "pid": 12345,
@@ -54,7 +63,7 @@ curl localhost:8180/jobs | jq .
 
 ### Workers 欄位
 
-`workers` 陣列顯示目前已註冊的 worker。Worker 透過 Redis key（`ad:workers:{id}`，30s TTL）維持心跳，斷線 30 秒後自動消失。
+`workers` 陣列顯示目前已註冊的 worker。Worker 透過 Redis key（`ad:workers:{id}`，30s TTL）維持心跳，斷線 30 秒後自動消失。每個 worker 會顯示 `status`（`busy`/`idle`）及正在處理的 `current_job`。
 
 若 `workers` 為空陣列，代表沒有活著的 worker — pending job 不會被處理。
 

--- a/internal/bot/parser.go
+++ b/internal/bot/parser.go
@@ -45,8 +45,9 @@ func ParseAgentOutput(output string) (TriageResult, error) {
 
 	// Try JSON format first.
 	if strings.HasPrefix(result, "{") {
+		jsonStr := extractJSON(result)
 		var tr TriageResult
-		if err := json.Unmarshal([]byte(result), &tr); err == nil && tr.Status != "" {
+		if err := json.Unmarshal([]byte(jsonStr), &tr); err == nil && tr.Status != "" {
 			return tr, nil
 		}
 	}
@@ -71,6 +72,45 @@ func ParseAgentOutput(output string) (TriageResult, error) {
 	}
 
 	return TriageResult{}, fmt.Errorf("unknown triage result: %s", result)
+}
+
+// extractJSON finds the first top-level JSON object in text by matching braces.
+// This handles cases where the agent appends extra content after the JSON.
+func extractJSON(text string) string {
+	depth := 0
+	start := strings.Index(text, "{")
+	if start < 0 {
+		return text
+	}
+	inString := false
+	escaped := false
+	for i := start; i < len(text); i++ {
+		ch := text[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if ch == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if ch == '{' {
+			depth++
+		} else if ch == '}' {
+			depth--
+			if depth == 0 {
+				return text[start : i+1]
+			}
+		}
+	}
+	return text // unbalanced, return as-is
 }
 
 // extractIssueURL finds a GitHub issue URL in text.

--- a/internal/bot/parser_test.go
+++ b/internal/bot/parser_test.go
@@ -122,3 +122,35 @@ func TestParseAgentOutput_NoResult(t *testing.T) {
 		t.Error("expected error when no result")
 	}
 }
+
+func TestParseAgentOutput_JSONWithTrailingContent(t *testing.T) {
+	output := "Investigation complete.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "Bug title",
+  "body": "Issue body",
+  "labels": ["bug"],
+  "confidence": "high",
+  "files_found": 4,
+  "open_questions": 1
+}
+
+---
+
+## Summary
+
+Some extra markdown the agent added after the JSON.`
+
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if result.Status != "CREATED" {
+		t.Errorf("status = %q, want CREATED", result.Status)
+	}
+	if result.Title != "Bug title" {
+		t.Errorf("title = %q", result.Title)
+	}
+	if result.FilesFound != 4 {
+		t.Errorf("files_found = %d, want 4", result.FilesFound)
+	}
+}

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -93,6 +93,14 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 	job := state.Job
 	owner, repo := splitRepo(job.Repo)
 
+	logger := slog.With("job_id", result.JobID, "repo", job.Repo, "status", result.Status)
+	if result.RawOutput != "" {
+		logger.Info("agent raw output", "output", result.RawOutput)
+	}
+	if result.Error != "" {
+		logger.Warn("job failed", "error", result.Error)
+	}
+
 	switch {
 	case result.Status == "failed":
 		r.handleFailure(job, state, result)
@@ -130,15 +138,21 @@ func (r *ResultListener) handleFailure(job *queue.Job, state *queue.JobState, re
 		workerInfo = fmt.Sprintf(" | worker: %s", workerID)
 	}
 
+	// Extract short error reason for Slack (before first colon detail or 80 chars).
+	errMsg := result.Error
+	if idx := strings.Index(errMsg, ":"); idx > 0 {
+		errMsg = errMsg[:idx]
+	}
+
 	if job.RetryCount < 1 {
 		// Show retry button.
-		text := fmt.Sprintf(":x: 分析失敗: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		text := fmt.Sprintf(":x: 分析失敗: %s\nrepo: `%s` | job: `%s`%s", errMsg, job.Repo, job.ID, workerInfo)
 		r.slack.PostMessageWithButton(job.ChannelID, text, job.ThreadTS,
 			"retry_job", "🔄 重試", job.ID)
 		// Do NOT clear dedup — user should use retry button.
 	} else {
 		// Retry exhausted, no button.
-		text := fmt.Sprintf(":x: 分析失敗（重試後仍失敗）: %s\nrepo: `%s`%s", result.Error, job.Repo, workerInfo)
+		text := fmt.Sprintf(":x: 分析失敗（重試後仍失敗）: %s\nrepo: `%s` | job: `%s`%s", errMsg, job.Repo, job.ID, workerInfo)
 		r.updateStatus(job, text)
 		r.clearDedup(job)
 	}

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -94,11 +94,14 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 	owner, repo := splitRepo(job.Repo)
 
 	logger := slog.With("job_id", result.JobID, "repo", job.Repo, "status", result.Status)
-	if result.RawOutput != "" {
-		logger.Info("agent raw output", "output", result.RawOutput)
-	}
-	if result.Error != "" {
-		logger.Warn("job failed", "error", result.Error)
+	if result.Status == "failed" {
+		truncated := result.RawOutput
+		if len(truncated) > 2000 {
+			truncated = truncated[:2000] + "…(truncated)"
+		}
+		logger.Warn("job failed", "error", result.Error, "raw_output", truncated)
+	} else {
+		logger.Info("job completed", "title", result.Title, "confidence", result.Confidence, "files_found", result.FilesFound)
 	}
 
 	switch {
@@ -138,10 +141,13 @@ func (r *ResultListener) handleFailure(job *queue.Job, state *queue.JobState, re
 		workerInfo = fmt.Sprintf(" | worker: %s", workerID)
 	}
 
-	// Extract short error reason for Slack (before first colon detail or 80 chars).
+	// Extract short error reason for Slack (before first colon detail, max 80 chars).
 	errMsg := result.Error
 	if idx := strings.Index(errMsg, ":"); idx > 0 {
 		errMsg = errMsg[:idx]
+	}
+	if len(errMsg) > 80 {
+		errMsg = errMsg[:80] + "…"
 	}
 
 	if job.RetryCount < 1 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,18 +173,21 @@ func LoadDefaults() (*Config, error) {
 			"claude": {
 				Command:  "claude",
 				Args:     []string{"--print", "--output-format", "stream-json", "-p", "{prompt}"},
+				Timeout:  15 * time.Minute,
 				SkillDir: ".claude/skills",
 				Stream:   true,
 			},
 			"codex": {
 				Command:  "codex",
 				Args:     []string{"--print", "--output-format", "stream-json", "-p", "{prompt}"},
+				Timeout:  15 * time.Minute,
 				SkillDir: ".codex/skills",
 				Stream:   true,
 			},
 			"opencode": {
 				Command:  "opencode",
 				Args:     []string{"--prompt", "{prompt}"},
+				Timeout:  15 * time.Minute,
 				SkillDir: ".opencode/skills",
 			},
 		},

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -37,14 +37,14 @@ func (rc *RepoCache) EnsureRepo(repoRef string) (string, error) {
 	localPath := filepath.Join(rc.dir, rc.dirName(repoRef))
 
 	if _, err := os.Stat(filepath.Join(localPath, ".git")); os.IsNotExist(err) {
-		slog.Info("cloning repo", "repo", repoRef, "path", localPath)
+		slog.Info("cloning repo", "repo", SanitizeURL(repoRef), "path", localPath)
 		if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
 			return "", fmt.Errorf("mkdir: %w", err)
 		}
 		// Full clone (not shallow) so we can switch branches
 		cmd := exec.Command("git", "clone", cloneURL, localPath)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("git clone: %w\n%s", err, out)
+		if _, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("git clone failed: %w", err)
 		}
 		rc.lastPull[repoRef] = time.Now()
 		return localPath, nil
@@ -54,20 +54,20 @@ func (rc *RepoCache) EnsureRepo(repoRef string) (string, error) {
 		return localPath, nil
 	}
 
-	slog.Info("fetching repo", "repo", repoRef)
+	slog.Info("fetching repo", "repo", SanitizeURL(repoRef))
 	cmd := exec.Command("git", "-C", localPath, "fetch", "--all", "--prune")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		slog.Warn("git fetch failed", "error", err, "output", string(out))
+		slog.Warn("git fetch failed", "error", err)
 		// Broken repo (e.g. interrupted clone) — remove and re-clone
 		if strings.Contains(string(out), "not a git repository") {
-			slog.Info("removing broken repo dir and re-cloning", "repo", repoRef)
+			slog.Info("removing broken repo dir and re-cloning", "repo", SanitizeURL(repoRef))
 			os.RemoveAll(localPath)
 			if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
 				return "", fmt.Errorf("mkdir: %w", err)
 			}
 			cmd = exec.Command("git", "clone", cloneURL, localPath)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return "", fmt.Errorf("git clone (retry): %w\n%s", err, out)
+			if _, err := cmd.CombinedOutput(); err != nil {
+				return "", fmt.Errorf("git clone (retry) failed: %w", err)
 			}
 			rc.lastPull[repoRef] = time.Now()
 			return localPath, nil
@@ -138,4 +138,15 @@ func (rc *RepoCache) ResolveURL(repoRef string) string {
 func (rc *RepoCache) dirName(repoRef string) string {
 	h := sha256.Sum256([]byte(repoRef))
 	return fmt.Sprintf("%x", h[:8])
+}
+
+// SanitizeURL strips embedded credentials from a URL for safe logging.
+func SanitizeURL(raw string) string {
+	// Matches https://TOKEN@github.com/... or https://user:pass@host/...
+	if idx := strings.Index(raw, "@"); idx > 0 {
+		if schemeEnd := strings.Index(raw, "://"); schemeEnd > 0 && schemeEnd < idx {
+			return raw[:schemeEnd+3] + "***@" + raw[idx+1:]
+		}
+	}
+	return raw
 }

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -82,6 +82,25 @@ func TestRepoCache_EnsureRepo_PullsExistingRepo(t *testing.T) {
 	}
 }
 
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://ghp_abc123@github.com/org/repo.git", "https://***@github.com/org/repo.git"},
+		{"https://user:pass@github.com/org/repo.git", "https://***@github.com/org/repo.git"},
+		{"https://github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"git@github.com:org/repo.git", "git@github.com:org/repo.git"},
+		{"file:///tmp/repo", "file:///tmp/repo"},
+		{"org/repo", "org/repo"},
+	}
+	for _, tt := range tests {
+		if got := SanitizeURL(tt.input); got != tt.want {
+			t.Errorf("SanitizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)

--- a/internal/queue/httpstatus.go
+++ b/internal/queue/httpstatus.go
@@ -44,6 +44,8 @@ type workerEntry struct {
 	Tags        []string `json:"tags,omitempty"`
 	ConnectedAt string   `json:"connected_at"`
 	Uptime      string   `json:"uptime"`
+	CurrentJob  string   `json:"current_job,omitempty"`
+	Status      string   `json:"status"`
 }
 
 type jobsResponse struct {
@@ -76,6 +78,8 @@ func StatusHandler(store JobStore, queue JobQueue) http.HandlerFunc {
 			}
 			if state.WorkerID != "" {
 				entry.WorkerID = state.WorkerID
+			} else if state.AgentStatus != nil && state.AgentStatus.WorkerID != "" {
+				entry.WorkerID = state.AgentStatus.WorkerID
 			}
 			if state.WaitTime > 0 {
 				entry.WaitTime = state.WaitTime.Truncate(time.Second).String()
@@ -108,17 +112,31 @@ func StatusHandler(store JobStore, queue JobQueue) http.HandlerFunc {
 			entries = append(entries, entry)
 		}
 
+		// Build worker → active job map from running jobs.
+		activeJobs := make(map[string]string) // workerID → jobID
+		for _, e := range entries {
+			if e.WorkerID != "" && (e.Status == JobRunning || e.Status == JobPending) {
+				activeJobs[e.WorkerID] = e.ID
+			}
+		}
+
 		var workers []workerEntry
 		if wl, err := queue.ListWorkers(r.Context()); err == nil {
 			for _, wi := range wl {
-				workers = append(workers, workerEntry{
+				we := workerEntry{
 					WorkerID:    wi.WorkerID,
 					Name:        wi.Name,
 					Agents:      wi.Agents,
 					Tags:        wi.Tags,
 					ConnectedAt: wi.ConnectedAt.Format(time.RFC3339),
 					Uptime:      now.Sub(wi.ConnectedAt).Truncate(time.Second).String(),
-				})
+					Status:      "idle",
+				}
+				if jobID, ok := activeJobs[wi.WorkerID]; ok {
+					we.CurrentJob = jobID
+					we.Status = "busy"
+				}
+				workers = append(workers, we)
 			}
 		}
 

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -86,7 +86,11 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	// Parse agent output.
 	parsed, err := bot.ParseAgentOutput(output)
 	if err != nil {
-		logger.Warn("parse failed, dumping raw output", "output", output)
+		truncated := output
+		if len(truncated) > 2000 {
+			truncated = truncated[:2000] + "…(truncated)"
+		}
+		logger.Warn("parse failed, dumping raw output", "output", truncated)
 		return failedResult(job, startedAt, fmt.Errorf("parse failed: %w", err))
 	}
 	logger.Info("parse succeeded", "status", parsed.Status, "confidence", parsed.Confidence, "files_found", parsed.FilesFound)

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,10 +33,12 @@ type executionDeps struct {
 
 func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bot.RunOptions) *queue.JobResult {
 	startedAt := time.Now()
+	logger := slog.With("job_id", job.ID, "repo", job.Repo)
 
 	// Resolve attachments (blocks until Prepare completes on app side).
 	var attachments []queue.AttachmentReady
 	if len(job.Attachments) > 0 {
+		logger.Info("resolving attachments", "count", len(job.Attachments))
 		var err error
 		attachments, err = deps.attachments.Resolve(ctx, job.ID)
 		if err != nil {
@@ -44,10 +47,12 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	}
 
 	// Clone/fetch repo.
+	logger.Info("preparing repo", "branch", job.Branch)
 	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch)
 	if err != nil {
 		return failedResult(job, startedAt, fmt.Errorf("repo prepare failed: %w", err))
 	}
+	logger.Info("repo ready", "path", repoPath)
 
 	// Copy attachments to repo workspace.
 	for _, att := range attachments {
@@ -58,26 +63,33 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 
 	// Mount skills to all agent skill directories.
 	if len(job.Skills) > 0 {
+		logger.Info("mounting skills", "count", len(job.Skills), "skill_dirs", deps.skillDirs)
 		for _, sd := range deps.skillDirs {
 			if err := mountSkills(repoPath, job.Skills, sd); err != nil {
 				return failedResult(job, startedAt, fmt.Errorf("skill mount failed: %w", err))
 			}
 			defer cleanupSkills(repoPath, job.Skills, sd)
 		}
+	} else {
+		logger.Warn("no skills in job payload")
 	}
 
 	// Execute agent.
 	deps.store.UpdateStatus(job.ID, queue.JobRunning)
+	logger.Info("executing agent")
 	output, err := deps.runner.Run(ctx, repoPath, job.Prompt, opts)
 	if err != nil {
 		return failedResult(job, startedAt, err)
 	}
+	logger.Info("agent finished", "output_len", len(output))
 
 	// Parse agent output.
 	parsed, err := bot.ParseAgentOutput(output)
 	if err != nil {
+		logger.Warn("parse failed, dumping raw output", "output", output)
 		return failedResult(job, startedAt, fmt.Errorf("parse failed: %w", err))
 	}
+	logger.Info("parse succeeded", "status", parsed.Status, "confidence", parsed.Confidence, "files_found", parsed.FilesFound)
 
 	return &queue.JobResult{
 		JobID:      job.ID,

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -221,11 +221,13 @@ func (p *Pool) workerHeartbeat(ctx context.Context) {
 				p.cfg.Queue.Register(ctx, info)
 			}
 		case <-ctx.Done():
-			// Unregister on shutdown.
+			// Best-effort unregister with short timeout; TTL expires in 30s anyway.
+			unregCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			for i := 0; i < p.cfg.WorkerCount; i++ {
 				wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i)
-				p.cfg.Queue.Unregister(context.Background(), wID)
+				p.cfg.Queue.Unregister(unregCtx, wID)
 			}
+			cancel()
 			return
 		}
 	}

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -45,6 +45,10 @@ func (p *Pool) Start(ctx context.Context) {
 	for i := 0; i < p.cfg.WorkerCount; i++ {
 		go p.runWorker(ctx, i)
 	}
+
+	// Register workers with the queue and maintain heartbeat.
+	go p.workerHeartbeat(ctx)
+
 	slog.Info("worker pool started", "count", p.cfg.WorkerCount)
 }
 
@@ -187,6 +191,44 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 		logger.Error("failed to publish result", "error", err)
 	}
 	logger.Info("job completed", "status", result.Status)
+}
+
+func (p *Pool) workerHeartbeat(ctx context.Context) {
+	now := time.Now()
+	for i := 0; i < p.cfg.WorkerCount; i++ {
+		info := queue.WorkerInfo{
+			WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
+			Name:        p.cfg.Hostname,
+			ConnectedAt: now,
+		}
+		if err := p.cfg.Queue.Register(ctx, info); err != nil {
+			slog.Warn("worker registration failed", "worker_id", info.WorkerID, "error", err)
+		}
+	}
+
+	// Re-register every 20s to keep the 30s TTL alive.
+	ticker := time.NewTicker(20 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			for i := 0; i < p.cfg.WorkerCount; i++ {
+				info := queue.WorkerInfo{
+					WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
+					Name:        p.cfg.Hostname,
+					ConnectedAt: now,
+				}
+				p.cfg.Queue.Register(ctx, info)
+			}
+		case <-ctx.Done():
+			// Unregister on shutdown.
+			for i := 0; i < p.cfg.WorkerCount; i++ {
+				wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i)
+				p.cfg.Queue.Unregister(context.Background(), wID)
+			}
+			return
+		}
+	}
 }
 
 func (p *Pool) reportStatus(ctx context.Context, status *statusAccumulator, interval time.Duration, stop <-chan struct{}) {


### PR DESCRIPTION
## Summary
- **Timeout**: Worker default agent timeout changed from 5m to 15m (matching app config)
- **Security**: GitHub PAT no longer leaks in log output or error messages (`SanitizeURL`)
- **Parser**: Handle trailing markdown after `===TRIAGE_RESULT===` JSON block
- **Slack errors**: Truncated to short reason + job ID instead of dumping full output
- **Worker logging**: Added structured logs for each executor stage (repo, skills, agent, parse)
- **Worker registration**: Workers now register via Redis heartbeat, visible in `/jobs` response
- **Worker status**: Each worker shows `busy`/`idle` and `current_job` in `/jobs`
- **Job worker_id**: Jobs show which worker is handling them (from AgentStatus)

## Test plan
- [x] 164 tests pass
- [ ] Local worker shows in `/jobs` workers array
- [ ] Clone logs show `***@` instead of token
- [ ] Agent timeout shows 15m in worker logs
- [ ] Failed jobs show short error + job ID in Slack
- [ ] JSON with trailing content parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)