### PR TITLE
fix(validate): skip workers.count check for redis transport

### DIFF
--- a/cmd/agentdock/validate.go
+++ b/cmd/agentdock/validate.go
@@ -12,7 +12,7 @@ import (
 func validate(cfg *config.Config) error {
 	var errs []string
 
-	if cfg.Workers.Count < 1 {
+	if cfg.Queue.Transport != "redis" && cfg.Workers.Count < 1 {
 		errs = append(errs, "workers.count must be >= 1")
 	}
 	if cfg.Queue.Capacity < 1 {

--- a/cmd/agentdock/validate_test.go
+++ b/cmd/agentdock/validate_test.go
@@ -24,6 +24,15 @@ func TestValidate_WorkersZero(t *testing.T) {
 	}
 }
 
+func TestValidate_WorkersZero_RedisTransport(t *testing.T) {
+	cfg := goodConfig()
+	cfg.Workers.Count = 0
+	cfg.Queue.Transport = "redis"
+	if err := validate(cfg); err != nil {
+		t.Errorf("redis transport should allow workers.count=0, got %v", err)
+	}
+}
+
 func TestValidate_MultipleErrors_ListedAtOnce(t *testing.T) {
 	cfg := goodConfig()
 	cfg.Workers.Count = 0


### PR DESCRIPTION
## Summary

- `workers.count >= 1` 驗證在 `transport: redis` 時不再強制要求，因為 redis 模式下 app 不啟動 local worker（`app.go:167`）
- 新增 `TestValidate_WorkersZero_RedisTransport` 測試案例

## Problem

使用者在 redis transport 下合理地設定 `workers.count: 0`，但驗證無條件拒絕，導致 pod CrashLoopBackOff。

## Test plan

- [x] `TestValidate_OK` — 既有正常 config 仍通過
- [x] `TestValidate_WorkersZero` — 非 redis 模式下 count=0 仍被拒絕
- [x] `TestValidate_WorkersZero_RedisTransport` — redis 模式下 count=0 通過
- [x] `TestValidate_MultipleErrors_ListedAtOnce` — 多錯誤聚合仍正常

Fixes #42