### PR TITLE
chore: update project descriptions to reflect orchestrator role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ deploy/overlays/*/
 .DS_Store
 dump.rdb
 worker.yaml
+dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,112 +1,23 @@
 # AgentDock
 
-AI agent dispatch platform. Currently: turns Slack conversations into structured GitHub issues with AI-powered codebase triage. Triggered by `@bot` mentions or `/triage` slash commands in threads. Core value: lowering the barrier for non-engineers to create useful issues from Slack conversations.
+Slack → GitHub issue triage bot. Spawns external CLI agents (`claude`, `opencode`, `codex`, `gemini`) to explore a cloned repo and draft the issue body; this bot only orchestrates.
 
-## Architecture
+Overview, architecture, build/run, tests, and release flow live in `README.md` and `docs/`. Do not duplicate them here.
 
-```
-@bot or /triage in thread → Socket Mode → Handler (dedup + rate limit + semaphore)
-  → Workflow (thread context read → repo/branch selection via buttons)
-    → CLI Agent (claude/opencode/codex/gemini):
-        Spawn agent with prompt (thread context + repo path)
-        Agent explores codebase using its own tools
-        Returns markdown issue body + JSON metadata
-    → Rejection/Degradation:
-        confidence=low → reject (wrong repo)
-        files=0 or questions>=5 → create issue WITHOUT triage section
-        otherwise → create issue WITH full triage
-    → GitHub Issue (Go-injected header + agent markdown) → Post URL in thread
-```
+## Landmines
 
-## Project Structure
+- **Binary is `agentdock`, not `bot`.** Entry is `cmd/agentdock/`, and it requires a subcommand (`app`, `worker`, `init`, ...). Any instruction saying `./bot -config ...` is pre-v1 and wrong; see `docs/MIGRATION-v1.md`.
+- **`/triage` is not a trigger anymore.** It only prints a usage hint because Slack doesn't expose thread context to slash commands. Real triggers are `@bot` mentions inside a thread.
+- **Slack `invalid_blocks`:** do not combine `MsgOptionMetadata` with `MsgOptionBlocks` in the same post — they reject silently together.
+- **Full clone required for branch listing.** Shallow clones can't enumerate branches. `internal/github/repo.go` uses `fetch --all --prune`; keep it that way.
+- **Reporter tag is plain text.** Slack display name ≠ GitHub handle. Never render `@username` into issue bodies.
 
-```
-cmd/bot/main.go              # Entry point, wires deps, Socket Mode event loop
-internal/
-  config/config.go           # YAML config: agents, channels, prompt, rate limits
-  bot/
-    workflow.go              # Orchestrator: trigger → interact → spawn agent → parse → issue
-    agent.go                 # AgentRunner: spawn CLI agent with provider chain
-    parser.go                # Parse agent output (===TRIAGE_RESULT=== CREATED/REJECTED/ERROR)
-    prompt.go                # Build minimal user prompt for CLI agent
-    result_listener.go       # ResultBus → create issue / retry button → Slack
-    retry_handler.go         # Retry button interaction → re-submit job
-    enrich.go                # Expand Mantis URLs in messages
-  slack/
-    client.go                # PostMessage/PostSelector/FetchThreadContext/DownloadAttachments
-    handler.go               # TriggerEvent dedup, rate limiting, bounded concurrency
-  github/
-    issue.go                 # CreateIssue(ctx, owner, repo, title, body, labels)
-    repo.go                  # RepoCache: full clone, fetch, branch list, checkout
-    discovery.go             # GitHub API repo discovery with cache (auto-bind)
-  skill/
-    config.go                # skills.yaml parsing (SkillsFileConfig)
-    validate.go              # File validation (size, whitelist, path safety)
-    npx.go                   # NPM package scanning (FetchPackage, scanPackageSkills)
-    loader.go                # SkillLoader: cache, singleflight, fallback, warmup
-    watcher.go               # fsnotify hot reload for skills.yaml (ConfigMap)
-  mantis/                    # Mantis bug tracker URL enrichment
-```
+## Product Positioning
 
-## Key Design Decisions
+This is a **structuring tool, not a diagnosis tool.** The core value is turning Slack threads into well-formatted GitHub issues. AI triage (file pointers, confidence scoring) is a bonus — do not sacrifice thread-capture reliability to improve diagnostic quality.
 
-### Tool positioning
-This is a **structuring tool**, not a diagnosis tool. The core value is turning Slack conversations into formatted issues — AI triage is a bonus.
+## Routing
 
-### CLI Agent Delegation (v2)
-Instead of implementing a custom agent loop with tools, the bot spawns external CLI agents (claude, opencode, codex, gemini) that use their own built-in tools to explore the codebase. The bot sends a minimal prompt with thread context and repo path, and parses the structured output.
-
-### Multi-Agent Providers
-Agents are configured in YAML with a `providers` list. If the active provider fails (timeout, not found, error), the bot tries the next provider in the chain.
-
-### Output Format
-Agent creates the GitHub issue directly via `gh issue create` and outputs a result marker. The parser looks for `===TRIAGE_RESULT===` followed by `CREATED: {url}`, `REJECTED: {reason}`, or `ERROR: {message}`. If the marker is missing, the parser falls back to extracting a GitHub issue URL from the output.
-
-### Rejection vs Degradation
-- `confidence=low` → reject (likely wrong repo)
-- `files=0` or `open_questions>=5` → create issue, skip triage
-- Normal → create issue with full triage
-
-### Thread-Only, Thread-Context
-Bot only operates in threads. Reads all thread messages before the trigger to build context. Agent decides issue type (bug/feature/improvement/question) from context.
-
-### Auto-bind
-Bot auto-registers when joining a channel. No static channel config needed.
-
-## Lessons Learned
-
-- **Slack `invalid_blocks`**: Don't combine `MsgOptionMetadata` with `MsgOptionBlocks`.
-- **Full clone required**: Shallow clone can't list branches. Use `fetch --all --prune`.
-- **Reporter tag**: Don't use `@username` — Slack/GitHub names differ. Plain text only.
-- **Logging conventions**: See `internal/logging/GUIDE.md` for component/phase classification, Chinese message format, and attribute naming rules.
-
-## Testing
-
-```bash
-go test ./...   # 150 tests
-```
-
-## Build & Run
-
-```bash
-./run.sh
-# or
-go build -o bot ./cmd/bot/ && ./bot -config config.yaml
-```
-
-## Release
-
-Automated via [release-please](https://github.com/googleapis/release-please). Flow:
-
-1. Write Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
-2. release-please auto-maintains a Release PR on `main` (version bump + CHANGELOG)
-3. Merge the Release PR → GitHub Release + tag created automatically
-4. GHA builds Docker image → pushes to `ghcr.io/ivantseng123/agentdock:<version>`
-
-If Docker build fails: manually trigger the `Release Publish` workflow with the tag from GitHub Actions UI.
-
-## Git Conventions
-
-- **Merge strategy:** rebase merge (preserve individual commits)
-- **Commit format:** [Conventional Commits](https://www.conventionalcommits.org/) — enforced by commitlint on PRs
-- **Versioning:** semver, automated by release-please (`feat:`→minor, `fix:`→patch, `BREAKING CHANGE`→major)
+- Logging conventions (component/phase taxonomy, attribute names, Chinese message format): `internal/logging/GUIDE.md`
+- v1 migration (binary rename, subcommands, config path): `docs/MIGRATION-v1.md`
+- Historical specs and plans: `docs/superpowers/`

--- a/cmd/agentdock/root.go
+++ b/cmd/agentdock/root.go
@@ -15,8 +15,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:     "agentdock",
-	Short:   "AgentDock — Slack to GitHub issue triage",
-	Long:    "AgentDock turns Slack threads into structured GitHub issues with AI-assisted triage.",
+	Short:   "AgentDock — Slack-driven LLM agent orchestrator",
+	Long:    "AgentDock listens to Slack events, dispatches work to external LLM agents, and delivers results back to your team.",
 	Version: fmt.Sprintf("%s (commit %s, built %s)", version, commit, date),
 }
 


### PR DESCRIPTION
## Summary

- Rewrite CLI `Short`/`Long` descriptions to emphasize Slack-driven LLM agent orchestration instead of tying identity to GitHub issue triage
- Trim `CLAUDE.md` to essential landmines, product positioning, and routing — move duplicated architecture/build/release info to `README.md` and `docs/`
- Add `dist/` to `.gitignore`

## Test plan

- [ ] `go build ./cmd/agentdock/` compiles
- [ ] `agentdock --help` shows updated Short/Long descriptions
- [ ] No functional changes — descriptions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)