### PR TITLE
feat: app-to-worker encrypted secret passing (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ config.local.yaml
 deploy/overlays/*/
 !deploy/overlays/example/
 
+# Worktrees
+.worktrees/
+
 # OS
 .DS_Store
 dump.rdb

--- a/cmd/agentdock/adapters.go
+++ b/cmd/agentdock/adapters.go
@@ -26,8 +26,8 @@ type repoCacheAdapter struct {
 	cache *ghclient.RepoCache
 }
 
-func (a *repoCacheAdapter) Prepare(cloneURL, branch string) (string, error) {
-	barePath, err := a.cache.EnsureRepo(cloneURL, "")
+func (a *repoCacheAdapter) Prepare(cloneURL, branch, token string) (string, error) {
+	barePath, err := a.cache.EnsureRepo(cloneURL, token)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agentdock/adapters.go
+++ b/cmd/agentdock/adapters.go
@@ -27,7 +27,7 @@ type repoCacheAdapter struct {
 }
 
 func (a *repoCacheAdapter) Prepare(cloneURL, branch string) (string, error) {
-	barePath, err := a.cache.EnsureRepo(cloneURL)
+	barePath, err := a.cache.EnsureRepo(cloneURL, "")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agentdock/app.go
+++ b/cmd/agentdock/app.go
@@ -11,6 +11,7 @@ import (
 
 	"agentdock/internal/bot"
 	"agentdock/internal/config"
+	"agentdock/internal/crypto"
 	ghclient "agentdock/internal/github"
 	"agentdock/internal/logging"
 	"agentdock/internal/mantis"
@@ -131,6 +132,18 @@ func runApp(cfg *config.Config) error {
 		}
 		bundle = queue.NewRedisBundle(rdb, jobStore, "triage")
 		appLogger.Info("使用 Redis transport", "phase", "處理中", "addr", cfg.Redis.Addr)
+
+		// Write secret key beacon so workers can verify key match at startup.
+		if cfg.SecretKey != "" {
+			sk, err := config.DecodeSecretKey(cfg.SecretKey)
+			if err != nil {
+				return fmt.Errorf("invalid secret_key: %w", err)
+			}
+			if err := crypto.WriteBeacon(context.Background(), rdb, sk); err != nil {
+				return fmt.Errorf("failed to write secret beacon: %w", err)
+			}
+			appLogger.Info("Secret beacon 已寫入 Redis", "phase", "完成")
+		}
 	default:
 		bundle = queue.NewInMemBundle(cfg.Queue.Capacity, cfg.Workers.Count, jobStore)
 		appLogger.Info("使用 in-memory transport", "phase", "處理中")

--- a/cmd/agentdock/preflight.go
+++ b/cmd/agentdock/preflight.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"golang.org/x/term"
 
 	"agentdock/internal/config"
+	"agentdock/internal/crypto"
+	"agentdock/internal/queue"
 )
 
 const maxRetries = 3
@@ -255,9 +258,16 @@ func preflightSlackApp(cfg *config.Config, interactive bool, prompted map[string
 
 func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[string]any, scope PreflightScope) error {
 	if cfg.SecretKey != "" {
-		if _, err := config.DecodeSecretKey(cfg.SecretKey); err != nil {
+		decoded, err := config.DecodeSecretKey(cfg.SecretKey)
+		if err != nil {
 			printFail("secret_key invalid: %v", err)
 			return err
+		}
+		if scope == ScopeWorker {
+			if err := verifyBeaconFromConfig(cfg, decoded); err != nil {
+				printFail("secret_key 與 app 不匹配: %v", err)
+				return err
+			}
 		}
 		printOK("Secret key configured")
 		return nil
@@ -290,12 +300,23 @@ func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[strin
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		key := promptHidden("Secret key: ")
-		if _, err := config.DecodeSecretKey(key); err != nil {
+		decoded, err := config.DecodeSecretKey(key)
+		if err != nil {
 			printFail("%v (attempt %d/%d)", err, attempt, maxRetries)
 			if attempt == maxRetries {
 				return fmt.Errorf("max retries exceeded for secret key")
 			}
 			continue
+		}
+		// Worker: verify key matches app's beacon immediately.
+		if scope == ScopeWorker {
+			if err := verifyBeaconFromConfig(cfg, decoded); err != nil {
+				printFail("secret_key 與 app 不匹配 (attempt %d/%d)", attempt, maxRetries)
+				if attempt == maxRetries {
+					return fmt.Errorf("max retries exceeded — key does not match app")
+				}
+				continue
+			}
 		}
 		cfg.SecretKey = key
 		prompted["secret_key"] = key
@@ -303,6 +324,22 @@ func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[strin
 		return nil
 	}
 	return nil
+}
+
+// verifyBeaconFromConfig connects to Redis and verifies the secret key
+// matches the app's beacon. Uses cfg.Redis for connection details.
+func verifyBeaconFromConfig(cfg *config.Config, secretKey []byte) error {
+	rdb, err := queue.NewRedisClient(queue.RedisConfig{
+		Addr:     cfg.Redis.Addr,
+		Password: cfg.Redis.Password,
+		DB:       cfg.Redis.DB,
+		TLS:      cfg.Redis.TLS,
+	})
+	if err != nil {
+		return fmt.Errorf("connect to Redis for beacon check: %w", err)
+	}
+	defer rdb.Close()
+	return crypto.VerifyBeacon(context.Background(), rdb, secretKey)
 }
 
 func preflightAgentCLIs(cfg *config.Config, interactive bool) error {

--- a/cmd/agentdock/preflight.go
+++ b/cmd/agentdock/preflight.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -51,6 +53,10 @@ func runPreflight(cfg *config.Config, scope PreflightScope) (map[string]any, err
 		}
 	}
 
+	if err := preflightSecretKey(cfg, interactive, prompted); err != nil {
+		return prompted, err
+	}
+
 	if err := preflightAgentCLIs(cfg, interactive); err != nil {
 		return prompted, err
 	}
@@ -63,7 +69,7 @@ func runPreflight(cfg *config.Config, scope PreflightScope) (map[string]any, err
 // is empty, meaning preflight should enter interactive mode when attached to
 // a terminal.
 func needsInput(cfg *config.Config, scope PreflightScope) bool {
-	base := cfg.Redis.Addr == "" || cfg.GitHub.Token == "" || len(cfg.Providers) == 0
+	base := cfg.Redis.Addr == "" || cfg.GitHub.Token == "" || len(cfg.Providers) == 0 || cfg.SecretKey == ""
 	if scope == ScopeApp {
 		return base || cfg.Slack.BotToken == "" || cfg.Slack.AppToken == ""
 	}
@@ -245,6 +251,51 @@ func preflightSlackApp(cfg *config.Config, interactive bool, prompted map[string
 		return nil
 	}
 	return fmt.Errorf("unreachable")
+}
+
+func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[string]any) error {
+	if cfg.SecretKey != "" {
+		// Validate existing key.
+		if _, err := config.DecodeSecretKey(cfg.SecretKey); err != nil {
+			printFail("secret_key invalid: %v", err)
+			return err
+		}
+		printOK("Secret key configured")
+		return nil
+	}
+	if !interactive {
+		return fmt.Errorf("SECRET_KEY is required — set secret_key in config or SECRET_KEY env var")
+	}
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "  Secret key for encrypting secrets between app and workers.")
+	fmt.Fprintln(stderr, "  Must be a 64-character hex string (32 bytes).")
+	if promptYesNo("  Auto-generate a key?") {
+		keyBytes := make([]byte, 32)
+		if _, err := rand.Read(keyBytes); err != nil {
+			return fmt.Errorf("generate key: %w", err)
+		}
+		hexKey := hex.EncodeToString(keyBytes)
+		cfg.SecretKey = hexKey
+		prompted["secret_key"] = hexKey
+		fmt.Fprintf(stderr, "  Generated: %s\n", hexKey)
+		printOK("Secret key generated (will be saved to config)")
+		return nil
+	}
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		key := promptHidden("Secret key: ")
+		if _, err := config.DecodeSecretKey(key); err != nil {
+			printFail("%v (attempt %d/%d)", err, attempt, maxRetries)
+			if attempt == maxRetries {
+				return fmt.Errorf("max retries exceeded for secret key")
+			}
+			continue
+		}
+		cfg.SecretKey = key
+		prompted["secret_key"] = key
+		printOK("Secret key valid")
+		return nil
+	}
+	return nil
 }
 
 func preflightAgentCLIs(cfg *config.Config, interactive bool) error {

--- a/cmd/agentdock/preflight.go
+++ b/cmd/agentdock/preflight.go
@@ -53,7 +53,7 @@ func runPreflight(cfg *config.Config, scope PreflightScope) (map[string]any, err
 		}
 	}
 
-	if err := preflightSecretKey(cfg, interactive, prompted); err != nil {
+	if err := preflightSecretKey(cfg, interactive, prompted, scope); err != nil {
 		return prompted, err
 	}
 
@@ -253,9 +253,8 @@ func preflightSlackApp(cfg *config.Config, interactive bool, prompted map[string
 	return fmt.Errorf("unreachable")
 }
 
-func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[string]any) error {
+func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[string]any, scope PreflightScope) error {
 	if cfg.SecretKey != "" {
-		// Validate existing key.
 		if _, err := config.DecodeSecretKey(cfg.SecretKey); err != nil {
 			printFail("secret_key invalid: %v", err)
 			return err
@@ -269,18 +268,26 @@ func preflightSecretKey(cfg *config.Config, interactive bool, prompted map[strin
 	fmt.Fprintln(stderr)
 	fmt.Fprintln(stderr, "  Secret key for encrypting secrets between app and workers.")
 	fmt.Fprintln(stderr, "  Must be a 64-character hex string (32 bytes).")
-	if promptYesNo("  Auto-generate a key?") {
-		keyBytes := make([]byte, 32)
-		if _, err := rand.Read(keyBytes); err != nil {
-			return fmt.Errorf("generate key: %w", err)
+
+	// Only app can auto-generate; worker must receive the key from app.
+	if scope == ScopeApp {
+		if promptYesNo("  Auto-generate a key?") {
+			keyBytes := make([]byte, 32)
+			if _, err := rand.Read(keyBytes); err != nil {
+				return fmt.Errorf("generate key: %w", err)
+			}
+			hexKey := hex.EncodeToString(keyBytes)
+			cfg.SecretKey = hexKey
+			prompted["secret_key"] = hexKey
+			fmt.Fprintf(stderr, "  Generated: %s\n", hexKey)
+			fmt.Fprintln(stderr, "  ⚠ Copy this key to all worker configs.")
+			printOK("Secret key generated (will be saved to config)")
+			return nil
 		}
-		hexKey := hex.EncodeToString(keyBytes)
-		cfg.SecretKey = hexKey
-		prompted["secret_key"] = hexKey
-		fmt.Fprintf(stderr, "  Generated: %s\n", hexKey)
-		printOK("Secret key generated (will be saved to config)")
-		return nil
+	} else {
+		fmt.Fprintln(stderr, "  Paste the secret key from the app config:")
 	}
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		key := promptHidden("Secret key: ")
 		if _, err := config.DecodeSecretKey(key); err != nil {

--- a/cmd/agentdock/preflight_test.go
+++ b/cmd/agentdock/preflight_test.go
@@ -91,6 +91,7 @@ func TestNeedsInput_AllEmpty(t *testing.T) {
 func TestNeedsInput_AllSet(t *testing.T) {
 	cfg := &config.Config{
 		Providers: []string{"claude"},
+		SecretKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}
 	cfg.Redis.Addr = "localhost:6379"
 	cfg.GitHub.Token = "ghp_test"
@@ -102,6 +103,7 @@ func TestNeedsInput_AllSet(t *testing.T) {
 func TestNeedsInput_AppScope_SlackRequired(t *testing.T) {
 	cfg := &config.Config{
 		Providers: []string{"claude"},
+		SecretKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 	}
 	cfg.Redis.Addr = "localhost:6379"
 	cfg.GitHub.Token = "ghp_test"

--- a/cmd/agentdock/worker.go
+++ b/cmd/agentdock/worker.go
@@ -10,6 +10,7 @@ import (
 
 	"agentdock/internal/bot"
 	"agentdock/internal/config"
+	"agentdock/internal/crypto"
 	ghclient "agentdock/internal/github"
 	"agentdock/internal/logging"
 	"agentdock/internal/queue"
@@ -59,15 +60,17 @@ func runWorker(cfg *config.Config) error {
 
 	agentRunner := bot.NewAgentRunnerFromConfig(cfg)
 
-	var secretKey []byte
-	if cfg.SecretKey != "" {
-		var err error
-		secretKey, err = config.DecodeSecretKey(cfg.SecretKey)
-		if err != nil {
-			return fmt.Errorf("invalid secret_key: %w", err)
-		}
-		appLogger.Info("Secret key 已載入", "phase", "完成")
+	if cfg.SecretKey == "" {
+		return fmt.Errorf("secret_key is required for Redis worker — set it in config or via SECRET_KEY env var")
 	}
+	secretKey, err := config.DecodeSecretKey(cfg.SecretKey)
+	if err != nil {
+		return fmt.Errorf("invalid secret_key: %w", err)
+	}
+	if err := crypto.VerifyBeacon(context.Background(), rdb, secretKey); err != nil {
+		return fmt.Errorf("secret key 驗證失敗: %w", err)
+	}
+	appLogger.Info("Secret key 已驗證", "phase", "完成")
 
 	githubLogger := logging.ComponentLogger(slog.Default(), logging.CompGitHub)
 	repoCache := ghclient.NewRepoCache(cfg.RepoCache.Dir, cfg.RepoCache.MaxAge, cfg.GitHub.Token, githubLogger)

--- a/cmd/agentdock/worker.go
+++ b/cmd/agentdock/worker.go
@@ -58,6 +58,17 @@ func runWorker(cfg *config.Config) error {
 	bundle := queue.NewRedisBundle(rdb, jobStore, "triage")
 
 	agentRunner := bot.NewAgentRunnerFromConfig(cfg)
+
+	var secretKey []byte
+	if cfg.SecretKey != "" {
+		var err error
+		secretKey, err = config.DecodeSecretKey(cfg.SecretKey)
+		if err != nil {
+			return fmt.Errorf("invalid secret_key: %w", err)
+		}
+		appLogger.Info("Secret key 已載入", "phase", "完成")
+	}
+
 	githubLogger := logging.ComponentLogger(slog.Default(), logging.CompGitHub)
 	repoCache := ghclient.NewRepoCache(cfg.RepoCache.Dir, cfg.RepoCache.MaxAge, cfg.GitHub.Token, githubLogger)
 
@@ -97,6 +108,8 @@ func runWorker(cfg *config.Config) error {
 		Status:         bundle.Status,
 		StatusInterval: cfg.Queue.StatusInterval,
 		Logger:         workerLogger,
+		SecretKey:      secretKey,
+		WorkerSecrets:  cfg.Secrets,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/agentdock/worker.go
+++ b/cmd/agentdock/worker.go
@@ -10,7 +10,6 @@ import (
 
 	"agentdock/internal/bot"
 	"agentdock/internal/config"
-	"agentdock/internal/crypto"
 	ghclient "agentdock/internal/github"
 	"agentdock/internal/logging"
 	"agentdock/internal/queue"
@@ -60,17 +59,11 @@ func runWorker(cfg *config.Config) error {
 
 	agentRunner := bot.NewAgentRunnerFromConfig(cfg)
 
-	if cfg.SecretKey == "" {
-		return fmt.Errorf("secret_key is required for Redis worker — set it in config or via SECRET_KEY env var")
-	}
+	// secret_key is validated and beacon-verified during preflight.
 	secretKey, err := config.DecodeSecretKey(cfg.SecretKey)
 	if err != nil {
 		return fmt.Errorf("invalid secret_key: %w", err)
 	}
-	if err := crypto.VerifyBeacon(context.Background(), rdb, secretKey); err != nil {
-		return fmt.Errorf("secret key 驗證失敗: %w", err)
-	}
-	appLogger.Info("Secret key 已驗證", "phase", "完成")
 
 	githubLogger := logging.ComponentLogger(slog.Default(), logging.CompGitHub)
 	repoCache := ghclient.NewRepoCache(cfg.RepoCache.Dir, cfg.RepoCache.MaxAge, cfg.GitHub.Token, githubLogger)

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -46,6 +46,13 @@ workers:
 #   password: ""
 #   db: 0
 
+# Secret encryption (required for Redis mode)
+secret_key: "64-char-hex-encoded-32-byte-AES-key"
+secrets:
+  GH_TOKEN: "ghp_xxx"
+  K8S_TOKEN: "your-k8s-token"
+  # key = env var name, value = plaintext
+
 channel_priority:
   # C_INCIDENTS: 100                  # production incidents get priority
   default: 50
@@ -55,6 +62,53 @@ prompt:
   extra_rules:
     - "List all related file names with full paths"
 ```
+
+## Secret Management
+
+In Redis mode, the app centrally manages secrets and sends them encrypted to workers.
+
+### How It Works
+
+1. App config defines `secret_key` (AES-256 encryption key) and `secrets` (key-value pairs)
+2. On startup, the app writes a beacon to Redis so workers can verify key consistency
+3. When submitting a job, `secrets` are AES-256-GCM encrypted into `Job.EncryptedSecrets`
+4. Workers decrypt and inject as environment variables for CLI agent processes (e.g., `GH_TOKEN`, `K8S_TOKEN`)
+
+### Configuration
+
+**App config (required):**
+```yaml
+secret_key: "0123456789abcdef..."   # 64 hex chars (32 bytes)
+secrets:
+  GH_TOKEN: "ghp_xxx"
+  K8S_TOKEN: "eyJhb..."
+```
+
+**Worker config (`secret_key` required, `secrets` optional override):**
+```yaml
+secret_key: "same-key-as-app"
+secrets:
+  GH_TOKEN: "ghp_worker_override"   # optional, overrides app-provided value
+```
+
+**Environment variable injection:**
+- `SECRET_KEY` → overrides `secret_key`
+- `AGENTDOCK_SECRET_<NAME>` → injects into `secrets["<NAME>"]` (e.g., `AGENTDOCK_SECRET_K8S_TOKEN=xxx`)
+
+### Interactive Startup
+
+When running `agentdock app` or `agentdock worker` for the first time without `secret_key`:
+- **App**: option to auto-generate a key (printed and saved to config)
+- **Worker**: prompted to paste the app's key, with immediate beacon verification
+
+### Priority Order
+
+Secrets are applied in this order (later overrides earlier):
+
+1. `github.token` (auto-merged as `secrets["GH_TOKEN"]`)
+2. App config `secrets`
+3. `AGENTDOCK_SECRET_*` environment variables
+4. Worker config `secrets` (overrides app-provided values)
 
 ## Agent Stream Mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,13 @@ workers:
 #   password: ""
 #   db: 0
 
+# Secret 加密（Redis 模式必填）
+secret_key: "64字元hex編碼的32-byte AES key"
+secrets:
+  GH_TOKEN: "ghp_xxx"
+  K8S_TOKEN: "your-k8s-token"
+  # key = 環境變數名稱，value = 明文值
+
 channel_priority:
   # C_INCIDENTS: 100                  # production incidents 優先
   default: 50
@@ -55,6 +62,53 @@ prompt:
   extra_rules:
     - "列出所有相關的檔案名稱與完整路徑"
 ```
+
+## Secret 管理
+
+Redis 模式下，app 集中管理 secrets 並加密傳給 worker。
+
+### 運作方式
+
+1. App config 設定 `secret_key`（AES-256 加密金鑰）和 `secrets`（key-value pairs）
+2. App 啟動時將 beacon 寫入 Redis，用於 worker 驗證金鑰一致性
+3. 每個 job 提交時，`secrets` 用 AES-256-GCM 加密後放入 `Job.EncryptedSecrets`
+4. Worker 解密後注入為子進程的環境變數（如 `GH_TOKEN`、`K8S_TOKEN`）
+
+### 設定
+
+**App config（必填）：**
+```yaml
+secret_key: "0123456789abcdef..."   # 64 字元 hex（32 bytes）
+secrets:
+  GH_TOKEN: "ghp_xxx"
+  K8S_TOKEN: "eyJhb..."
+```
+
+**Worker config（必填 `secret_key`，`secrets` 可選覆蓋）：**
+```yaml
+secret_key: "跟 app 同一把"
+secrets:
+  GH_TOKEN: "ghp_worker_override"   # 選填，會覆蓋 app 給的值
+```
+
+**環境變數注入：**
+- `SECRET_KEY` → 覆蓋 `secret_key`
+- `AGENTDOCK_SECRET_<NAME>` → 注入 `secrets["<NAME>"]`（例如 `AGENTDOCK_SECRET_K8S_TOKEN=xxx`）
+
+### 互動式啟動
+
+首次執行 `agentdock app` 或 `agentdock worker` 時，如果 `secret_key` 未設定：
+- **App**：可選擇自動產生金鑰，產生後會印出並寫入 config
+- **Worker**：提示貼入 app 的金鑰，並立即驗證與 app 的 beacon 是否匹配
+
+### 優先級
+
+Secret 的套用順序（後者覆蓋前者）：
+
+1. `github.token`（自動合併為 `secrets["GH_TOKEN"]`）
+2. App config 的 `secrets`
+3. `AGENTDOCK_SECRET_*` 環境變數
+4. Worker config 的 `secrets`（覆蓋 app 給的值）
 
 ## Agent Stream 模式
 

--- a/docs/superpowers/plans/2026-04-17-app-worker-secrets.md
+++ b/docs/superpowers/plans/2026-04-17-app-worker-secrets.md
@@ -1,0 +1,1082 @@
+# App-to-Worker Secret Passing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the app to send encrypted secrets to workers through Redis, so workers can use centrally-managed tokens for CLI agent execution and repo cloning.
+
+**Architecture:** App encrypts a `map[string]string` of secrets with AES-256-GCM and embeds the ciphertext in the Job struct. Workers decrypt, merge with local overrides, and inject into `cmd.Env` for CLI agents and into `RepoCache` for git operations. Redis-only; inmem mode unchanged.
+
+**Tech Stack:** Go stdlib `crypto/aes`, `crypto/cipher`, `crypto/rand`, `encoding/hex`, `encoding/json`
+
+**Spec:** `docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md`
+
+---
+
+### Task 1: Encryption Module
+
+**Files:**
+- Create: `internal/crypto/aes.go`
+- Create: `internal/crypto/aes_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/crypto/aes_test.go
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte(`{"GH_TOKEN":"ghp_xxx","K8S_TOKEN":"eyJhb"}`)
+
+	ciphertext, err := Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if bytes.Equal(ciphertext, plaintext) {
+		t.Fatal("ciphertext should differ from plaintext")
+	}
+
+	decrypted, err := Decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestDecrypt_WrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	rand.Read(key1)
+	rand.Read(key2)
+
+	ciphertext, _ := Encrypt(key1, []byte("secret"))
+	_, err := Decrypt(key2, ciphertext)
+	if err == nil {
+		t.Fatal("expected error decrypting with wrong key")
+	}
+}
+
+func TestDecrypt_CorruptData(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	_, err := Decrypt(key, []byte("not-valid-ciphertext"))
+	if err == nil {
+		t.Fatal("expected error decrypting corrupt data")
+	}
+}
+
+func TestEncrypt_InvalidKeyLength(t *testing.T) {
+	_, err := Encrypt([]byte("short"), []byte("data"))
+	if err == nil {
+		t.Fatal("expected error with invalid key length")
+	}
+}
+
+func TestEncrypt_EmptyPlaintext(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	ciphertext, err := Encrypt(key, []byte{})
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+	decrypted, err := Decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt empty: %v", err)
+	}
+	if len(decrypted) != 0 {
+		t.Errorf("expected empty, got %q", decrypted)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/crypto/ -v`
+Expected: compilation error — package does not exist
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// internal/crypto/aes.go
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// Encrypt encrypts plaintext using AES-256-GCM.
+// Returns nonce (12 bytes) prepended to ciphertext.
+func Encrypt(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt decrypts ciphertext produced by Encrypt.
+func Decrypt(key, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/crypto/ -v`
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/crypto/
+git commit -m "feat(crypto): add AES-256-GCM encrypt/decrypt module (#56)"
+```
+
+---
+
+### Task 2: Config — Add SecretKey, Secrets, and Env Var Scan
+
+**Files:**
+- Modify: `internal/config/config.go:13-38` (Config struct) + `EnvOverrideMap` + new `resolveSecrets`
+- Modify: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// Add to internal/config/config_test.go
+
+func TestResolveSecrets_GitHubTokenAutoMerge(t *testing.T) {
+	cfg := &Config{
+		GitHub: GitHubConfig{Token: "ghp_from_github"},
+	}
+	resolveSecrets(cfg)
+	if cfg.Secrets["GH_TOKEN"] != "ghp_from_github" {
+		t.Errorf("got %q, want ghp_from_github", cfg.Secrets["GH_TOKEN"])
+	}
+}
+
+func TestResolveSecrets_ExplicitSecretsWin(t *testing.T) {
+	cfg := &Config{
+		GitHub:  GitHubConfig{Token: "ghp_from_github"},
+		Secrets: map[string]string{"GH_TOKEN": "ghp_explicit"},
+	}
+	resolveSecrets(cfg)
+	if cfg.Secrets["GH_TOKEN"] != "ghp_explicit" {
+		t.Errorf("got %q, want ghp_explicit", cfg.Secrets["GH_TOKEN"])
+	}
+}
+
+func TestResolveSecrets_InitializesNilMap(t *testing.T) {
+	cfg := &Config{}
+	resolveSecrets(cfg)
+	if cfg.Secrets == nil {
+		t.Error("Secrets should be initialized to non-nil map")
+	}
+}
+
+func TestEnvOverrideMap_SecretKey(t *testing.T) {
+	t.Setenv("SECRET_KEY", "abc123")
+	m := EnvOverrideMap()
+	if m["secret_key"] != "abc123" {
+		t.Errorf("got %q, want abc123", m["secret_key"])
+	}
+}
+
+func TestScanSecretEnvVars(t *testing.T) {
+	t.Setenv("AGENTDOCK_SECRET_K8S_TOKEN", "k8s-val")
+	t.Setenv("AGENTDOCK_SECRET_NPM_TOKEN", "npm-val")
+	t.Setenv("UNRELATED_VAR", "ignore")
+
+	got := ScanSecretEnvVars()
+	if got["K8S_TOKEN"] != "k8s-val" {
+		t.Errorf("K8S_TOKEN = %q, want k8s-val", got["K8S_TOKEN"])
+	}
+	if got["NPM_TOKEN"] != "npm-val" {
+		t.Errorf("NPM_TOKEN = %q, want npm-val", got["NPM_TOKEN"])
+	}
+	if _, exists := got["UNRELATED_VAR"]; exists {
+		t.Error("should not include UNRELATED_VAR")
+	}
+}
+
+func TestValidateSecretKey_Valid(t *testing.T) {
+	// 64 hex chars = 32 bytes
+	key := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	_, err := DecodeSecretKey(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSecretKey_Invalid(t *testing.T) {
+	cases := []string{
+		"tooshort",
+		"not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hex",
+		"",
+	}
+	for _, c := range cases {
+		if _, err := DecodeSecretKey(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run "TestResolveSecrets|TestEnvOverrideMap_SecretKey|TestScanSecret|TestValidateSecretKey|TestDecodeSecretKey" -v`
+Expected: compilation error — `resolveSecrets`, `ScanSecretEnvVars`, `DecodeSecretKey` not defined
+
+- [ ] **Step 3: Write the implementation**
+
+Add fields to `Config` struct (`config.go:13-38`):
+
+```go
+// Add after SkillsConfig field (line 37):
+SecretKey string            `yaml:"secret_key"`
+Secrets   map[string]string `yaml:"secrets"`
+```
+
+Add `SECRET_KEY` to `EnvOverrideMap()` (after the `ACTIVE_AGENT` block, around line 265):
+
+```go
+if v := os.Getenv("SECRET_KEY"); v != "" {
+    out["secret_key"] = v
+}
+```
+
+Add new functions at the end of `config.go`:
+
+```go
+// ScanSecretEnvVars scans environment for AGENTDOCK_SECRET_* variables
+// and returns them as a map with the prefix stripped.
+// E.g., AGENTDOCK_SECRET_K8S_TOKEN=xxx → {"K8S_TOKEN": "xxx"}
+func ScanSecretEnvVars() map[string]string {
+	const prefix = "AGENTDOCK_SECRET_"
+	out := make(map[string]string)
+	for _, env := range os.Environ() {
+		if idx := strings.Index(env, "="); idx > 0 {
+			key := env[:idx]
+			if strings.HasPrefix(key, prefix) {
+				name := key[len(prefix):]
+				if name != "" {
+					out[name] = env[idx+1:]
+				}
+			}
+		}
+	}
+	return out
+}
+
+// resolveSecrets merges github.token into secrets and applies env var overrides.
+func resolveSecrets(cfg *Config) {
+	if cfg.Secrets == nil {
+		cfg.Secrets = make(map[string]string)
+	}
+	// Auto-merge github.token → secrets["GH_TOKEN"] if not explicitly set
+	if cfg.GitHub.Token != "" {
+		if _, exists := cfg.Secrets["GH_TOKEN"]; !exists {
+			cfg.Secrets["GH_TOKEN"] = cfg.GitHub.Token
+		}
+	}
+	// Overlay env vars (env wins over config file)
+	for k, v := range ScanSecretEnvVars() {
+		cfg.Secrets[k] = v
+	}
+}
+
+// DecodeSecretKey validates and decodes a hex-encoded 32-byte AES key.
+func DecodeSecretKey(hexKey string) ([]byte, error) {
+	decoded, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("secret_key: invalid hex: %w", err)
+	}
+	if len(decoded) != 32 {
+		return nil, fmt.Errorf("secret_key: must be 32 bytes (64 hex chars), got %d bytes", len(decoded))
+	}
+	return decoded, nil
+}
+```
+
+Add `"encoding/hex"` to the imports.
+
+Call `resolveSecrets` from `applyDefaults` — add at the end of `applyDefaults` (after line 219):
+
+```go
+resolveSecrets(cfg)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run "TestResolveSecrets|TestEnvOverrideMap_SecretKey|TestScanSecret|TestValidateSecretKey|TestDecodeSecretKey" -v`
+Expected: all tests PASS
+
+- [ ] **Step 5: Run all config tests to check for regressions**
+
+Run: `go test ./internal/config/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add SecretKey, Secrets fields with env var scan (#56)"
+```
+
+---
+
+### Task 3: Job Struct — Add EncryptedSecrets
+
+**Files:**
+- Modify: `internal/queue/job.go:22-41` (Job struct)
+- Modify: `internal/bot/retry_handler.go:48-64` (propagate field)
+
+- [ ] **Step 1: Add EncryptedSecrets to Job**
+
+In `internal/queue/job.go`, add after `SubmittedAt` field (line 40):
+
+```go
+EncryptedSecrets []byte `json:"encrypted_secrets,omitempty"`
+```
+
+- [ ] **Step 2: Propagate EncryptedSecrets in retry handler**
+
+In `internal/bot/retry_handler.go`, add to the `newJob` construction (after `SubmittedAt` line):
+
+```go
+EncryptedSecrets: original.EncryptedSecrets,
+```
+
+- [ ] **Step 3: Run existing tests to check nothing breaks**
+
+Run: `go test ./internal/queue/ ./internal/bot/ -v`
+Expected: all tests PASS (new field has `omitempty`, zero value is nil)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/queue/job.go internal/bot/retry_handler.go
+git commit -m "feat(queue): add EncryptedSecrets field to Job struct (#56)"
+```
+
+---
+
+### Task 4: AgentRunner — Generic Secret Injection
+
+**Files:**
+- Modify: `internal/bot/agent.go:20-23` (RunOptions) + `agent.go:111-112` (env injection)
+- Modify: `internal/bot/agent_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Add to internal/bot/agent_test.go
+
+func TestAgentRunner_SecretsInjected(t *testing.T) {
+	dir := t.TempDir()
+	// Script prints all env vars containing "TOKEN"
+	script := filepath.Join(dir, "env-agent")
+	os.WriteFile(script, []byte(`#!/bin/sh
+env | grep TOKEN | sort
+echo "padding padding padding padding padding padding padding"
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second},
+	})
+
+	secrets := map[string]string{
+		"GH_TOKEN":  "ghp_from_secrets",
+		"K8S_TOKEN": "k8s_val",
+	}
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{Secrets: secrets})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !strings.Contains(output, "GH_TOKEN=ghp_from_secrets") {
+		t.Errorf("GH_TOKEN not injected: %q", output)
+	}
+	if !strings.Contains(output, "K8S_TOKEN=k8s_val") {
+		t.Errorf("K8S_TOKEN not injected: %q", output)
+	}
+}
+
+func TestAgentRunner_GithubTokenFallback(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "env-agent")
+	os.WriteFile(script, []byte(`#!/bin/sh
+env | grep GH_TOKEN
+echo "padding padding padding padding padding padding padding"
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second},
+	})
+	runner.githubToken = "ghp_fallback"
+
+	// No secrets in RunOptions → fallback to githubToken
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !strings.Contains(output, "GH_TOKEN=ghp_fallback") {
+		t.Errorf("githubToken fallback not working: %q", output)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/bot/ -run "TestAgentRunner_Secrets|TestAgentRunner_GithubTokenFallback" -v`
+Expected: FAIL — `RunOptions` has no `Secrets` field
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/bot/agent.go`, add `Secrets` field to `RunOptions` (line 20-23):
+
+```go
+type RunOptions struct {
+	OnStarted func(pid int, command string)
+	OnEvent   func(event queue.StreamEvent)
+	Secrets   map[string]string
+}
+```
+
+Replace the env injection block at line 111-112:
+
+```go
+	// Inject secrets as environment variables.
+	env := os.Environ()
+	if len(opts.Secrets) > 0 {
+		for k, v := range opts.Secrets {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	} else if r.githubToken != "" {
+		env = append(env, fmt.Sprintf("GH_TOKEN=%s", r.githubToken))
+	}
+	cmd.Env = env
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/bot/ -run "TestAgentRunner_Secrets|TestAgentRunner_GithubTokenFallback" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run all bot tests for regressions**
+
+Run: `go test ./internal/bot/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bot/agent.go internal/bot/agent_test.go
+git commit -m "feat(agent): generic secret injection via RunOptions.Secrets (#56)"
+```
+
+---
+
+### Task 5: RepoCache — Per-Call Token
+
+**Files:**
+- Modify: `internal/github/repo.go:34` (`EnsureRepo` signature) + `ResolveURL`
+- Modify: `internal/github/repo_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// Add to internal/github/repo_test.go
+
+func TestRepoCache_EnsureRepo_PerCallToken(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+	// Create with empty githubPAT (Redis mode)
+	rc := NewRepoCache(dir, 0, "", logger)
+
+	// ResolveURL with per-call token
+	url := rc.resolveURLWithToken("owner/repo", "ghp_percall")
+	if url != "https://ghp_percall@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_Fallback(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+	rc := NewRepoCache(dir, 0, "ghp_default", logger)
+
+	// Empty per-call token → fallback to rc.githubPAT
+	url := rc.resolveURLWithToken("owner/repo", "")
+	if url != "https://ghp_default@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_NoToken(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+	rc := NewRepoCache(dir, 0, "", logger)
+
+	url := rc.resolveURLWithToken("owner/repo", "")
+	if url != "https://github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/github/ -run "TestRepoCache_EnsureRepo_PerCall|TestRepoCache_ResolveURLWithToken" -v`
+Expected: FAIL — `resolveURLWithToken` not defined
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/github/repo.go`, add `resolveURLWithToken` method:
+
+```go
+// resolveURLWithToken builds a clone URL. Uses perCallToken if non-empty,
+// otherwise falls back to rc.githubPAT.
+func (rc *RepoCache) resolveURLWithToken(repoRef, perCallToken string) string {
+	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
+		return repoRef
+	}
+	token := perCallToken
+	if token == "" {
+		token = rc.githubPAT
+	}
+	if token != "" {
+		return fmt.Sprintf("https://%s@github.com/%s.git", token, repoRef)
+	}
+	return fmt.Sprintf("https://github.com/%s.git", repoRef)
+}
+```
+
+Change `EnsureRepo` signature to accept a token parameter:
+
+```go
+func (rc *RepoCache) EnsureRepo(repoRef string, token string) (string, error) {
+```
+
+Inside `EnsureRepo`, replace `cloneURL := rc.ResolveURL(repoRef)` with:
+
+```go
+cloneURL := rc.resolveURLWithToken(repoRef, token)
+```
+
+On cache hit (line 57-59), before `git fetch`, add conditional `set-url`:
+
+```go
+if last, ok := rc.lastPull[repoRef]; ok && rc.maxAge > 0 && time.Since(last) < rc.maxAge {
+    return localPath, nil
+}
+
+// Update remote URL if token changed
+currentURL := rc.getRemoteURL(localPath)
+if cloneURL != currentURL && cloneURL != "" {
+    setCmd := exec.Command("git", "-C", localPath, "remote", "set-url", "origin", cloneURL)
+    setCmd.Run() // best-effort
+}
+```
+
+Add helper:
+
+```go
+func (rc *RepoCache) getRemoteURL(repoPath string) string {
+	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+```
+
+Also update the re-clone path (around line 72) to use `cloneURL` (it already does via the local variable — just make sure the new `cloneURL` from `resolveURLWithToken` is used consistently).
+
+Update existing callers that call `EnsureRepo` without the token parameter. There is one in `repoCacheAdapter.Prepare()` — that will be updated in Task 7.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/github/ -run "TestRepoCache_EnsureRepo_PerCall|TestRepoCache_ResolveURLWithToken" -v`
+Expected: PASS
+
+- [ ] **Step 5: Fix existing EnsureRepo callers**
+
+The existing tests in `repo_test.go` call `EnsureRepo` with one arg. Add `""` as the second arg to `TestRepoCache_EnsureRepo_ClonesNewRepo` and `TestRepoCache_EnsureRepo_PullsExistingRepo`:
+
+```go
+// Change: rc.EnsureRepo("owner/repo")
+// To:     rc.EnsureRepo("owner/repo", "")
+```
+
+- [ ] **Step 6: Run all github tests for regressions**
+
+Run: `go test ./internal/github/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/github/repo.go internal/github/repo_test.go
+git commit -m "feat(repo): add per-call token to EnsureRepo (#56)"
+```
+
+---
+
+### Task 6: RepoProvider Interface + Adapter — Add Token Param
+
+**Files:**
+- Modify: `internal/worker/executor.go:22-27` (RepoProvider interface)
+- Modify: `internal/worker/executor.go:55` (Prepare call)
+- Modify: `cmd/agentdock/adapters.go:29-48` (repoCacheAdapter)
+- Modify: `internal/worker/pool_test.go:31` (mockRepo.Prepare)
+
+- [ ] **Step 1: Update RepoProvider interface**
+
+In `internal/worker/executor.go`, change line 23:
+
+```go
+Prepare(cloneURL, branch, token string) (string, error)
+```
+
+- [ ] **Step 2: Update repoCacheAdapter**
+
+In `cmd/agentdock/adapters.go`, change `Prepare` method (line 29):
+
+```go
+func (a *repoCacheAdapter) Prepare(cloneURL, branch, token string) (string, error) {
+```
+
+Inside, change `EnsureRepo` call to pass token:
+
+```go
+barePath, err := a.cache.EnsureRepo(cloneURL, token)
+```
+
+- [ ] **Step 3: Update mockRepo in tests**
+
+In `internal/worker/pool_test.go`, change mock (line 31):
+
+```go
+func (m *mockRepo) Prepare(cloneURL, branch, token string) (string, error) {
+```
+
+- [ ] **Step 4: Update executeJob call site**
+
+In `internal/worker/executor.go`, line 55 — this will be updated in Task 8 when we add secret handling. For now, pass empty string:
+
+```go
+repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, "")
+```
+
+- [ ] **Step 5: Compile check**
+
+Run: `go build ./...`
+Expected: builds successfully
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test ./internal/worker/ ./cmd/agentdock/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/worker/executor.go cmd/agentdock/adapters.go internal/worker/pool_test.go
+git commit -m "feat(worker): add token param to RepoProvider.Prepare (#56)"
+```
+
+---
+
+### Task 7: Workflow — Encrypt Secrets + Clean CloneURL
+
+**Files:**
+- Modify: `internal/bot/workflow.go:431` (CloneURL)
+- Modify: `internal/bot/workflow.go` (encrypt secrets into Job)
+
+- [ ] **Step 1: Understand the Workflow struct**
+
+Read `internal/bot/workflow.go` to find where the `Workflow` struct stores config and secrets. The Workflow needs access to `cfg.Secrets` and `cfg.SecretKey` to encrypt.
+
+- [ ] **Step 2: Add secrets fields to Workflow**
+
+The Workflow struct needs `secretKey []byte` and `secrets map[string]string`. Add these fields and set them during construction (wherever `NewWorkflow` or equivalent is called).
+
+- [ ] **Step 3: Change CloneURL to not include token**
+
+In `workflow.go:431`, replace:
+
+```go
+CloneURL: w.repoCache.ResolveURL(pt.SelectedRepo),
+```
+
+With:
+
+```go
+CloneURL: fmt.Sprintf("https://github.com/%s.git", pt.SelectedRepo),
+```
+
+If `pt.SelectedRepo` is already a full URL (starts with `http` or `git@`), preserve it as-is. Add a helper if needed:
+
+```go
+func cleanCloneURL(repoRef string) string {
+	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
+		return repoRef
+	}
+	return fmt.Sprintf("https://github.com/%s.git", repoRef)
+}
+```
+
+- [ ] **Step 4: Encrypt secrets into Job**
+
+After Job construction (around line 437), add encryption:
+
+```go
+if len(w.secretKey) > 0 && len(w.secrets) > 0 {
+    secretsJSON, err := json.Marshal(w.secrets)
+    if err != nil {
+        return fmt.Errorf("marshal secrets: %w", err)
+    }
+    encrypted, err := crypto.Encrypt(w.secretKey, secretsJSON)
+    if err != nil {
+        return fmt.Errorf("encrypt secrets: %w", err)
+    }
+    job.EncryptedSecrets = encrypted
+}
+```
+
+Add imports: `"encoding/json"` and `"agentdock/internal/crypto"`.
+
+- [ ] **Step 5: Compile check**
+
+Run: `go build ./...`
+Expected: builds successfully
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bot/workflow.go
+git commit -m "feat(workflow): encrypt secrets into Job, clean CloneURL (#56)"
+```
+
+---
+
+### Task 8: Worker Executor — Decrypt, Merge, Inject
+
+**Files:**
+- Modify: `internal/worker/executor.go:29-35` (executionDeps)
+- Modify: `internal/worker/executor.go:37-91` (executeJob — decrypt + merge + pass to Prepare and RunOptions)
+- Modify: `internal/worker/pool.go:13-27` (Pool Config)
+- Modify: `internal/worker/pool.go:163-169` (executionDeps construction)
+- Modify: `cmd/agentdock/worker.go:86-100` (pass secrets to Pool)
+- Modify: `internal/worker/pool_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Add to internal/worker/pool_test.go
+
+func TestExecuteJob_DecryptsAndMergesSecrets(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a secret key and encrypt some secrets
+	secretKey := make([]byte, 32)
+	rand.Read(secretKey)
+
+	appSecrets := map[string]string{
+		"GH_TOKEN":  "ghp_from_app",
+		"K8S_TOKEN": "k8s_from_app",
+	}
+	secretsJSON, _ := json.Marshal(appSecrets)
+	encrypted, _ := crypto.Encrypt(secretKey, secretsJSON)
+
+	workerSecrets := map[string]string{
+		"GH_TOKEN": "ghp_worker_override",
+	}
+
+	// Track what secrets the runner receives
+	var capturedSecrets map[string]string
+	runner := &secretCapturingRunner{
+		onRun: func(opts bot.RunOptions) {
+			capturedSecrets = opts.Secrets
+		},
+	}
+
+	job := &queue.Job{
+		ID:               "test-job",
+		CloneURL:         "https://github.com/owner/repo.git",
+		EncryptedSecrets: encrypted,
+	}
+
+	deps := executionDeps{
+		attachments:   queue.NewInMemAttachmentStore(),
+		repoCache:     &mockRepo{path: dir},
+		runner:        runner,
+		store:         queue.NewMemJobStore(),
+		skillDirs:     nil,
+		secretKey:     secretKey,
+		workerSecrets: workerSecrets,
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+	if result.Status == "failed" {
+		t.Fatalf("job failed: %s", result.Error)
+	}
+
+	// Worker override wins
+	if capturedSecrets["GH_TOKEN"] != "ghp_worker_override" {
+		t.Errorf("GH_TOKEN = %q, want ghp_worker_override", capturedSecrets["GH_TOKEN"])
+	}
+	// App secret passes through
+	if capturedSecrets["K8S_TOKEN"] != "k8s_from_app" {
+		t.Errorf("K8S_TOKEN = %q, want k8s_from_app", capturedSecrets["K8S_TOKEN"])
+	}
+}
+
+func TestExecuteJob_NoSecretKey_EncryptedSecrets_Fails(t *testing.T) {
+	dir := t.TempDir()
+
+	job := &queue.Job{
+		ID:               "test-job",
+		CloneURL:         "https://github.com/owner/repo.git",
+		EncryptedSecrets: []byte("some-encrypted-data"),
+	}
+
+	deps := executionDeps{
+		attachments: queue.NewInMemAttachmentStore(),
+		repoCache:   &mockRepo{path: dir},
+		runner:      &mockRunner{output: "ok"},
+		store:       queue.NewMemJobStore(),
+		secretKey:   nil, // no key!
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+	if result.Status != "failed" {
+		t.Error("expected job to fail when EncryptedSecrets present but no secretKey")
+	}
+}
+
+// Helper: runner that captures RunOptions
+type secretCapturingRunner struct {
+	onRun func(opts bot.RunOptions)
+}
+
+func (r *secretCapturingRunner) Run(ctx context.Context, workDir, prompt string, opts bot.RunOptions) (string, error) {
+	if r.onRun != nil {
+		r.onRun(opts)
+	}
+	return `## Summary
+
+Test
+
+===TRIAGE_METADATA===
+{"issue_type":"bug","confidence":"high","files":[],"open_questions":[],"suggested_title":"test"}`, nil
+}
+```
+
+Add imports to the test file: `"crypto/rand"`, `"encoding/json"`, `"agentdock/internal/crypto"`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/worker/ -run "TestExecuteJob_Decrypts|TestExecuteJob_NoSecretKey" -v`
+Expected: FAIL — `executionDeps` has no `secretKey`/`workerSecrets` fields
+
+- [ ] **Step 3: Add fields to executionDeps**
+
+In `internal/worker/executor.go`, update `executionDeps` (line 29-35):
+
+```go
+type executionDeps struct {
+	attachments   queue.AttachmentStore
+	repoCache     RepoProvider
+	runner        Runner
+	store         queue.JobStore
+	skillDirs     []string
+	secretKey     []byte
+	workerSecrets map[string]string
+}
+```
+
+- [ ] **Step 4: Add decrypt + merge logic to executeJob**
+
+In `internal/worker/executor.go`, add secret handling after attachment resolution and before repo clone (after line 50, before line 52):
+
+```go
+	// Decrypt and merge secrets.
+	var mergedSecrets map[string]string
+	if len(job.EncryptedSecrets) > 0 {
+		if len(deps.secretKey) == 0 {
+			return failedResult(job, startedAt, fmt.Errorf("job has encrypted secrets but worker has no secret_key configured"), "")
+		}
+		decrypted, err := crypto.Decrypt(deps.secretKey, job.EncryptedSecrets)
+		if err != nil {
+			return failedResult(job, startedAt, fmt.Errorf("decrypt secrets: %w", err), "")
+		}
+		var appSecrets map[string]string
+		if err := json.Unmarshal(decrypted, &appSecrets); err != nil {
+			return failedResult(job, startedAt, fmt.Errorf("unmarshal secrets: %w", err), "")
+		}
+		mergedSecrets = appSecrets
+	}
+	// Overlay worker secrets (worker wins)
+	if len(deps.workerSecrets) > 0 {
+		if mergedSecrets == nil {
+			mergedSecrets = make(map[string]string)
+		}
+		for k, v := range deps.workerSecrets {
+			mergedSecrets[k] = v
+		}
+	}
+```
+
+Add imports: `"encoding/json"` and `"agentdock/internal/crypto"`.
+
+- [ ] **Step 5: Pass GH_TOKEN to RepoCache.Prepare**
+
+Update the `Prepare` call (line 55) to pass the resolved GH_TOKEN:
+
+```go
+	ghToken := ""
+	if mergedSecrets != nil {
+		ghToken = mergedSecrets["GH_TOKEN"]
+	}
+	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, ghToken)
+```
+
+- [ ] **Step 6: Pass secrets to RunOptions**
+
+Before `deps.runner.Run` call (line 91), set secrets on opts:
+
+```go
+	opts.Secrets = mergedSecrets
+	output, err := deps.runner.Run(ctx, repoPath, prompt, opts)
+```
+
+- [ ] **Step 7: Add SecretKey/WorkerSecrets to Pool Config**
+
+In `internal/worker/pool.go`, add to `Config` struct (after `Logger` field):
+
+```go
+	SecretKey     []byte
+	WorkerSecrets map[string]string
+```
+
+In `executeWithTracking` (line 163-169), add to `executionDeps` construction:
+
+```go
+deps := executionDeps{
+	attachments:   p.cfg.Attachments,
+	repoCache:     p.cfg.RepoCache,
+	runner:        p.cfg.Runner,
+	store:         p.cfg.Store,
+	skillDirs:     p.cfg.SkillDirs,
+	secretKey:     p.cfg.SecretKey,
+	workerSecrets: p.cfg.WorkerSecrets,
+}
+```
+
+- [ ] **Step 8: Pass secrets from worker.go to Pool**
+
+In `cmd/agentdock/worker.go`, after `agentRunner` construction (line 60), decode the secret key and pass to Pool:
+
+```go
+	var secretKey []byte
+	if cfg.SecretKey != "" {
+		var err error
+		secretKey, err = config.DecodeSecretKey(cfg.SecretKey)
+		if err != nil {
+			return fmt.Errorf("invalid secret_key: %w", err)
+		}
+		appLogger.Info("Secret key 已載入", "phase", "完成")
+	}
+```
+
+Then in Pool config construction (line 86-100), add:
+
+```go
+	SecretKey:      secretKey,
+	WorkerSecrets:  cfg.Secrets,
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `go test ./internal/worker/ -run "TestExecuteJob_Decrypts|TestExecuteJob_NoSecretKey" -v`
+Expected: PASS
+
+- [ ] **Step 10: Run all tests**
+
+Run: `go test ./... 2>&1 | tail -30`
+Expected: all tests PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/worker/executor.go internal/worker/pool.go internal/worker/pool_test.go cmd/agentdock/worker.go
+git commit -m "feat(worker): decrypt, merge, and inject secrets per-job (#56)"
+```
+
+---
+
+### Task 9: Full Integration Smoke Test
+
+**Files:**
+- All modified files (no new files)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `go test ./... -count=1 2>&1 | tail -40`
+Expected: all packages PASS
+
+- [ ] **Step 2: Build check**
+
+Run: `go build ./cmd/agentdock/`
+Expected: builds successfully
+
+- [ ] **Step 3: Verify no secrets in git diff**
+
+Run: `git diff HEAD~8 --stat`
+Expected: see all expected files changed, no unexpected files
+
+- [ ] **Step 4: Final commit (if any fixups needed)**
+
+```bash
+git add -A
+git commit -m "fix: integration fixups for secret passing (#56)"
+```

--- a/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
+++ b/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
@@ -2,21 +2,24 @@
 
 **Issue**: [#56](https://github.com/Ivantseng123/agentdock/issues/56)
 **Date**: 2026-04-16
+**Updated**: 2026-04-17 (post-grill review)
 
 ## Problem
 
-Secrets (GitHub token, K8s token, NPM token, etc.) are currently hardcoded as a single `GH_TOKEN` environment variable in the worker. There is no mechanism for the app to centrally manage and distribute multiple secrets to workers. Workers cannot be guaranteed to have the correct or up-to-date tokens.
+Secrets (GitHub token, K8s token, NPM token, etc.) are currently hardcoded as a single `GH_TOKEN` environment variable in the worker. There is no mechanism for the app to centrally manage and distribute multiple secrets to workers. Workers cannot be guaranteed to have the correct or up-to-date tokens. Additionally, `Job.CloneURL` embeds the GitHub token in plaintext through Redis.
 
 ## Decision Summary
 
 | Item | Decision |
 |------|----------|
-| Secret source | App centralized (config plaintext + env var via `EnvOverrideMap` pattern) |
+| Secret source | App centralized (config plaintext + env var via dynamic scan) |
 | Transport | Job struct → Redis (AES-256-GCM encrypted) |
 | Worker injection | Decrypted → `cmd.Env` (never in prompt) |
 | Worker override | Worker config `secrets` map overrides app-provided values |
 | Encryption key | Symmetric AES-256, shared `secret_key` in config |
-| Backward compat | No `secret_key` → no encryption; `github.token` auto-merges into `secrets["GH_TOKEN"]` |
+| Scope | **Redis transport only**; inmem mode unchanged |
+| Backward compat | No `secret_key` → no encryption; `github.token` kept (not deprecated) |
+| CloneURL | No longer contains token; worker assembles authenticated URL from job secrets |
 
 ## Config Structure
 
@@ -40,10 +43,10 @@ secrets:
 
 - `secrets` is `map[string]string`; keys become environment variable names
 - `secret_key` is hex-encoded 32 bytes (AES-256); config string is 64 hex characters
-- **Environment variable injection** uses the existing `EnvOverrideMap()` pattern in `config.go`, not a `${...}` interpolation syntax (which does not exist in this codebase). New env var mappings:
-  - `SECRET_KEY` env var → `secret_key` config path
-  - `SECRET_<NAME>` env var → `secrets.<name>` config path (e.g., `SECRET_K8S_TOKEN` → `secrets.K8S_TOKEN`)
-  - This is consistent with how `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, etc. already work
+- **Environment variable injection**:
+  - `SECRET_KEY` env var → `secret_key` config path (static mapping in `EnvOverrideMap()`)
+  - `AGENTDOCK_SECRET_<NAME>` env vars → dynamic scan at config load time. E.g., `AGENTDOCK_SECRET_K8S_TOKEN=xxx` → `cfg.Secrets["K8S_TOKEN"] = "xxx"`. The `AGENTDOCK_` prefix avoids collision with K8s or other system env vars.
+  - Config-file values and env var values merge; env var wins on conflict.
 
 ## Encryption Module
 
@@ -75,6 +78,24 @@ type Job struct {
 - If `secret_key` is not configured, `EncryptedSecrets` is left empty (nil). Secrets are not sent through the Job at all — only worker-local config secrets apply.
 - This eliminates ambiguity: if the field is non-empty, it is encrypted. Period.
 
+### CloneURL Change
+
+`Job.CloneURL` no longer contains the GitHub token. App submits a clean URL (e.g., `https://github.com/owner/repo.git`). Worker assembles the authenticated URL using `GH_TOKEN` from the resolved secrets map.
+
+Before:
+```go
+// workflow.go — app side
+CloneURL: w.repoCache.ResolveURL(pt.SelectedRepo)  // https://ghp_xxx@github.com/...
+```
+
+After:
+```go
+// workflow.go — app side
+CloneURL: fmt.Sprintf("https://github.com/%s.git", pt.SelectedRepo)  // no token
+```
+
+This eliminates plaintext token leakage through Redis in `Job.CloneURL`.
+
 ## Secret Passing Interface
 
 Secrets flow from `executor.go` (decryption) to `AgentRunner` (env injection) via `RunOptions`:
@@ -89,10 +110,72 @@ type RunOptions struct {
 
 - `executor.go` decrypts job secrets, merges with worker config secrets, sets `opts.Secrets`
 - `AgentRunner.runOne()` reads `opts.Secrets` and injects into `cmd.Env`
-- `AgentRunner` no longer stores `githubToken` as a field — it comes through `opts.Secrets`
+- **`AgentRunner.githubToken` field is kept** as fallback for inmem mode. Injection logic:
+  ```go
+  if len(opts.Secrets) > 0 {
+      for k, v := range opts.Secrets { env = append(env, k+"="+v) }
+  } else if r.githubToken != "" {
+      env = append(env, "GH_TOKEN="+r.githubToken)
+  }
+  ```
 - The `Runner` interface signature does not change (it already accepts `RunOptions`)
 
-## Data Flow
+## Worker Execution Dependencies
+
+`executionDeps` gains two fields for secret handling:
+
+```go
+type executionDeps struct {
+    // ... existing fields
+    secretKey     []byte            // decoded AES key, nil if not configured
+    workerSecrets map[string]string // worker config overrides
+}
+```
+
+`Pool` passes these from config at construction time.
+
+## RepoCache Per-Call Token
+
+`RepoCache.EnsureRepo` gains a `token` parameter so the worker can pass the job's `GH_TOKEN`:
+
+```go
+// Before
+func (rc *RepoCache) EnsureRepo(repoRef string) (string, error)
+
+// After
+func (rc *RepoCache) EnsureRepo(repoRef string, token string) (string, error)
+```
+
+- If `token` is non-empty, use it; otherwise fallback to `rc.githubPAT` (backward compat for inmem mode)
+- On cache hit (repo already cloned), only run `git remote set-url origin <url-with-token>` **if the token differs** from what's currently in the remote URL. Same token → skip `set-url`, go straight to `git fetch`.
+- On cache miss, clone with the provided token.
+
+### RepoProvider Interface Change
+
+```go
+type RepoProvider interface {
+    Prepare(cloneURL, branch, token string) (string, error)  // token added
+    RemoveWorktree(worktreePath string) error
+    CleanAll() error
+    PurgeStale() error
+}
+```
+
+`repoCacheAdapter.Prepare()` passes token to `EnsureRepo`. `executor.go` extracts `GH_TOKEN` from the resolved secrets map and passes it to `Prepare`.
+
+`NewRepoCache` signature unchanged — in Redis mode, pass `""` as `githubPAT` at startup (token comes per-call from jobs). In inmem mode, pass `cfg.GitHub.Token` as before.
+
+## Scope: Redis Transport Only
+
+This feature is **only active in Redis transport mode** (`queue.transport: "redis"`).
+
+In inmem mode:
+- `AgentRunner.githubToken` fallback handles `GH_TOKEN` injection (same as today)
+- `RepoCache` uses `rc.githubPAT` from startup config (same as today)
+- `opts.Secrets` is empty; no encryption/decryption occurs
+- No behavioral changes whatsoever
+
+## Data Flow (Redis Mode)
 
 ```
 ┌─────────── App ───────────┐
@@ -101,16 +184,17 @@ type RunOptions struct {
 │  ├ secret_key: "aes-key"   │
 │  ├ secrets:                │
 │  │   GH_TOKEN: "ghp_xxx"  │
-│  │   K8S_TOKEN: "from-cfg" │  ← or via SECRET_K8S_TOKEN env (EnvOverrideMap)
-│  └ github.token: "ghp_x"  │  ← backward compat → secrets["GH_TOKEN"]
+│  │   K8S_TOKEN: "from-cfg" │  ← or via AGENTDOCK_SECRET_K8S_TOKEN env
+│  └ github.token: "ghp_x"  │  ← auto-merge → secrets["GH_TOKEN"]
 │                            │
 │  Submit Job:               │
 │  1. Resolve secrets map    │
 │  2. JSON marshal secrets   │
 │  3. AES-GCM encrypt        │
 │  4. Job.EncryptedSecrets   │
+│  5. Job.CloneURL (no token)│
 └──────────┬─────────────────┘
-           │ Redis (ciphertext)
+           │ Redis (ciphertext + clean URL)
 ┌──────────▼─────────────────┐
 │                            │
 │  Worker                    │
@@ -122,7 +206,10 @@ type RunOptions struct {
 │  Receive Job:              │
 │  1. AES-GCM decrypt        │
 │  2. Merge (worker wins)    │
-│  3. cmd.Env inject all     │
+│  3. RepoCache.EnsureRepo   │
+│     with GH_TOKEN from     │
+│     merged secrets         │
+│  4. cmd.Env inject all     │
 │                            │
 │  exec claude --print ...   │
 │  env: GH_TOKEN=ghp_ovr    │
@@ -135,17 +222,29 @@ type RunOptions struct {
 
 1. Start with app-provided secrets (decrypted from Job)
 2. Overlay worker config `secrets` (worker wins on conflict)
-3. Result is the final `map[string]string` injected into `cmd.Env`
+3. Result is the final `map[string]string` — used for both `cmd.Env` injection and `RepoCache` token
 
 ## Backward Compatibility
 
 | Scenario | Behavior |
 |----------|----------|
-| No `secret_key`, no `secrets` | Same as today; `github.token` → `GH_TOKEN` env var |
+| No `secret_key`, no `secrets` | Same as today; `github.token` → `GH_TOKEN` env var via `AgentRunner.githubToken` fallback |
 | `secrets` set, no `secret_key` | Secrets are NOT sent through Job; only worker-local config secrets apply |
 | `secret_key` set, `secrets` set | Full encryption flow |
 | Worker has no `secret_key` but receives `EncryptedSecrets` | Job fails with clear error |
 | `github.token` set alongside `secrets` | `github.token` auto-merged as `secrets["GH_TOKEN"]`; explicit `secrets.GH_TOKEN` wins |
+| inmem transport | Completely unchanged; secrets feature not active |
+
+## `github.token` Handling
+
+`github.token` is **not deprecated**. Both `github.token` and `secrets.GH_TOKEN` are valid config paths.
+
+The auto-merge happens at config post-processing time (in `applyDefaults` or a new `resolveSecrets` step):
+
+1. If `cfg.GitHub.Token` is set and `cfg.Secrets["GH_TOKEN"]` is not → copy `cfg.GitHub.Token` into `cfg.Secrets["GH_TOKEN"]`
+2. If both are set → `cfg.Secrets["GH_TOKEN"]` wins (explicit beats implicit)
+3. After this step, `cfg.Secrets` is the single source of truth for all secrets
+4. `RepoCache` in inmem mode still reads `cfg.GitHub.Token` directly for its own `githubPAT` field
 
 ## Error Handling
 
@@ -160,15 +259,6 @@ Add optional step in the init wizard:
 1. Ask if user wants to enable secret encryption
 2. If yes, auto-generate 32 bytes via `crypto/rand`, hex-encode, write to config
 3. Prompt for secrets (key-value pairs) — or tell user to add manually later
-
-## `github.token` Auto-Merge
-
-The merge happens at config post-processing time (in `applyDefaults` or a new `resolveSecrets` step):
-
-1. If `cfg.GitHub.Token` is set and `cfg.Secrets["GH_TOKEN"]` is not → copy `cfg.GitHub.Token` into `cfg.Secrets["GH_TOKEN"]`
-2. If both are set → `cfg.Secrets["GH_TOKEN"]` wins (explicit beats implicit)
-3. After this step, `cfg.Secrets` is the single source of truth for all secrets
-4. `AgentRunner` no longer reads `cfg.GitHub.Token` directly for env injection
 
 ## Environment Variable Composition
 
@@ -196,6 +286,10 @@ On Linux/macOS, later entries override earlier ones with the same key, so append
 | No `secret_key` → `EncryptedSecrets` is nil | `internal/bot/workflow_test.go` |
 | Worker receives `EncryptedSecrets` without `secret_key` → job fails | `internal/worker/executor_test.go` |
 | `RunOptions.Secrets` injected into `cmd.Env` | `internal/bot/agent_test.go` |
+| `AGENTDOCK_SECRET_*` env var scan | `internal/config/config_test.go` |
+| `RepoCache.EnsureRepo` with per-call token | `internal/github/repo_test.go` |
+| `RepoCache` skips `set-url` when token unchanged | `internal/github/repo_test.go` |
+| `Job.CloneURL` does not contain token | `internal/bot/workflow_test.go` |
 
 ## Files Changed
 
@@ -203,12 +297,15 @@ On Linux/macOS, later entries override earlier ones with the same key, so append
 |------|--------|
 | `internal/crypto/aes.go` | **New** — Encrypt / Decrypt functions |
 | `internal/crypto/aes_test.go` | **New** — encryption round-trip tests |
-| `internal/config/config.go` | Add `SecretKey`, `Secrets` fields + env var expansion |
+| `internal/config/config.go` | Add `SecretKey`, `Secrets` fields + `AGENTDOCK_SECRET_*` dynamic scan + `SECRET_KEY` in `EnvOverrideMap` |
 | `internal/queue/job.go` | Add `EncryptedSecrets []byte` field |
-| `internal/bot/agent.go` | Generic secret injection via `cmd.Env`, remove hardcoded `GH_TOKEN` |
-| `internal/bot/workflow.go` | Encrypt secrets when submitting job |
-| `internal/worker/executor.go` | Decrypt + merge worker secrets before agent execution |
-| `cmd/agentdock/adapters.go` | Pass secrets through to Runner |
+| `internal/bot/agent.go` | Generic secret injection via `opts.Secrets` with `githubToken` fallback, remove hardcoded `GH_TOKEN` |
+| `internal/bot/workflow.go` | Encrypt secrets when submitting job; `CloneURL` without token |
+| `internal/worker/executor.go` | Decrypt + merge worker secrets; pass `GH_TOKEN` to `RepoCache.Prepare`; add `secretKey`/`workerSecrets` to `executionDeps` |
+| `internal/github/repo.go` | `EnsureRepo` per-call token param; conditional `git remote set-url` |
+| `internal/worker/executor.go` | `RepoProvider.Prepare` adds `token` param |
+| `cmd/agentdock/adapters.go` | `repoCacheAdapter.Prepare` passes token; `agentRunnerAdapter` unchanged |
+| `cmd/agentdock/worker.go` | Pass `secretKey`/`workerSecrets` to Pool config |
 | `cmd/agentdock/init.go` / `prompts.go` | Init wizard: secret_key generation step |
 
 ## Out of Scope
@@ -217,3 +314,4 @@ On Linux/macOS, later entries override earlier ones with the same key, so append
 - Per-channel secret overrides (all jobs get the same secrets from app config)
 - Secret rotation mechanism (manual: update config, restart)
 - Prompt-level secret injection (secrets are env vars only, never in prompt text)
+- inmem transport support for secrets (inmem mode unchanged)

--- a/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
+++ b/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
@@ -11,7 +11,7 @@ Secrets (GitHub token, K8s token, NPM token, etc.) are currently hardcoded as a 
 
 | Item | Decision |
 |------|----------|
-| Secret source | App centralized (config plaintext + K8s env var via `${...}`) |
+| Secret source | App centralized (config plaintext + env var via `EnvOverrideMap` pattern) |
 | Transport | Job struct → Redis (AES-256-GCM encrypted) |
 | Worker injection | Decrypted → `cmd.Env` (never in prompt) |
 | Worker override | Worker config `secrets` map overrides app-provided values |
@@ -23,10 +23,10 @@ Secrets (GitHub token, K8s token, NPM token, etc.) are currently hardcoded as a 
 ### App config
 
 ```yaml
-secret_key: "64-char-hex-encoded-32-byte-aes-key"  # or ${SECRET_KEY}
+secret_key: "64-char-hex-encoded-32-byte-aes-key"
 secrets:
   GH_TOKEN: "ghp_xxx"
-  K8S_TOKEN: "${K8S_TOKEN}"     # expanded from environment variable
+  K8S_TOKEN: "hardcoded-or-set-via-env"
   NPM_TOKEN: "npm_xxx"
 ```
 
@@ -39,9 +39,11 @@ secrets:
 ```
 
 - `secrets` is `map[string]string`; keys become environment variable names
-- `${VAR}` syntax is expanded at config load time
-- `secret_key` is hex-encoded 32 bytes (AES-256)
-- Both `secret_key` and `secrets` values support `${...}` env var expansion
+- `secret_key` is hex-encoded 32 bytes (AES-256); config string is 64 hex characters
+- **Environment variable injection** uses the existing `EnvOverrideMap()` pattern in `config.go`, not a `${...}` interpolation syntax (which does not exist in this codebase). New env var mappings:
+  - `SECRET_KEY` env var → `secret_key` config path
+  - `SECRET_<NAME>` env var → `secrets.<name>` config path (e.g., `SECRET_K8S_TOKEN` → `secrets.K8S_TOKEN`)
+  - This is consistent with how `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, etc. already work
 
 ## Encryption Module
 
@@ -68,6 +70,27 @@ type Job struct {
     EncryptedSecrets []byte `json:"encrypted_secrets,omitempty"`
 }
 ```
+
+- `EncryptedSecrets` is **always** AES-GCM ciphertext when present; there is no unencrypted fallback through this field.
+- If `secret_key` is not configured, `EncryptedSecrets` is left empty (nil). Secrets are not sent through the Job at all — only worker-local config secrets apply.
+- This eliminates ambiguity: if the field is non-empty, it is encrypted. Period.
+
+## Secret Passing Interface
+
+Secrets flow from `executor.go` (decryption) to `AgentRunner` (env injection) via `RunOptions`:
+
+```go
+type RunOptions struct {
+    OnStarted func(pid int, command string)
+    OnEvent   func(event queue.StreamEvent)
+    Secrets   map[string]string  // NEW: injected as cmd.Env
+}
+```
+
+- `executor.go` decrypts job secrets, merges with worker config secrets, sets `opts.Secrets`
+- `AgentRunner.runOne()` reads `opts.Secrets` and injects into `cmd.Env`
+- `AgentRunner` no longer stores `githubToken` as a field — it comes through `opts.Secrets`
+- The `Runner` interface signature does not change (it already accepts `RunOptions`)
 
 ## Data Flow
 
@@ -119,16 +142,16 @@ type Job struct {
 | Scenario | Behavior |
 |----------|----------|
 | No `secret_key`, no `secrets` | Same as today; `github.token` → `GH_TOKEN` env var |
-| `secrets` set, no `secret_key` | Secrets travel unencrypted (not recommended, but works) |
+| `secrets` set, no `secret_key` | Secrets are NOT sent through Job; only worker-local config secrets apply |
 | `secret_key` set, `secrets` set | Full encryption flow |
 | Worker has no `secret_key` but receives `EncryptedSecrets` | Job fails with clear error |
 | `github.token` set alongside `secrets` | `github.token` auto-merged as `secrets["GH_TOKEN"]`; explicit `secrets.GH_TOKEN` wins |
 
 ## Error Handling
 
-- `secret_key` not 32 bytes → **fatal at startup** (fail fast)
+- `secret_key` is not valid 64-character hex or does not decode to 32 bytes → **fatal at startup** (fail fast)
 - Decryption failure (wrong key, corrupt data) → **job fails**, no retry
-- `${ENV_VAR}` references nonexistent var → **fatal at startup**
+- Env var referenced by `EnvOverrideMap` is unset → value simply not overridden (consistent with existing behavior)
 
 ## `agentdock init` Changes
 
@@ -137,6 +160,42 @@ Add optional step in the init wizard:
 1. Ask if user wants to enable secret encryption
 2. If yes, auto-generate 32 bytes via `crypto/rand`, hex-encode, write to config
 3. Prompt for secrets (key-value pairs) — or tell user to add manually later
+
+## `github.token` Auto-Merge
+
+The merge happens at config post-processing time (in `applyDefaults` or a new `resolveSecrets` step):
+
+1. If `cfg.GitHub.Token` is set and `cfg.Secrets["GH_TOKEN"]` is not → copy `cfg.GitHub.Token` into `cfg.Secrets["GH_TOKEN"]`
+2. If both are set → `cfg.Secrets["GH_TOKEN"]` wins (explicit beats implicit)
+3. After this step, `cfg.Secrets` is the single source of truth for all secrets
+4. `AgentRunner` no longer reads `cfg.GitHub.Token` directly for env injection
+
+## Environment Variable Composition
+
+Secrets override host environment variables of the same name. The composition is:
+
+```go
+env := os.Environ()
+for k, v := range mergedSecrets {
+    env = append(env, fmt.Sprintf("%s=%s", k, v))
+}
+cmd.Env = env
+```
+
+On Linux/macOS, later entries override earlier ones with the same key, so appending secrets after `os.Environ()` guarantees the secret value wins.
+
+## Testing
+
+| Test | Scope |
+|------|-------|
+| AES-GCM round-trip (encrypt → decrypt) | `internal/crypto/aes_test.go` |
+| Decrypt with wrong key fails | `internal/crypto/aes_test.go` |
+| Decrypt with corrupt data fails | `internal/crypto/aes_test.go` |
+| Merge logic: app secrets + worker override | `internal/worker/executor_test.go` |
+| `github.token` auto-merge into `secrets["GH_TOKEN"]` | `internal/config/config_test.go` |
+| No `secret_key` → `EncryptedSecrets` is nil | `internal/bot/workflow_test.go` |
+| Worker receives `EncryptedSecrets` without `secret_key` → job fails | `internal/worker/executor_test.go` |
+| `RunOptions.Secrets` injected into `cmd.Env` | `internal/bot/agent_test.go` |
 
 ## Files Changed
 

--- a/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
+++ b/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
@@ -101,11 +101,11 @@ type RunOptions struct {
 │  ├ secret_key: "aes-key"   │
 │  ├ secrets:                │
 │  │   GH_TOKEN: "ghp_xxx"  │
-│  │   K8S_TOKEN: "${K8S_T}" │  ← env var expansion
+│  │   K8S_TOKEN: "from-cfg" │  ← or via SECRET_K8S_TOKEN env (EnvOverrideMap)
 │  └ github.token: "ghp_x"  │  ← backward compat → secrets["GH_TOKEN"]
 │                            │
 │  Submit Job:               │
-│  1. Expand ${...}          │
+│  1. Resolve secrets map    │
 │  2. JSON marshal secrets   │
 │  3. AES-GCM encrypt        │
 │  4. Job.EncryptedSecrets   │

--- a/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
+++ b/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
@@ -1,0 +1,160 @@
+# App-to-Worker Secret Passing
+
+**Issue**: [#56](https://github.com/Ivantseng123/agentdock/issues/56)
+**Date**: 2026-04-16
+
+## Problem
+
+Secrets (GitHub token, K8s token, NPM token, etc.) are currently hardcoded as a single `GH_TOKEN` environment variable in the worker. There is no mechanism for the app to centrally manage and distribute multiple secrets to workers. Workers cannot be guaranteed to have the correct or up-to-date tokens.
+
+## Decision Summary
+
+| Item | Decision |
+|------|----------|
+| Secret source | App centralized (config plaintext + K8s env var via `${...}`) |
+| Transport | Job struct → Redis (AES-256-GCM encrypted) |
+| Worker injection | Decrypted → `cmd.Env` (never in prompt) |
+| Worker override | Worker config `secrets` map overrides app-provided values |
+| Encryption key | Symmetric AES-256, shared `secret_key` in config |
+| Backward compat | No `secret_key` → no encryption; `github.token` auto-merges into `secrets["GH_TOKEN"]` |
+
+## Config Structure
+
+### App config
+
+```yaml
+secret_key: "64-char-hex-encoded-32-byte-aes-key"  # or ${SECRET_KEY}
+secrets:
+  GH_TOKEN: "ghp_xxx"
+  K8S_TOKEN: "${K8S_TOKEN}"     # expanded from environment variable
+  NPM_TOKEN: "npm_xxx"
+```
+
+### Worker config (optional override)
+
+```yaml
+secret_key: "same-key-as-app"
+secrets:
+  GH_TOKEN: "ghp_worker_specific"  # overrides app-provided value
+```
+
+- `secrets` is `map[string]string`; keys become environment variable names
+- `${VAR}` syntax is expanded at config load time
+- `secret_key` is hex-encoded 32 bytes (AES-256)
+- Both `secret_key` and `secrets` values support `${...}` env var expansion
+
+## Encryption Module
+
+New package: `internal/crypto/`
+
+```go
+// Encrypt encrypts plaintext using AES-256-GCM.
+// Returns nonce (12 bytes) prepended to ciphertext.
+func Encrypt(key, plaintext []byte) ([]byte, error)
+
+// Decrypt decrypts ciphertext produced by Encrypt.
+func Decrypt(key, ciphertext []byte) ([]byte, error)
+```
+
+- Uses Go stdlib `crypto/aes` + `crypto/cipher` — zero external dependencies
+- Random nonce per encryption via `crypto/rand`
+- GCM provides authentication (tamper detection) for free
+
+## Job Struct Change
+
+```go
+type Job struct {
+    // ... existing fields
+    EncryptedSecrets []byte `json:"encrypted_secrets,omitempty"`
+}
+```
+
+## Data Flow
+
+```
+┌─────────── App ───────────┐
+│                            │
+│  config.yaml               │
+│  ├ secret_key: "aes-key"   │
+│  ├ secrets:                │
+│  │   GH_TOKEN: "ghp_xxx"  │
+│  │   K8S_TOKEN: "${K8S_T}" │  ← env var expansion
+│  └ github.token: "ghp_x"  │  ← backward compat → secrets["GH_TOKEN"]
+│                            │
+│  Submit Job:               │
+│  1. Expand ${...}          │
+│  2. JSON marshal secrets   │
+│  3. AES-GCM encrypt        │
+│  4. Job.EncryptedSecrets   │
+└──────────┬─────────────────┘
+           │ Redis (ciphertext)
+┌──────────▼─────────────────┐
+│                            │
+│  Worker                    │
+│  config.yaml               │
+│  ├ secret_key: "same-key"  │
+│  └ secrets:                │  ← optional override
+│      GH_TOKEN: "ghp_ovr"  │
+│                            │
+│  Receive Job:              │
+│  1. AES-GCM decrypt        │
+│  2. Merge (worker wins)    │
+│  3. cmd.Env inject all     │
+│                            │
+│  exec claude --print ...   │
+│  env: GH_TOKEN=ghp_ovr    │
+│  env: K8S_TOKEN=eyJhb...   │
+│  env: NPM_TOKEN=npm_xxx    │
+└────────────────────────────┘
+```
+
+## Merge Order
+
+1. Start with app-provided secrets (decrypted from Job)
+2. Overlay worker config `secrets` (worker wins on conflict)
+3. Result is the final `map[string]string` injected into `cmd.Env`
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| No `secret_key`, no `secrets` | Same as today; `github.token` → `GH_TOKEN` env var |
+| `secrets` set, no `secret_key` | Secrets travel unencrypted (not recommended, but works) |
+| `secret_key` set, `secrets` set | Full encryption flow |
+| Worker has no `secret_key` but receives `EncryptedSecrets` | Job fails with clear error |
+| `github.token` set alongside `secrets` | `github.token` auto-merged as `secrets["GH_TOKEN"]`; explicit `secrets.GH_TOKEN` wins |
+
+## Error Handling
+
+- `secret_key` not 32 bytes → **fatal at startup** (fail fast)
+- Decryption failure (wrong key, corrupt data) → **job fails**, no retry
+- `${ENV_VAR}` references nonexistent var → **fatal at startup**
+
+## `agentdock init` Changes
+
+Add optional step in the init wizard:
+
+1. Ask if user wants to enable secret encryption
+2. If yes, auto-generate 32 bytes via `crypto/rand`, hex-encode, write to config
+3. Prompt for secrets (key-value pairs) — or tell user to add manually later
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/crypto/aes.go` | **New** — Encrypt / Decrypt functions |
+| `internal/crypto/aes_test.go` | **New** — encryption round-trip tests |
+| `internal/config/config.go` | Add `SecretKey`, `Secrets` fields + env var expansion |
+| `internal/queue/job.go` | Add `EncryptedSecrets []byte` field |
+| `internal/bot/agent.go` | Generic secret injection via `cmd.Env`, remove hardcoded `GH_TOKEN` |
+| `internal/bot/workflow.go` | Encrypt secrets when submitting job |
+| `internal/worker/executor.go` | Decrypt + merge worker secrets before agent execution |
+| `cmd/agentdock/adapters.go` | Pass secrets through to Runner |
+| `cmd/agentdock/init.go` / `prompts.go` | Init wizard: secret_key generation step |
+
+## Out of Scope
+
+- Asymmetric encryption (future upgrade path if shared key management becomes painful)
+- Per-channel secret overrides (all jobs get the same secrets from app config)
+- Secret rotation mechanism (manual: update config, restart)
+- Prompt-level secret injection (secrets are env vars only, never in prompt text)

--- a/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
+++ b/docs/superpowers/specs/2026-04-16-app-worker-secrets-design.md
@@ -306,6 +306,7 @@ On Linux/macOS, later entries override earlier ones with the same key, so append
 | `internal/worker/executor.go` | `RepoProvider.Prepare` adds `token` param |
 | `cmd/agentdock/adapters.go` | `repoCacheAdapter.Prepare` passes token; `agentRunnerAdapter` unchanged |
 | `cmd/agentdock/worker.go` | Pass `secretKey`/`workerSecrets` to Pool config |
+| `internal/bot/retry_handler.go` | Propagate `EncryptedSecrets` from original job to retry job |
 | `cmd/agentdock/init.go` / `prompts.go` | Init wizard: secret_key generation step |
 
 ## Out of Scope

--- a/internal/bot/agent.go
+++ b/internal/bot/agent.go
@@ -20,6 +20,7 @@ import (
 type RunOptions struct {
 	OnStarted func(pid int, command string)
 	OnEvent   func(event queue.StreamEvent)
+	Secrets   map[string]string
 }
 
 type AgentRunner struct {
@@ -108,8 +109,16 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
 	cmd.WaitDelay = 10 * time.Second
 
-	// Pass GH_TOKEN for agent to access GitHub API.
-	cmd.Env = append(os.Environ(), fmt.Sprintf("GH_TOKEN=%s", r.githubToken))
+	// Inject secrets as environment variables.
+	env := os.Environ()
+	if len(opts.Secrets) > 0 {
+		for k, v := range opts.Secrets {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	} else if r.githubToken != "" {
+		env = append(env, fmt.Sprintf("GH_TOKEN=%s", r.githubToken))
+	}
+	cmd.Env = env
 
 	if useStdin {
 		cmd.Stdin = strings.NewReader(prompt)

--- a/internal/bot/agent_test.go
+++ b/internal/bot/agent_test.go
@@ -106,3 +106,53 @@ echo "padding padding padding padding padding padding padding"
 		t.Errorf("prompt not substituted in output: %q", output)
 	}
 }
+
+func TestAgentRunner_SecretsInjected(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "env-agent")
+	os.WriteFile(script, []byte(`#!/bin/sh
+env | grep TOKEN | sort
+echo "padding padding padding padding padding padding padding"
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second},
+	})
+
+	secrets := map[string]string{
+		"GH_TOKEN":  "ghp_from_secrets",
+		"K8S_TOKEN": "k8s_val",
+	}
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{Secrets: secrets})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !strings.Contains(output, "GH_TOKEN=ghp_from_secrets") {
+		t.Errorf("GH_TOKEN not injected: %q", output)
+	}
+	if !strings.Contains(output, "K8S_TOKEN=k8s_val") {
+		t.Errorf("K8S_TOKEN not injected: %q", output)
+	}
+}
+
+func TestAgentRunner_GithubTokenFallback(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "env-agent")
+	os.WriteFile(script, []byte(`#!/bin/sh
+env | grep GH_TOKEN
+echo "padding padding padding padding padding padding padding"
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second},
+	})
+	runner.githubToken = "ghp_fallback"
+
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !strings.Contains(output, "GH_TOKEN=ghp_fallback") {
+		t.Errorf("githubToken fallback not working: %q", output)
+	}
+}

--- a/internal/bot/retry_handler.go
+++ b/internal/bot/retry_handler.go
@@ -61,6 +61,7 @@ func (h *RetryHandler) Handle(channelID, jobID, msgTS string) {
 		RetryCount:   original.RetryCount + 1,
 		RetryOfJobID: original.ID,
 		SubmittedAt:  time.Now(),
+		EncryptedSecrets: original.EncryptedSecrets,
 	}
 
 	// Put in store before posting button (so cancel_job can find it).

--- a/internal/bot/workflow.go
+++ b/internal/bot/workflow.go
@@ -52,6 +52,7 @@ type Workflow struct {
 	attachments   queue.AttachmentStore
 	results       queue.ResultBus
 	skillProvider SkillProvider
+	secretKey    []byte // decoded AES key, nil if not configured
 
 	mu        sync.Mutex
 	pending   map[string]*pendingTriage
@@ -71,6 +72,15 @@ func NewWorkflow(
 	resultBus queue.ResultBus,
 	skillProvider SkillProvider,
 ) *Workflow {
+	// Decode secret key once at startup (nil if not configured).
+	var sk []byte
+	if cfg.SecretKey != "" {
+		var err error
+		sk, err = config.DecodeSecretKey(cfg.SecretKey)
+		if err != nil {
+			slog.Error("secret_key 無效，secret 加密功能停用", "phase", "失敗", "error", err)
+		}
+	}
 	return &Workflow{
 		cfg:           cfg,
 		slack:         slack,
@@ -83,6 +93,7 @@ func NewWorkflow(
 		attachments:   attachStore,
 		results:       resultBus,
 		skillProvider: skillProvider,
+		secretKey:     sk,
 		pending:       make(map[string]*pendingTriage),
 		autoBound:     make(map[string]bool),
 	}
@@ -243,7 +254,7 @@ func (w *Workflow) afterRepoSelected(pt *pendingTriage, channelCfg config.Channe
 		return
 	}
 
-	repoPath, err := w.repoCache.EnsureRepo(pt.SelectedRepo, "")
+	repoPath, err := w.repoCache.EnsureRepo(pt.SelectedRepo, w.cfg.Secrets["GH_TOKEN"])
 	if err != nil {
 		w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to access repo %s: %v", pt.SelectedRepo, err)
 		return
@@ -438,20 +449,14 @@ func (w *Workflow) runTriage(pt *pendingTriage) {
 		SubmittedAt: time.Now(),
 	}
 
-	if w.cfg.SecretKey != "" && len(w.cfg.Secrets) > 0 {
-		secretKey, err := config.DecodeSecretKey(w.cfg.SecretKey)
-		if err != nil {
-			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Invalid secret_key: %v", err)
-			w.clearDedup(pt)
-			return
-		}
+	if len(w.secretKey) > 0 && len(w.cfg.Secrets) > 0 {
 		secretsJSON, err := json.Marshal(w.cfg.Secrets)
 		if err != nil {
 			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to marshal secrets: %v", err)
 			w.clearDedup(pt)
 			return
 		}
-		encrypted, err := crypto.Encrypt(secretKey, secretsJSON)
+		encrypted, err := crypto.Encrypt(w.secretKey, secretsJSON)
 		if err != nil {
 			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to encrypt secrets: %v", err)
 			w.clearDedup(pt)

--- a/internal/bot/workflow.go
+++ b/internal/bot/workflow.go
@@ -241,7 +241,7 @@ func (w *Workflow) afterRepoSelected(pt *pendingTriage, channelCfg config.Channe
 		return
 	}
 
-	repoPath, err := w.repoCache.EnsureRepo(pt.SelectedRepo)
+	repoPath, err := w.repoCache.EnsureRepo(pt.SelectedRepo, "")
 	if err != nil {
 		w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to access repo %s: %v", pt.SelectedRepo, err)
 		return

--- a/internal/bot/workflow.go
+++ b/internal/bot/workflow.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"agentdock/internal/config"
+	"agentdock/internal/crypto"
 	ghclient "agentdock/internal/github"
 	"agentdock/internal/logging"
 	"agentdock/internal/mantis"
@@ -428,12 +430,34 @@ func (w *Workflow) runTriage(pt *pendingTriage) {
 		UserID:      pt.UserID,
 		Repo:        pt.SelectedRepo,
 		Branch:      pt.SelectedBranch,
-		CloneURL:    w.repoCache.ResolveURL(pt.SelectedRepo),
+		CloneURL:    cleanCloneURL(pt.SelectedRepo),
 		Prompt:      prompt,
 		Skills:      w.loadSkills(ctx),
 		RequestID:   pt.RequestID,
 		Attachments: attachMeta,
 		SubmittedAt: time.Now(),
+	}
+
+	if w.cfg.SecretKey != "" && len(w.cfg.Secrets) > 0 {
+		secretKey, err := config.DecodeSecretKey(w.cfg.SecretKey)
+		if err != nil {
+			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Invalid secret_key: %v", err)
+			w.clearDedup(pt)
+			return
+		}
+		secretsJSON, err := json.Marshal(w.cfg.Secrets)
+		if err != nil {
+			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to marshal secrets: %v", err)
+			w.clearDedup(pt)
+			return
+		}
+		encrypted, err := crypto.Encrypt(secretKey, secretsJSON)
+		if err != nil {
+			w.notifyError(pt.Logger, pt.ChannelID, pt.ThreadTS, "Failed to encrypt secrets: %v", err)
+			w.clearDedup(pt)
+			return
+		}
+		job.EncryptedSecrets = encrypted
 	}
 
 	if err := w.queue.Submit(ctx, job); err != nil {
@@ -475,6 +499,13 @@ func (w *Workflow) runTriage(pt *pendingTriage) {
 		w.store.Put(job) // update with StatusMsgTS
 	}
 	// Don't clearDedup here — ResultListener handles cleanup after job completes.
+}
+
+func cleanCloneURL(repoRef string) string {
+	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
+		return repoRef
+	}
+	return fmt.Sprintf("https://github.com/%s.git", repoRef)
 }
 
 func (w *Workflow) loadSkills(ctx context.Context) map[string]*queue.SkillPayload {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -35,6 +37,8 @@ type Config struct {
 	Attachments       AttachmentsConfig        `yaml:"attachments"`
 	Redis             RedisConfig              `yaml:"redis"`
 	SkillsConfig      string                   `yaml:"skills_config"`
+	SecretKey         string                   `yaml:"secret_key"`
+	Secrets           map[string]string        `yaml:"secrets"`
 }
 
 type ServerConfig struct {
@@ -217,6 +221,7 @@ func applyDefaults(cfg *Config) {
 	if cfg.Attachments.TTL <= 0 {
 		cfg.Attachments.TTL = 30 * time.Minute
 	}
+	resolveSecrets(cfg)
 }
 
 // DefaultsMap returns a koanf-friendly map[string]any of all default values
@@ -264,6 +269,9 @@ func EnvOverrideMap() map[string]any {
 	if v := os.Getenv("ACTIVE_AGENT"); v != "" {
 		out["active_agent"] = v
 	}
+	if v := os.Getenv("SECRET_KEY"); v != "" {
+		out["secret_key"] = v
+	}
 	if v := os.Getenv("PROVIDERS"); v != "" {
 		var providers []string
 		for _, p := range strings.Split(v, ",") {
@@ -276,5 +284,51 @@ func EnvOverrideMap() map[string]any {
 		}
 	}
 	return out
+}
+
+// ScanSecretEnvVars scans environment for AGENTDOCK_SECRET_* variables
+// and returns them as a map with the prefix stripped.
+func ScanSecretEnvVars() map[string]string {
+	const prefix = "AGENTDOCK_SECRET_"
+	out := make(map[string]string)
+	for _, env := range os.Environ() {
+		if idx := strings.Index(env, "="); idx > 0 {
+			key := env[:idx]
+			if strings.HasPrefix(key, prefix) {
+				name := key[len(prefix):]
+				if name != "" {
+					out[name] = env[idx+1:]
+				}
+			}
+		}
+	}
+	return out
+}
+
+// resolveSecrets merges github.token into secrets and applies env var overrides.
+func resolveSecrets(cfg *Config) {
+	if cfg.Secrets == nil {
+		cfg.Secrets = make(map[string]string)
+	}
+	if cfg.GitHub.Token != "" {
+		if _, exists := cfg.Secrets["GH_TOKEN"]; !exists {
+			cfg.Secrets["GH_TOKEN"] = cfg.GitHub.Token
+		}
+	}
+	for k, v := range ScanSecretEnvVars() {
+		cfg.Secrets[k] = v
+	}
+}
+
+// DecodeSecretKey validates and decodes a hex-encoded 32-byte AES key.
+func DecodeSecretKey(hexKey string) ([]byte, error) {
+	decoded, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("secret_key: invalid hex: %w", err)
+	}
+	if len(decoded) != 32 {
+		return nil, fmt.Errorf("secret_key: must be 32 bytes (64 hex chars), got %d bytes", len(decoded))
+	}
+	return decoded, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -430,3 +430,78 @@ func TestDefaultsMap_AgreesWithApplyDefaults(t *testing.T) {
 		t.Errorf("DefaultsMap.workers.count=%v != applyDefaults.Workers.Count=%v", got, cfg.Workers.Count)
 	}
 }
+
+func TestResolveSecrets_GitHubTokenAutoMerge(t *testing.T) {
+	cfg := &Config{
+		GitHub: GitHubConfig{Token: "ghp_from_github"},
+	}
+	resolveSecrets(cfg)
+	if cfg.Secrets["GH_TOKEN"] != "ghp_from_github" {
+		t.Errorf("got %q, want ghp_from_github", cfg.Secrets["GH_TOKEN"])
+	}
+}
+
+func TestResolveSecrets_ExplicitSecretsWin(t *testing.T) {
+	cfg := &Config{
+		GitHub:  GitHubConfig{Token: "ghp_from_github"},
+		Secrets: map[string]string{"GH_TOKEN": "ghp_explicit"},
+	}
+	resolveSecrets(cfg)
+	if cfg.Secrets["GH_TOKEN"] != "ghp_explicit" {
+		t.Errorf("got %q, want ghp_explicit", cfg.Secrets["GH_TOKEN"])
+	}
+}
+
+func TestResolveSecrets_InitializesNilMap(t *testing.T) {
+	cfg := &Config{}
+	resolveSecrets(cfg)
+	if cfg.Secrets == nil {
+		t.Error("Secrets should be initialized to non-nil map")
+	}
+}
+
+func TestEnvOverrideMap_SecretKey(t *testing.T) {
+	t.Setenv("SECRET_KEY", "abc123")
+	m := EnvOverrideMap()
+	if m["secret_key"] != "abc123" {
+		t.Errorf("got %q, want abc123", m["secret_key"])
+	}
+}
+
+func TestScanSecretEnvVars(t *testing.T) {
+	t.Setenv("AGENTDOCK_SECRET_K8S_TOKEN", "k8s-val")
+	t.Setenv("AGENTDOCK_SECRET_NPM_TOKEN", "npm-val")
+	t.Setenv("UNRELATED_VAR", "ignore")
+
+	got := ScanSecretEnvVars()
+	if got["K8S_TOKEN"] != "k8s-val" {
+		t.Errorf("K8S_TOKEN = %q, want k8s-val", got["K8S_TOKEN"])
+	}
+	if got["NPM_TOKEN"] != "npm-val" {
+		t.Errorf("NPM_TOKEN = %q, want npm-val", got["NPM_TOKEN"])
+	}
+	if _, exists := got["UNRELATED_VAR"]; exists {
+		t.Error("should not include UNRELATED_VAR")
+	}
+}
+
+func TestValidateSecretKey_Valid(t *testing.T) {
+	key := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	_, err := DecodeSecretKey(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSecretKey_Invalid(t *testing.T) {
+	cases := []string{
+		"tooshort",
+		"not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hex-not-hex",
+		"",
+	}
+	for _, c := range cases {
+		if _, err := DecodeSecretKey(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}

--- a/internal/crypto/aes.go
+++ b/internal/crypto/aes.go
@@ -1,0 +1,45 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// Encrypt encrypts plaintext using AES-256-GCM.
+// Returns nonce (12 bytes) prepended to ciphertext.
+func Encrypt(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt decrypts ciphertext produced by Encrypt.
+func Decrypt(key, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}

--- a/internal/crypto/aes_test.go
+++ b/internal/crypto/aes_test.go
@@ -1,0 +1,78 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte(`{"GH_TOKEN":"ghp_xxx","K8S_TOKEN":"eyJhb"}`)
+
+	ciphertext, err := Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if bytes.Equal(ciphertext, plaintext) {
+		t.Fatal("ciphertext should differ from plaintext")
+	}
+
+	decrypted, err := Decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Errorf("got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestDecrypt_WrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	rand.Read(key1)
+	rand.Read(key2)
+
+	ciphertext, _ := Encrypt(key1, []byte("secret"))
+	_, err := Decrypt(key2, ciphertext)
+	if err == nil {
+		t.Fatal("expected error decrypting with wrong key")
+	}
+}
+
+func TestDecrypt_CorruptData(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	_, err := Decrypt(key, []byte("not-valid-ciphertext"))
+	if err == nil {
+		t.Fatal("expected error decrypting corrupt data")
+	}
+}
+
+func TestEncrypt_InvalidKeyLength(t *testing.T) {
+	_, err := Encrypt([]byte("short"), []byte("data"))
+	if err == nil {
+		t.Fatal("expected error with invalid key length")
+	}
+}
+
+func TestEncrypt_EmptyPlaintext(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	ciphertext, err := Encrypt(key, []byte{})
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+	decrypted, err := Decrypt(key, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt empty: %v", err)
+	}
+	if len(decrypted) != 0 {
+		t.Errorf("expected empty, got %q", decrypted)
+	}
+}

--- a/internal/crypto/beacon.go
+++ b/internal/crypto/beacon.go
@@ -1,0 +1,46 @@
+package crypto
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	beaconKey       = "agentdock:secret_beacon"
+	beaconPlaintext = "agentdock-key-check"
+	beaconTTL       = 24 * time.Hour
+)
+
+// WriteBeacon encrypts a known plaintext and stores it in Redis.
+// Called by the app at startup so workers can verify their key matches.
+func WriteBeacon(ctx context.Context, rdb *redis.Client, key []byte) error {
+	ciphertext, err := Encrypt(key, []byte(beaconPlaintext))
+	if err != nil {
+		return fmt.Errorf("encrypt beacon: %w", err)
+	}
+	return rdb.Set(ctx, beaconKey, ciphertext, beaconTTL).Err()
+}
+
+// VerifyBeacon reads the beacon from Redis and attempts to decrypt it.
+// Returns nil if the key matches, an error otherwise.
+// If no beacon exists (app hasn't started yet), returns nil (skip check).
+func VerifyBeacon(ctx context.Context, rdb *redis.Client, key []byte) error {
+	ciphertext, err := rdb.Get(ctx, beaconKey).Bytes()
+	if err == redis.Nil {
+		return nil // no beacon yet, app hasn't written one
+	}
+	if err != nil {
+		return fmt.Errorf("read beacon from Redis: %w", err)
+	}
+	plaintext, err := Decrypt(key, ciphertext)
+	if err != nil {
+		return fmt.Errorf("secret_key does not match app — decryption failed")
+	}
+	if string(plaintext) != beaconPlaintext {
+		return fmt.Errorf("secret_key does not match app — plaintext mismatch")
+	}
+	return nil
+}

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -32,7 +32,8 @@ func NewRepoCache(dir string, maxAge time.Duration, githubPAT string, logger *sl
 }
 
 // resolveURLWithToken builds a clone URL. Uses perCallToken if non-empty,
-// otherwise falls back to rc.githubPAT.
+// otherwise falls back to rc.githubPAT. Full URLs (http/git@/file://) pass
+// through unchanged — callers must ensure they don't contain stale tokens.
 func (rc *RepoCache) resolveURLWithToken(repoRef, perCallToken string) string {
 	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
 		return repoRef

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -31,12 +31,36 @@ func NewRepoCache(dir string, maxAge time.Duration, githubPAT string, logger *sl
 	}
 }
 
-func (rc *RepoCache) EnsureRepo(repoRef string) (string, error) {
+// resolveURLWithToken builds a clone URL. Uses perCallToken if non-empty,
+// otherwise falls back to rc.githubPAT.
+func (rc *RepoCache) resolveURLWithToken(repoRef, perCallToken string) string {
+	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
+		return repoRef
+	}
+	token := perCallToken
+	if token == "" {
+		token = rc.githubPAT
+	}
+	if token != "" {
+		return fmt.Sprintf("https://%s@github.com/%s.git", token, repoRef)
+	}
+	return fmt.Sprintf("https://github.com/%s.git", repoRef)
+}
+
+func (rc *RepoCache) getRemoteURL(repoPath string) string {
+	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func (rc *RepoCache) EnsureRepo(repoRef string, token string) (string, error) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
 	start := time.Now()
-	cloneURL := rc.ResolveURL(repoRef)
+	cloneURL := rc.resolveURLWithToken(repoRef, token)
 	localPath := filepath.Join(rc.dir, rc.dirName(repoRef))
 
 	if _, err := os.Stat(filepath.Join(localPath, "HEAD")); os.IsNotExist(err) {
@@ -56,6 +80,13 @@ func (rc *RepoCache) EnsureRepo(repoRef string) (string, error) {
 
 	if last, ok := rc.lastPull[repoRef]; ok && rc.maxAge > 0 && time.Since(last) < rc.maxAge {
 		return localPath, nil
+	}
+
+	// Update remote URL if token changed
+	currentURL := rc.getRemoteURL(localPath)
+	if cloneURL != currentURL && cloneURL != "" {
+		setCmd := exec.Command("git", "-C", localPath, "remote", "set-url", "origin", cloneURL)
+		setCmd.Run() // best-effort
 	}
 
 	rc.logger.Info("開始 fetch repo", "phase", "處理中", "repo", SanitizeURL(repoRef))

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -27,7 +27,7 @@ func TestRepoCache_EnsureRepo_ClonesNewRepo(t *testing.T) {
 	cacheDir := t.TempDir()
 	cache := NewRepoCache(cacheDir, time.Hour, "", slog.Default())
 
-	repoPath, err := cache.EnsureRepo("file://" + bareDir)
+	repoPath, err := cache.EnsureRepo("file://"+bareDir, "")
 	if err != nil {
 		t.Fatalf("EnsureRepo failed: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestRepoCache_EnsureRepo_PullsExistingRepo(t *testing.T) {
 	cacheDir := t.TempDir()
 	cache := NewRepoCache(cacheDir, 0, "", slog.Default())
 
-	repoPath, err := cache.EnsureRepo("file://" + bareDir)
+	repoPath, err := cache.EnsureRepo("file://"+bareDir, "")
 	if err != nil {
 		t.Fatalf("first EnsureRepo failed: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestRepoCache_EnsureRepo_PullsExistingRepo(t *testing.T) {
 	run(t, workDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "v2")
 	run(t, workDir, "git", "push")
 
-	repoPath2, err := cache.EnsureRepo("file://" + bareDir)
+	repoPath2, err := cache.EnsureRepo("file://"+bareDir, "")
 	if err != nil {
 		t.Fatalf("second EnsureRepo failed: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestRepoCache_BareCloneAndWorktree(t *testing.T) {
 	cache := NewRepoCache(cacheDir, time.Hour, "", slog.Default())
 
 	// EnsureRepo should create a bare clone.
-	barePath, err := cache.EnsureRepo("file://" + sourceDir)
+	barePath, err := cache.EnsureRepo("file://"+sourceDir, "")
 	if err != nil {
 		t.Fatalf("EnsureRepo failed: %v", err)
 	}
@@ -180,6 +180,33 @@ func TestRepoCache_PurgeStale(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("expected empty cache dir, got %d entries", len(entries))
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_PerCall(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "", slog.Default())
+	url := rc.resolveURLWithToken("owner/repo", "ghp_percall")
+	if url != "https://ghp_percall@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_Fallback(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "ghp_default", slog.Default())
+	url := rc.resolveURLWithToken("owner/repo", "")
+	if url != "https://ghp_default@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_NoToken(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "", slog.Default())
+	url := rc.resolveURLWithToken("owner/repo", "")
+	if url != "https://github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
 	}
 }
 

--- a/internal/queue/integration_test.go
+++ b/internal/queue/integration_test.go
@@ -32,7 +32,7 @@ func (f *fakeRunner) Run(ctx context.Context, workDir, prompt string, opts bot.R
 
 type fakeRepo struct{}
 
-func (f *fakeRepo) Prepare(cloneURL, branch string) (string, error) {
+func (f *fakeRepo) Prepare(cloneURL, branch, token string) (string, error) {
 	return "/tmp/fake-repo", nil
 }
 

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -38,6 +38,7 @@ type Job struct {
 	RetryCount   int               `json:"retry_count,omitempty"`
 	RetryOfJobID string            `json:"retry_of_job_id,omitempty"`
 	SubmittedAt  time.Time         `json:"submitted_at"`
+	EncryptedSecrets []byte    `json:"encrypted_secrets,omitempty"`
 }
 
 type AttachmentMeta struct {

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"agentdock/internal/bot"
+	"agentdock/internal/crypto"
 	"agentdock/internal/queue"
 )
 
@@ -27,11 +29,13 @@ type RepoProvider interface {
 }
 
 type executionDeps struct {
-	attachments queue.AttachmentStore
-	repoCache   RepoProvider
-	runner      Runner
-	store       queue.JobStore
-	skillDirs   []string
+	attachments   queue.AttachmentStore
+	repoCache     RepoProvider
+	runner        Runner
+	store         queue.JobStore
+	skillDirs     []string
+	secretKey     []byte
+	workerSecrets map[string]string
 }
 
 func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bot.RunOptions, logger *slog.Logger) *queue.JobResult {
@@ -49,10 +53,40 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 		}
 	}
 
+	// Decrypt and merge secrets.
+	var mergedSecrets map[string]string
+	if len(job.EncryptedSecrets) > 0 {
+		if len(deps.secretKey) == 0 {
+			return failedResult(job, startedAt, fmt.Errorf("job has encrypted secrets but worker has no secret_key configured"), "")
+		}
+		decrypted, err := crypto.Decrypt(deps.secretKey, job.EncryptedSecrets)
+		if err != nil {
+			return failedResult(job, startedAt, fmt.Errorf("decrypt secrets: %w", err), "")
+		}
+		var appSecrets map[string]string
+		if err := json.Unmarshal(decrypted, &appSecrets); err != nil {
+			return failedResult(job, startedAt, fmt.Errorf("unmarshal secrets: %w", err), "")
+		}
+		mergedSecrets = appSecrets
+	}
+	// Overlay worker secrets (worker wins)
+	if len(deps.workerSecrets) > 0 {
+		if mergedSecrets == nil {
+			mergedSecrets = make(map[string]string)
+		}
+		for k, v := range deps.workerSecrets {
+			mergedSecrets[k] = v
+		}
+	}
+
 	// Clone/fetch repo.
 	logger.Info("準備 repo 中", "phase", "處理中", "branch", job.Branch)
 	prepareStart := time.Now()
-	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, "")
+	ghToken := ""
+	if mergedSecrets != nil {
+		ghToken = mergedSecrets["GH_TOKEN"]
+	}
+	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, ghToken)
 	if err != nil {
 		return failedResult(job, startedAt, fmt.Errorf("repo prepare failed: %w", err), "")
 	}
@@ -88,6 +122,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	// Execute agent.
 	deps.store.UpdateStatus(job.ID, queue.JobRunning)
 	logger.Info("執行 agent 中", "phase", "處理中")
+	opts.Secrets = mergedSecrets
 	output, err := deps.runner.Run(ctx, repoPath, prompt, opts)
 	if err != nil {
 		return failedResult(job, startedAt, err, repoPath)

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -20,7 +20,7 @@ type Runner interface {
 
 // RepoProvider abstracts repo clone/checkout (for testing).
 type RepoProvider interface {
-	Prepare(cloneURL, branch string) (string, error)
+	Prepare(cloneURL, branch, token string) (string, error)
 	RemoveWorktree(worktreePath string) error
 	CleanAll() error
 	PurgeStale() error
@@ -52,7 +52,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	// Clone/fetch repo.
 	logger.Info("準備 repo 中", "phase", "處理中", "branch", job.Branch)
 	prepareStart := time.Now()
-	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch)
+	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, "")
 	if err != nil {
 		return failedResult(job, startedAt, fmt.Errorf("repo prepare failed: %w", err), "")
 	}

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -24,6 +24,8 @@ type Config struct {
 	Status         queue.StatusBus
 	StatusInterval time.Duration
 	Logger         *slog.Logger
+	SecretKey      []byte
+	WorkerSecrets  map[string]string
 }
 
 type Pool struct {
@@ -161,11 +163,13 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	p.cfg.Store.SetWorker(job.ID, wID)
 
 	deps := executionDeps{
-		attachments: p.cfg.Attachments,
-		repoCache:   p.cfg.RepoCache,
-		runner:      p.cfg.Runner,
-		store:       p.cfg.Store,
-		skillDirs:   p.cfg.SkillDirs,
+		attachments:   p.cfg.Attachments,
+		repoCache:     p.cfg.RepoCache,
+		runner:        p.cfg.Runner,
+		store:         p.cfg.Store,
+		skillDirs:     p.cfg.SkillDirs,
+		secretKey:     p.cfg.SecretKey,
+		workerSecrets: p.cfg.WorkerSecrets,
 	}
 
 	result := executeJob(jobCtx, job, deps, opts, logger)

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -28,7 +28,7 @@ type mockRepo struct {
 	purgedStale      bool
 }
 
-func (m *mockRepo) Prepare(cloneURL, branch string) (string, error) {
+func (m *mockRepo) Prepare(cloneURL, branch, token string) (string, error) {
 	return m.path, m.err
 }
 

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -2,12 +2,15 @@ package worker
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"testing"
 	"time"
 
 	"agentdock/internal/bot"
+	"agentdock/internal/crypto"
 	"agentdock/internal/queue"
 )
 
@@ -188,5 +191,99 @@ func TestPool_AgentFailurePublishesFailedResult(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("timeout")
+	}
+}
+
+type secretCapturingRunner struct {
+	onRun func(opts bot.RunOptions)
+}
+
+func (r *secretCapturingRunner) Run(ctx context.Context, workDir, prompt string, opts bot.RunOptions) (string, error) {
+	if r.onRun != nil {
+		r.onRun(opts)
+	}
+	return "Analysis done.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "test",
+  "body": "## Problem\nTest",
+  "labels": ["bug"],
+  "confidence": "high",
+  "files_found": 0,
+  "open_questions": 0
+}`, nil
+}
+
+func TestExecuteJob_DecryptsAndMergesSecrets(t *testing.T) {
+	dir := t.TempDir()
+
+	secretKey := make([]byte, 32)
+	rand.Read(secretKey)
+
+	appSecrets := map[string]string{
+		"GH_TOKEN":  "ghp_from_app",
+		"K8S_TOKEN": "k8s_from_app",
+	}
+	secretsJSON, _ := json.Marshal(appSecrets)
+	encrypted, _ := crypto.Encrypt(secretKey, secretsJSON)
+
+	workerSecrets := map[string]string{
+		"GH_TOKEN": "ghp_worker_override",
+	}
+
+	var capturedSecrets map[string]string
+	runner := &secretCapturingRunner{
+		onRun: func(opts bot.RunOptions) {
+			capturedSecrets = opts.Secrets
+		},
+	}
+
+	job := &queue.Job{
+		ID:               "test-job",
+		CloneURL:         "https://github.com/owner/repo.git",
+		EncryptedSecrets: encrypted,
+	}
+
+	deps := executionDeps{
+		attachments:   queue.NewInMemAttachmentStore(),
+		repoCache:     &mockRepo{path: dir},
+		runner:        runner,
+		store:         queue.NewMemJobStore(),
+		secretKey:     secretKey,
+		workerSecrets: workerSecrets,
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+	if result.Status == "failed" {
+		t.Fatalf("job failed: %s", result.Error)
+	}
+
+	if capturedSecrets["GH_TOKEN"] != "ghp_worker_override" {
+		t.Errorf("GH_TOKEN = %q, want ghp_worker_override", capturedSecrets["GH_TOKEN"])
+	}
+	if capturedSecrets["K8S_TOKEN"] != "k8s_from_app" {
+		t.Errorf("K8S_TOKEN = %q, want k8s_from_app", capturedSecrets["K8S_TOKEN"])
+	}
+}
+
+func TestExecuteJob_NoSecretKey_EncryptedSecrets_Fails(t *testing.T) {
+	dir := t.TempDir()
+
+	job := &queue.Job{
+		ID:               "test-job",
+		CloneURL:         "https://github.com/owner/repo.git",
+		EncryptedSecrets: []byte("some-encrypted-data"),
+	}
+
+	deps := executionDeps{
+		attachments: queue.NewInMemAttachmentStore(),
+		repoCache:   &mockRepo{path: dir},
+		runner:      &mockRunner{output: "ok"},
+		store:       queue.NewMemJobStore(),
+		secretKey:   nil,
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+	if result.Status != "failed" {
+		t.Error("expected job to fail when EncryptedSecrets present but no secretKey")
 	}
 }


### PR DESCRIPTION
## Summary

- App 集中管理 secrets（config 明碼 + `AGENTDOCK_SECRET_*` 環境變數），AES-256-GCM 加密後透過 Redis Job 傳遞給 worker
- Worker 解密後與本地 secrets merge（worker 優先），注入 `cmd.Env` 給 CLI agent + 傳給 `RepoCache` 做 git clone 認證
- `Job.CloneURL` 不再包含 token，消除 Redis 中的明文洩漏
- `RepoCache.EnsureRepo` 支援 per-call token，token 變更時自動 `git remote set-url`
- Worker 啟動時必須提供 `secret_key`，並透過 Redis beacon 驗證與 app 的 key 一致
- 互動式 preflight 支援：app 可自動產生 key，worker 需手動貼入 app 的 key

## Files Changed (21 files, +736/-27)

| 區塊 | 檔案 | 說明 |
|------|------|------|
| Crypto | `internal/crypto/aes.go` | AES-256-GCM Encrypt/Decrypt |
| Crypto | `internal/crypto/beacon.go` | Redis beacon 寫入/驗證 |
| Config | `internal/config/config.go` | `SecretKey`, `Secrets` 欄位 + `AGENTDOCK_SECRET_*` 掃描 + `DecodeSecretKey` |
| Queue | `internal/queue/job.go` | `EncryptedSecrets` 欄位 |
| Agent | `internal/bot/agent.go` | `RunOptions.Secrets` 通用注入 + `githubToken` fallback |
| Repo | `internal/github/repo.go` | `EnsureRepo` per-call token + conditional `set-url` |
| Workflow | `internal/bot/workflow.go` | 加密 secrets + `CloneURL` 不含 token + `secretKey` decode once |
| Retry | `internal/bot/retry_handler.go` | 傳播 `EncryptedSecrets` |
| Worker | `internal/worker/executor.go` | 解密 + merge + inject |
| Worker | `internal/worker/pool.go` | Pool Config 傳遞 `SecretKey`/`WorkerSecrets` |
| Startup | `cmd/agentdock/app.go` | 寫入 beacon |
| Startup | `cmd/agentdock/worker.go` | Decode secret key |
| Startup | `cmd/agentdock/preflight.go` | 互動式 `secret_key` prompt + beacon 驗證 |
| Adapter | `cmd/agentdock/adapters.go` | `Prepare` token 參數 |

## Related Issues

- Closes #56
- Sub-issue: #57 (nack/requeue — worker 無法處理的 job 應退回 queue，不在此 PR 範圍)

## Test plan

- [x] 235 tests pass, 0 failures
- [x] AES round-trip, wrong key, corrupt data, empty plaintext
- [x] Secret injection into cmd.Env + githubToken fallback
- [x] Config: resolveSecrets auto-merge, AGENTDOCK_SECRET_* scan, DecodeSecretKey validation
- [x] Worker: decrypt + merge (worker override wins), missing secret_key fails job
- [x] RepoCache: per-call token, URL fallback
- [x] Preflight: needsInput includes SecretKey
- [ ] Manual: 啟動 app → 寫入 beacon → 啟動 worker → beacon 驗證通過
- [ ] Manual: worker 用錯誤的 key 啟動 → preflight 階段就被擋下

🤖 Generated with [Claude Code](https://claude.com/claude-code)