### PR TITLE
fix: distinguish user cancellation from agent failure (#36)

### DIFF
--- a/cmd/agentdock/app.go
+++ b/cmd/agentdock/app.go
@@ -235,6 +235,7 @@ func runApp(cfg *config.Config) error {
 		JobTimeout:     cfg.Queue.JobTimeout,
 		IdleTimeout:    cfg.Queue.AgentIdleTimeout,
 		PrepareTimeout: cfg.Queue.PrepareTimeout,
+		CancelTimeout:  cfg.Queue.CancelTimeout,
 	}, queueLogger,
 		queue.WithWatchdogKillHook(func(reason string) {
 			metrics.WatchdogKillsTotal.WithLabelValues(reason).Inc()
@@ -373,9 +374,14 @@ func runApp(cfg *config.Config) error {
 					case strings.HasPrefix(action.ActionID, "cancel_job"):
 						jobID := action.Value
 						state, err := jobStore.Get(jobID)
-						if err == nil && state.Status != queue.JobFailed && state.Status != queue.JobCompleted {
+						if err == nil &&
+							state.Status != queue.JobFailed &&
+							state.Status != queue.JobCompleted &&
+							state.Status != queue.JobCancelled {
+							// Order matters: UpdateStatus BEFORE Send so the worker's classifyResult
+							// observes JobCancelled when ctx cancellation propagates.
+							jobStore.UpdateStatus(jobID, queue.JobCancelled)
 							bundle.Commands.Send(context.Background(), queue.Command{JobID: jobID, Action: "kill"})
-							jobStore.UpdateStatus(jobID, queue.JobFailed)
 							slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":stop_sign: 正在取消...")
 							handler.ClearThreadDedup(cb.Channel.ID, state.Job.ThreadTS)
 						} else {

--- a/docs/superpowers/plans/2026-04-17-cancel-vs-failure.md
+++ b/docs/superpowers/plans/2026-04-17-cancel-vs-failure.md
@@ -1,0 +1,1580 @@
+# Distinguish User Cancellation from Agent Failure — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Slack "取消" button produce a clean cancelled state end-to-end (Slack, logs, metrics, GitHub), while keeping true agent failures and admin force-kills routed as `failed`.
+
+**Architecture:** Introduce a `JobCancelled` status. The executor classifies each error site by reading the store — user cancels set `JobCancelled` before sending kill, everything else leaves the store at `JobRunning`/`JobFailed`. A watchdog fallback publishes `cancelled` if the worker crashes mid-cancel. Design A in the result listener (store pre-check) handles the completed-before-cancel race.
+
+**Tech Stack:** Go 1.22+, `log/slog`, `context`, `prometheus/client_golang`. Tests use the standard `testing` package; integration tests under `internal/worker/pool_test.go` use `InMemBundle` helpers from `internal/queue`.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md`
+
+**Worktree hint:** This plan touches 19 files across queue / worker / bot / config / cmd. Run all tests from repo root with `go test ./...` at the end of each task. Individual test commands are per-task below.
+
+---
+
+## File Structure
+
+Created:
+- `internal/worker/executor_test.go` — classifier unit tests
+- `internal/bot/agent_test.go` may gain new cases (file already exists; we extend it)
+
+Modified:
+- `internal/queue/job.go` — `JobCancelled`, `CancelledAt` field
+- `internal/queue/memstore.go` — stamp `CancelledAt`
+- `internal/queue/memstore_test.go` — assertions for stamping
+- `internal/queue/registry.go` — split `Register` → `RegisterPending` + `SetStarted`
+- `internal/queue/registry_test.go` — migrated tests + new assertions
+- `internal/queue/watchdog.go` — cancel reorder, `publishCancelledFallback`, back-off, config
+- `internal/queue/watchdog_test.go` — fallback + skip + back-off assertions
+- `internal/queue/httpstatus.go` — admin guard extension
+- `internal/worker/executor.go` — `classifyResult`, `cancelledResult`, pre-`Prepare` guard, call-site migration
+- `internal/worker/pool.go` — lifecycle `defer`s, switch short-circuit, race re-read, cancelled log
+- `internal/worker/pool_test.go` — cancellation scenarios
+- `internal/bot/agent.go` — provider chain early-return on ctx.Canceled
+- `internal/bot/result_listener.go` — Design A pre-check, `handleCancellation`, log switch, metrics branches
+- `internal/bot/result_listener_test.go` — cancellation + race assertions
+- `internal/config/config.go` — `CancelTimeout` in `QueueConfig`, default 60s
+- `internal/config/config_test.go` — default + override
+- `cmd/agentdock/app.go` — cancel handler order, extended guard, pipe CancelTimeout into `WatchdogConfig`
+
+---
+
+## Task 1: Data Model Changes
+
+**Files:**
+- Modify: `internal/queue/job.go`
+
+- [ ] **Step 1: Add `JobCancelled` constant and `CancelledAt` field**
+
+Open `internal/queue/job.go`. In the `JobStatus` const block (around line 10), append:
+
+```go
+const (
+    JobPending   JobStatus = "pending"
+    JobPreparing JobStatus = "preparing"
+    JobRunning   JobStatus = "running"
+    JobCompleted JobStatus = "completed"
+    JobFailed    JobStatus = "failed"
+    JobCancelled JobStatus = "cancelled"
+)
+```
+
+In the `JobState` struct (around line 85), add `CancelledAt`:
+
+```go
+type JobState struct {
+    Job         *Job
+    Status      JobStatus
+    Position    int
+    WorkerID    string
+    StartedAt   time.Time
+    WaitTime    time.Duration
+    AgentStatus *StatusReport
+    CancelledAt time.Time
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `go build ./...`
+Expected: exits 0 (no output).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/queue/job.go
+git commit -m "feat(queue): add JobCancelled status and CancelledAt timestamp"
+```
+
+---
+
+## Task 2: MemJobStore stamps CancelledAt
+
+**Files:**
+- Modify: `internal/queue/memstore.go:58-71`
+- Modify: `internal/queue/memstore_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/queue/memstore_test.go`:
+
+```go
+func TestMemJobStore_UpdateStatus_StampsCancelledAt(t *testing.T) {
+    s := NewMemJobStore()
+    s.Put(&Job{ID: "j1"})
+
+    before := time.Now()
+    if err := s.UpdateStatus("j1", JobCancelled); err != nil {
+        t.Fatalf("UpdateStatus: %v", err)
+    }
+    state, _ := s.Get("j1")
+    if state.CancelledAt.IsZero() {
+        t.Fatal("CancelledAt should be stamped")
+    }
+    if state.CancelledAt.Before(before) {
+        t.Errorf("CancelledAt (%v) earlier than call start (%v)", state.CancelledAt, before)
+    }
+}
+
+func TestMemJobStore_UpdateStatus_CancelledAtIdempotent(t *testing.T) {
+    s := NewMemJobStore()
+    s.Put(&Job{ID: "j1"})
+
+    s.UpdateStatus("j1", JobCancelled)
+    state, _ := s.Get("j1")
+    first := state.CancelledAt
+
+    time.Sleep(5 * time.Millisecond)
+    s.UpdateStatus("j1", JobCancelled)
+    state, _ = s.Get("j1")
+
+    if !state.CancelledAt.Equal(first) {
+        t.Errorf("second UpdateStatus should not re-stamp; first=%v second=%v", first, state.CancelledAt)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/queue/ -run TestMemJobStore_UpdateStatus_Cancelled -v`
+Expected: FAIL — `CancelledAt should be stamped` (field is zero).
+
+- [ ] **Step 3: Implement the stamping**
+
+In `internal/queue/memstore.go`, extend `UpdateStatus` (existing code at lines 58-71) to stamp on transition:
+
+```go
+func (s *MemJobStore) UpdateStatus(jobID string, status JobStatus) error {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    state, ok := s.jobs[jobID]
+    if !ok {
+        return fmt.Errorf("job %q not found", jobID)
+    }
+    state.Status = status
+    if status == JobRunning && state.StartedAt.IsZero() {
+        state.StartedAt = time.Now()
+        state.WaitTime = state.StartedAt.Sub(state.Job.SubmittedAt)
+    }
+    if status == JobCancelled && state.CancelledAt.IsZero() {
+        state.CancelledAt = time.Now()
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/queue/ -run TestMemJobStore_UpdateStatus_Cancelled -v`
+Expected: PASS for both tests.
+
+- [ ] **Step 5: Run full queue package**
+
+Run: `go test ./internal/queue/ -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/queue/memstore.go internal/queue/memstore_test.go
+git commit -m "feat(queue): stamp CancelledAt when transitioning to JobCancelled"
+```
+
+---
+
+## Task 3: ProcessRegistry — split Register
+
+**Files:**
+- Modify: `internal/queue/registry.go`
+- Modify: `internal/queue/registry_test.go`
+
+Keeps the existing `Register` method alive for now (removed in Task 10 after pool migrates). Adds `RegisterPending` and `SetStarted` plus tests that cover cancel-before-start.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/queue/registry_test.go`:
+
+```go
+func TestProcessRegistry_RegisterPendingThenKill(t *testing.T) {
+    reg := NewProcessRegistry()
+    ctx, cancel := context.WithCancel(context.Background())
+
+    reg.RegisterPending("j1", cancel)
+
+    go func() {
+        <-ctx.Done()
+        time.Sleep(10 * time.Millisecond)
+        reg.Remove("j1")
+    }()
+
+    if err := reg.Kill("j1"); err != nil {
+        t.Fatalf("Kill: %v", err)
+    }
+    if ctx.Err() == nil {
+        t.Error("context should be cancelled after Kill on pending entry")
+    }
+}
+
+func TestProcessRegistry_SetStartedAfterPending(t *testing.T) {
+    reg := NewProcessRegistry()
+    _, cancel := context.WithCancel(context.Background())
+
+    reg.RegisterPending("j1", cancel)
+    reg.SetStarted("j1", 42, "claude")
+
+    agent, ok := reg.Get("j1")
+    if !ok {
+        t.Fatal("expected agent entry")
+    }
+    if agent.PID != 42 {
+        t.Errorf("PID = %d, want 42", agent.PID)
+    }
+    if agent.Command != "claude" {
+        t.Errorf("Command = %q, want claude", agent.Command)
+    }
+    if agent.StartedAt.IsZero() {
+        t.Error("StartedAt should be set by SetStarted")
+    }
+}
+
+func TestProcessRegistry_SetStartedWithoutPendingIsNoop(t *testing.T) {
+    reg := NewProcessRegistry()
+    reg.SetStarted("unknown", 1, "x") // must not panic
+    if _, ok := reg.Get("unknown"); ok {
+        t.Error("SetStarted without RegisterPending should not create an entry")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/queue/ -run TestProcessRegistry_ -v`
+Expected: FAIL on the new three with `reg.RegisterPending undefined` / `reg.SetStarted undefined`.
+
+- [ ] **Step 3: Add the new methods**
+
+In `internal/queue/registry.go`, after the existing `Register` function (around line 45), add:
+
+```go
+func (r *ProcessRegistry) RegisterPending(jobID string, cancel context.CancelFunc) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.processes[jobID] = &RunningAgent{
+        JobID:  jobID,
+        cancel: cancel,
+        done:   make(chan struct{}),
+    }
+}
+
+func (r *ProcessRegistry) SetStarted(jobID string, pid int, command string) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    if a, ok := r.processes[jobID]; ok {
+        a.PID = pid
+        a.Command = command
+        a.StartedAt = time.Now()
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/queue/ -run TestProcessRegistry_ -v`
+Expected: all four PASS (existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/queue/registry.go internal/queue/registry_test.go
+git commit -m "feat(registry): add RegisterPending and SetStarted"
+```
+
+---
+
+## Task 4: Executor classifier
+
+**Files:**
+- Modify: `internal/worker/executor.go`
+- Create: `internal/worker/executor_test.go`
+
+Adds the classifier without migrating existing call sites yet; they stay on `failedResult` until Task 5.
+
+- [ ] **Step 1: Create failing test file**
+
+Create `internal/worker/executor_test.go`:
+
+```go
+package worker
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "testing"
+    "time"
+
+    "agentdock/internal/queue"
+)
+
+func TestClassifyResult_UserCancel(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "j1"})
+    store.UpdateStatus("j1", queue.JobCancelled)
+
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    job := &queue.Job{ID: "j1"}
+    result := classifyResult(job, time.Now(), fmt.Errorf("killed"), "/tmp/repo", ctx, store)
+
+    if result.Status != "cancelled" {
+        t.Errorf("status = %q, want cancelled", result.Status)
+    }
+    if result.RepoPath != "/tmp/repo" {
+        t.Errorf("RepoPath = %q, want /tmp/repo", result.RepoPath)
+    }
+    if result.Error != "" {
+        t.Errorf("Error should be empty for cancelled, got %q", result.Error)
+    }
+}
+
+func TestClassifyResult_WatchdogKillFallsThroughToFailed(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "j1"})
+    store.UpdateStatus("j1", queue.JobFailed)
+
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+        fmt.Errorf("killed"), "/tmp/repo", ctx, store)
+
+    if result.Status != "failed" {
+        t.Errorf("status = %q, want failed", result.Status)
+    }
+    if result.Error == "" {
+        t.Error("Error should be populated for failed")
+    }
+}
+
+func TestClassifyResult_RunningStoreIsFailed(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "j1"})
+    store.UpdateStatus("j1", queue.JobRunning)
+
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+        errors.New("exit 143"), "/tmp/repo", ctx, store)
+
+    if result.Status != "failed" {
+        t.Errorf("status = %q, want failed (store not yet JobCancelled)", result.Status)
+    }
+}
+
+func TestClassifyResult_DeadlineExceededIsFailed(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "j1"})
+    store.UpdateStatus("j1", queue.JobCancelled) // even with cancelled store…
+
+    ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+    defer cancel()
+
+    result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+        fmt.Errorf("timeout"), "/tmp/repo", ctx, store)
+
+    if result.Status != "failed" {
+        t.Errorf("DeadlineExceeded must yield failed, got %q", result.Status)
+    }
+}
+
+func TestClassifyResult_NoErrorRoutesToFailed(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "j1"})
+
+    ctx := context.Background()
+    result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+        errors.New("parse failed"), "/tmp/repo", ctx, store)
+
+    if result.Status != "failed" {
+        t.Errorf("status = %q, want failed", result.Status)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/worker/ -run TestClassifyResult -v`
+Expected: FAIL with `undefined: classifyResult`.
+
+- [ ] **Step 3: Implement classifier**
+
+In `internal/worker/executor.go`, add these functions above `failedResult` (around line 191):
+
+```go
+func classifyResult(job *queue.Job, startedAt time.Time, err error, repoPath string, ctx context.Context, store queue.JobStore) *queue.JobResult {
+    if ctx.Err() == context.Canceled {
+        if state, lookupErr := store.Get(job.ID); lookupErr == nil && state.Status == queue.JobCancelled {
+            return cancelledResult(job, startedAt, repoPath)
+        }
+    }
+    return failedResult(job, startedAt, err, repoPath)
+}
+
+func cancelledResult(job *queue.Job, startedAt time.Time, repoPath string) *queue.JobResult {
+    return &queue.JobResult{
+        JobID:      job.ID,
+        Status:     "cancelled",
+        RepoPath:   repoPath,
+        StartedAt:  startedAt,
+        FinishedAt: time.Now(),
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `go test ./internal/worker/ -run TestClassifyResult -v`
+Expected: all five PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/executor.go internal/worker/executor_test.go
+git commit -m "feat(worker): add classifyResult to split cancel from failure"
+```
+
+---
+
+## Task 5: Migrate executor call sites + pre-Prepare guard
+
+**Files:**
+- Modify: `internal/worker/executor.go:41-159`
+
+Switches every failure return in `executeJob` from `failedResult(...)` to `classifyResult(...)` and inserts one ctx check before `Prepare`. `failedResult` remains as a helper used by `classifyResult` internally.
+
+- [ ] **Step 1: Migrate the eight call sites**
+
+Open `internal/worker/executor.go`. Replace each `return failedResult(...)` in `executeJob` with `return classifyResult(..., ctx, deps.store)`. Concretely:
+
+Lines ~52, ~60, ~64, ~68, ~91, ~114, ~128, ~140 — each has shape:
+
+```go
+return failedResult(job, startedAt, <errExpr>, <pathExpr>)
+```
+
+Change each to:
+
+```go
+return classifyResult(job, startedAt, <errExpr>, <pathExpr>, ctx, deps.store)
+```
+
+Preserve the original error expressions and repoPath arguments. Do **not** delete `failedResult` — classifier calls it.
+
+- [ ] **Step 2: Add pre-Prepare ctx guard**
+
+Immediately before the `repoPath, err := deps.repoCache.Prepare(...)` call (currently around line 89), add:
+
+```go
+if err := ctx.Err(); err != nil {
+    return classifyResult(job, startedAt, err, "", ctx, deps.store)
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./...`
+Expected: exits 0.
+
+- [ ] **Step 4: Run executor + package tests**
+
+Run: `go test ./internal/worker/ -v`
+Expected: all PASS (existing pool tests should still pass because nothing meaningful changed in their setup).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/executor.go
+git commit -m "feat(worker): route executor failures through classifier; guard Prepare"
+```
+
+---
+
+## Task 6: Agent runner early-return on ctx.Canceled
+
+**Files:**
+- Modify: `internal/bot/agent.go:55-70`
+- Modify: `internal/bot/agent_test.go`
+
+Stops the provider loop after the first `ctx.Canceled` to eliminate the `所有 agent 已耗盡` spam and change the warn-log verb.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/bot/agent_test.go`:
+
+```go
+func TestAgentRunner_CancelShortCircuitsProviderChain(t *testing.T) {
+    runner := &AgentRunner{
+        agents: []config.AgentConfig{
+            {Command: "nonexistent-agent-one", Args: []string{"{prompt}"}, Timeout: time.Second},
+            {Command: "nonexistent-agent-two", Args: []string{"{prompt}"}, Timeout: time.Second},
+        },
+    }
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    _, err := runner.Run(ctx, slog.Default(), t.TempDir(), "noop", RunOptions{})
+    if err == nil {
+        t.Fatal("expected error on cancelled ctx")
+    }
+    if err.Error() != "cancelled" {
+        t.Errorf("err = %q, want \"cancelled\" (chain must not try the second agent)", err.Error())
+    }
+}
+```
+
+Why the assertion works:
+- Before the fix, both agents are attempted. `exec.CommandContext` fails for each (no binary found), producing `all agents failed: nonexistent-agent-one: ...; nonexistent-agent-two: ...`.
+- After the fix, the first agent fails, `ctx.Err() == context.Canceled` matches, and the runner returns `cancelled` without touching the second.
+
+Ensure these imports exist at the top of `agent_test.go` (add any missing):
+
+```go
+import (
+    "context"
+    "log/slog"
+    "testing"
+    "time"
+
+    "agentdock/internal/config"
+)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/bot/ -run TestAgentRunner_CancelShortCircuits -v`
+Expected: FAIL — with current code, iterating two providers produces an error string like `all agents failed: ...`, not `cancelled`.
+
+- [ ] **Step 3: Implement early-return**
+
+Edit `internal/bot/agent.go` `Run` (lines 55-70). Replace the loop body so cancellation breaks out immediately:
+
+```go
+func (r *AgentRunner) Run(ctx context.Context, logger *slog.Logger, workDir, prompt string, opts RunOptions) (string, error) {
+    var errs []string
+    for i, agent := range r.agents {
+        logger.Info("嘗試 agent", "phase", "處理中", "command", agent.Command, "index", i, "total", len(r.agents), "timeout", agent.Timeout)
+        output, err := r.runOne(ctx, logger, agent, workDir, prompt, opts)
+        if err != nil {
+            if ctx.Err() == context.Canceled {
+                logger.Info("Agent 執行已中斷", "phase", "完成", "command", agent.Command, "index", i)
+                return "", fmt.Errorf("cancelled")
+            }
+            logger.Warn("Agent 失敗", "phase", "失敗", "command", agent.Command, "index", i, "error", err)
+            errs = append(errs, fmt.Sprintf("%s: %s", agent.Command, err))
+            continue
+        }
+        logger.Info("Agent 執行成功", "phase", "完成", "command", agent.Command, "output_len", len(output))
+        return output, nil
+    }
+    logger.Error("所有 agent 已耗盡", "phase", "失敗", "errors", strings.Join(errs, "; "))
+    return "", fmt.Errorf("all agents failed: %s", strings.Join(errs, "; "))
+}
+```
+
+- [ ] **Step 4: Run test to verify PASS**
+
+Run: `go test ./internal/bot/ -run TestAgentRunner_CancelShortCircuits -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full bot package**
+
+Run: `go test ./internal/bot/ -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bot/agent.go internal/bot/agent_test.go
+git commit -m "feat(agent): short-circuit provider chain on ctx.Canceled"
+```
+
+---
+
+## Task 7: Config — CancelTimeout
+
+**Files:**
+- Modify: `internal/config/config.go:65-71,196-204`
+- Modify: `internal/config/config_test.go`
+
+Adds `QueueConfig.CancelTimeout` with default 60s.
+
+- [ ] **Step 1: Write failing tests**
+
+The test file uses a `loadFromString(t, yaml)` helper and the pattern from `TestLoad_TrackingTimeoutDefaults` (line 326) and `TestLoad_TrackingTimeouts` (line 305). Mirror those.
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestLoad_CancelTimeoutDefault(t *testing.T) {
+    cfg := loadFromString(t, `
+agents:
+  claude:
+    command: claude
+`)
+    if cfg.Queue.CancelTimeout != 60*time.Second {
+        t.Errorf("default cancel_timeout = %v, want 60s", cfg.Queue.CancelTimeout)
+    }
+}
+
+func TestLoad_CancelTimeoutOverride(t *testing.T) {
+    cfg := loadFromString(t, `
+queue:
+  cancel_timeout: 20s
+agents:
+  claude:
+    command: claude
+`)
+    if cfg.Queue.CancelTimeout != 20*time.Second {
+        t.Errorf("cancel_timeout = %v, want 20s", cfg.Queue.CancelTimeout)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/config/ -run TestConfig_CancelTimeout -v`
+Expected: FAIL (field doesn't exist).
+
+- [ ] **Step 3: Add field and default**
+
+In `internal/config/config.go`, `QueueConfig` (line 65), add:
+
+```go
+type QueueConfig struct {
+    // ... existing fields ...
+    JobTimeout       time.Duration `yaml:"job_timeout"`
+    AgentIdleTimeout time.Duration `yaml:"agent_idle_timeout"`
+    PrepareTimeout   time.Duration `yaml:"prepare_timeout"`
+    CancelTimeout    time.Duration `yaml:"cancel_timeout"`
+}
+```
+
+In the defaults block (around lines 196-204), append:
+
+```go
+if cfg.Queue.CancelTimeout <= 0 {
+    cfg.Queue.CancelTimeout = 60 * time.Second
+}
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `go test ./internal/config/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add queue.cancel_timeout with 60s default"
+```
+
+---
+
+## Task 8: Watchdog — cancel reorder, fallback, back-off, config wire
+
+**Files:**
+- Modify: `internal/queue/watchdog.go`
+- Modify: `internal/queue/watchdog_test.go`
+
+Adds `CancelTimeout` to `WatchdogConfig`, inserts a `JobCancelled` handler ahead of timeout checks, provides `publishCancelledFallback`, and back-offs `killAndPublish` if a cancellation races.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/queue/watchdog_test.go`:
+
+```go
+func TestWatchdog_CancelFallbackAfterTimeout(t *testing.T) {
+    store := NewMemJobStore()
+    store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+    store.UpdateStatus("j1", JobCancelled)
+    // Force CancelledAt older than cancelTimeout
+    state, _ := store.Get("j1")
+    state.CancelledAt = time.Now().Add(-2 * time.Minute)
+
+    results := NewInMemResultBus(10)
+    defer results.Close()
+    commands := NewInMemCommandBus(10)
+    defer commands.Close()
+
+    var onKillReasons []string
+    wd := NewWatchdog(store, commands, results, WatchdogConfig{
+        JobTimeout:    10 * time.Minute,
+        CancelTimeout: 60 * time.Second,
+    }, slog.Default(), WithWatchdogKillHook(func(r string) { onKillReasons = append(onKillReasons, r) }))
+
+    wd.check()
+
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+    ch, _ := results.Subscribe(ctx)
+
+    select {
+    case r := <-ch:
+        if r.Status != "cancelled" {
+            t.Errorf("status = %q, want cancelled", r.Status)
+        }
+    case <-ctx.Done():
+        t.Fatal("no result published")
+    }
+    if len(onKillReasons) != 1 || onKillReasons[0] != "cancel fallback" {
+        t.Errorf("onKill reasons = %v, want [cancel fallback]", onKillReasons)
+    }
+
+    // Store status should remain JobCancelled (not flipped to JobFailed)
+    state, _ = store.Get("j1")
+    if state.Status != JobCancelled {
+        t.Errorf("store status = %q, want JobCancelled", state.Status)
+    }
+}
+
+func TestWatchdog_CancelWithinTimeoutDoesNotFire(t *testing.T) {
+    store := NewMemJobStore()
+    store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+    store.UpdateStatus("j1", JobCancelled) // CancelledAt is now()
+
+    results := NewInMemResultBus(10)
+    defer results.Close()
+    commands := NewInMemCommandBus(10)
+    defer commands.Close()
+
+    wd := NewWatchdog(store, commands, results, WatchdogConfig{
+        JobTimeout:    10 * time.Minute,
+        CancelTimeout: 60 * time.Second,
+    }, slog.Default())
+
+    wd.check()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+    defer cancel()
+    ch, _ := results.Subscribe(ctx)
+    select {
+    case r := <-ch:
+        t.Fatalf("unexpected publish: %+v", r)
+    case <-ctx.Done():
+        // ok
+    }
+}
+
+func TestWatchdog_CancelStatePreemptsJobTimeout(t *testing.T) {
+    store := NewMemJobStore()
+    store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-30 * time.Minute)})
+    store.UpdateStatus("j1", JobCancelled)
+
+    results := NewInMemResultBus(10)
+    defer results.Close()
+    commands := NewInMemCommandBus(10)
+    defer commands.Close()
+
+    wd := NewWatchdog(store, commands, results, WatchdogConfig{
+        JobTimeout:    1 * time.Minute, // already exceeded
+        CancelTimeout: 0,               // disable fallback
+    }, slog.Default())
+
+    wd.check()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+    defer cancel()
+    ch, _ := results.Subscribe(ctx)
+    select {
+    case r := <-ch:
+        t.Fatalf("expected no publish, got %+v", r)
+    case <-ctx.Done():
+        // ok — cancelled state must not trigger jobTimeout killAndPublish
+    }
+    state, _ := store.Get("j1")
+    if state.Status != JobCancelled {
+        t.Errorf("store flipped to %q, should stay JobCancelled", state.Status)
+    }
+}
+
+func TestWatchdog_KillAndPublishBackOffOnRaceCancel(t *testing.T) {
+    store := NewMemJobStore()
+    store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+    store.UpdateStatus("j1", JobRunning)
+
+    results := NewInMemResultBus(10)
+    defer results.Close()
+    commands := NewInMemCommandBus(10)
+    defer commands.Close()
+
+    wd := NewWatchdog(store, commands, results, WatchdogConfig{}, slog.Default())
+
+    // Simulate race: caller flips to JobCancelled between check() and killAndPublish.
+    store.UpdateStatus("j1", JobCancelled)
+
+    state, _ := store.Get("j1")
+    wd.killAndPublish(state, "job timeout")
+
+    // Store must remain JobCancelled (back-off kicked in).
+    state, _ = store.Get("j1")
+    if state.Status != JobCancelled {
+        t.Errorf("store flipped to %q, back-off failed", state.Status)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `go test ./internal/queue/ -run TestWatchdog_Cancel -v`
+Expected: FAIL (new behaviour not implemented, struct field missing).
+
+- [ ] **Step 3: Extend config and type**
+
+In `internal/queue/watchdog.go`, update `WatchdogConfig`:
+
+```go
+type WatchdogConfig struct {
+    JobTimeout     time.Duration
+    IdleTimeout    time.Duration
+    PrepareTimeout time.Duration
+    CancelTimeout  time.Duration
+}
+```
+
+And `Watchdog`:
+
+```go
+type Watchdog struct {
+    store          JobStore
+    commands       CommandBus
+    results        ResultBus
+    jobTimeout     time.Duration
+    idleTimeout    time.Duration
+    prepareTimeout time.Duration
+    cancelTimeout  time.Duration
+    interval       time.Duration
+    logger         *slog.Logger
+    onKill         func(reason string)
+}
+```
+
+Update `NewWatchdog` to copy `cfg.CancelTimeout` into `w.cancelTimeout`.
+
+- [ ] **Step 4: Reorder check() and add fallback**
+
+Replace `check()` body (around line 81):
+
+```go
+func (w *Watchdog) check() {
+    all, err := w.store.ListAll()
+    if err != nil {
+        w.logger.Warn("Watchdog 列舉工作失敗", "phase", "失敗", "error", err)
+        return
+    }
+
+    now := time.Now()
+    for _, state := range all {
+        // Terminal states (no action needed).
+        if state.Status == JobCompleted || state.Status == JobFailed {
+            continue
+        }
+
+        // Cancelled: wait for worker, fall back after cancelTimeout.
+        if state.Status == JobCancelled {
+            if w.cancelTimeout > 0 && !state.CancelledAt.IsZero() &&
+                now.Sub(state.CancelledAt) > w.cancelTimeout {
+                w.publishCancelledFallback(state)
+            }
+            continue
+        }
+
+        if now.Sub(state.Job.SubmittedAt) > w.jobTimeout {
+            w.killAndPublish(state, "job timeout")
+            continue
+        }
+
+        if state.Status == JobPreparing && w.prepareTimeout > 0 {
+            if state.AgentStatus == nil || state.AgentStatus.LastEventAt.IsZero() {
+                if !state.StartedAt.IsZero() && now.Sub(state.StartedAt) > w.prepareTimeout {
+                    w.killAndPublish(state, "prepare timeout")
+                    continue
+                }
+            }
+        }
+
+        if w.idleTimeout > 0 && state.AgentStatus != nil && !state.AgentStatus.LastEventAt.IsZero() {
+            if now.Sub(state.AgentStatus.LastEventAt) > w.idleTimeout {
+                w.killAndPublish(state, "agent idle timeout")
+                continue
+            }
+        }
+    }
+}
+
+func (w *Watchdog) publishCancelledFallback(state *JobState) {
+    if w.onKill != nil {
+        w.onKill("cancel fallback")
+    }
+    w.logger.Warn("取消狀態逾時，補發 cancelled result", "phase", "完成",
+        "job_id", state.Job.ID,
+        "cancelled_age", time.Since(state.CancelledAt))
+    if w.results != nil {
+        w.results.Publish(context.Background(), &JobResult{
+            JobID:      state.Job.ID,
+            Status:     "cancelled",
+            FinishedAt: time.Now(),
+        })
+    }
+}
+```
+
+- [ ] **Step 5: Add killAndPublish back-off**
+
+At the top of `killAndPublish` (before `if w.onKill != nil`), insert:
+
+```go
+// Back off if the job was cancelled in the race window.
+if fresh, _ := w.store.Get(state.Job.ID); fresh != nil && fresh.Status == JobCancelled {
+    return
+}
+```
+
+- [ ] **Step 6: Run tests to verify PASS**
+
+Run: `go test ./internal/queue/ -run TestWatchdog -v`
+Expected: existing plus new four all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/queue/watchdog.go internal/queue/watchdog_test.go
+git commit -m "feat(watchdog): handle JobCancelled with fallback and back-off"
+```
+
+---
+
+## Task 9: Admin endpoint guard
+
+**Files:**
+- Modify: `internal/queue/httpstatus.go:178-182`
+
+- [ ] **Step 1: Extend the guard**
+
+In `internal/queue/httpstatus.go`, find the admin kill handler's guard (line 178) and add `JobCancelled`:
+
+```go
+if state.Status == JobCompleted || state.Status == JobFailed || state.Status == JobCancelled {
+    w.WriteHeader(http.StatusConflict)
+    json.NewEncoder(w).Encode(map[string]string{"error": "job not running"})
+    return
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./...`
+Expected: exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/queue/httpstatus.go
+git commit -m "fix(queue): admin force-kill guard includes JobCancelled"
+```
+
+---
+
+## Task 10: Pool migration — RegisterPending wiring, switch short-circuit, race re-read, cancelled log
+
+**Files:**
+- Modify: `internal/worker/pool.go`
+- Modify: `internal/worker/pool_test.go`
+- Modify: `internal/queue/registry.go` (removal of old `Register`)
+- Modify: `internal/queue/registry_test.go` (drop two test cases that exercised removed `Register`)
+
+This is the largest single change. It migrates pool's registry usage, replaces the short-circuit with a switch covering `JobCancelled` and `JobFailed`, adds the race re-read, changes the final log to distinguish cancelled, and removes the now-unused `Register` method.
+
+- [ ] **Step 1: Write failing pool tests**
+
+Append to `internal/worker/pool_test.go`:
+
+```go
+func TestPool_ShortCircuitsCancelledJobAsCancelled(t *testing.T) {
+    store := queue.NewMemJobStore()
+    bundle := queue.NewInMemBundle(10, 3, store)
+    defer bundle.Close()
+
+    job := &queue.Job{ID: "jc", Repo: "o/r", SubmittedAt: time.Now()}
+    store.Put(job)
+    store.UpdateStatus("jc", queue.JobCancelled)
+
+    pool := NewPool(Config{
+        Queue:       bundle.Queue,
+        Attachments: bundle.Attachments,
+        Results:     bundle.Results,
+        Store:       store,
+        Runner:      &mockRunner{},
+        RepoCache:   &mockRepo{},
+        WorkerCount: 1,
+        Logger:      slog.Default(),
+    })
+
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    pool.Start(ctx)
+
+    if err := bundle.Queue.Submit(ctx, job); err != nil {
+        t.Fatalf("Submit: %v", err)
+    }
+
+    ch, _ := bundle.Results.Subscribe(ctx)
+    select {
+    case r := <-ch:
+        if r.Status != "cancelled" {
+            t.Errorf("status = %q, want cancelled", r.Status)
+        }
+    case <-ctx.Done():
+        t.Fatal("no result")
+    }
+}
+
+func TestPool_ShortCircuitsFailedJobAsFailed(t *testing.T) {
+    store := queue.NewMemJobStore()
+    bundle := queue.NewInMemBundle(10, 3, store)
+    defer bundle.Close()
+
+    job := &queue.Job{ID: "jf", Repo: "o/r", SubmittedAt: time.Now()}
+    store.Put(job)
+    store.UpdateStatus("jf", queue.JobFailed)
+
+    pool := NewPool(Config{
+        Queue:       bundle.Queue,
+        Attachments: bundle.Attachments,
+        Results:     bundle.Results,
+        Store:       store,
+        Runner:      &mockRunner{},
+        RepoCache:   &mockRepo{},
+        WorkerCount: 1,
+        Logger:      slog.Default(),
+    })
+
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    pool.Start(ctx)
+
+    if err := bundle.Queue.Submit(ctx, job); err != nil {
+        t.Fatalf("Submit: %v", err)
+    }
+
+    ch, _ := bundle.Results.Subscribe(ctx)
+    select {
+    case r := <-ch:
+        if r.Status != "failed" {
+            t.Errorf("status = %q, want failed", r.Status)
+        }
+    case <-ctx.Done():
+        t.Fatal("no result")
+    }
+}
+
+type blockingRunner struct {
+    started chan struct{}
+}
+
+func (b *blockingRunner) Run(ctx context.Context, workDir, prompt string, opts bot.RunOptions) (string, error) {
+    if opts.OnStarted != nil {
+        opts.OnStarted(1234, "fake")
+    }
+    close(b.started)
+    <-ctx.Done()
+    return "", ctx.Err()
+}
+
+func TestPool_KillOnRunningAgentProducesCancelledResult(t *testing.T) {
+    store := queue.NewMemJobStore()
+    bundle := queue.NewInMemBundle(10, 3, store)
+    defer bundle.Close()
+
+    job := &queue.Job{ID: "jrun", Repo: "o/r", SubmittedAt: time.Now()}
+    store.Put(job)
+
+    runner := &blockingRunner{started: make(chan struct{})}
+    pool := NewPool(Config{
+        Queue:       bundle.Queue,
+        Attachments: bundle.Attachments,
+        Results:     bundle.Results,
+        Store:       store,
+        Runner:      runner,
+        RepoCache:   &mockRepo{path: "/tmp/r"},
+        Commands:    bundle.Commands,
+        WorkerCount: 1,
+        Logger:      slog.Default(),
+    })
+
+    ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+    defer cancel()
+    pool.Start(ctx)
+
+    if err := bundle.Queue.Submit(ctx, job); err != nil {
+        t.Fatalf("Submit: %v", err)
+    }
+
+    <-runner.started
+    // User cancel: mark store then send kill.
+    store.UpdateStatus("jrun", queue.JobCancelled)
+    bundle.Commands.Send(ctx, queue.Command{JobID: "jrun", Action: "kill"})
+
+    ch, _ := bundle.Results.Subscribe(ctx)
+    select {
+    case r := <-ch:
+        if r.Status != "cancelled" {
+            t.Errorf("status = %q, want cancelled", r.Status)
+        }
+    case <-ctx.Done():
+        t.Fatal("no result")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/worker/ -run TestPool_ShortCircuits -v`
+Expected: FAIL — `TestPool_ShortCircuitsFailedJobAsFailed` expects the worker to publish `failed` (currently publishes with the old `JobFailed` branch which would short-circuit as `failed` — this may actually already pass). `TestPool_ShortCircuitsCancelledJobAsCancelled` will FAIL because current pool publishes `failed` for JobFailed only and doesn't know about JobCancelled.
+
+Run: `go test ./internal/worker/ -run TestPool_KillOnRunningAgent -v`
+Expected: FAIL — currently returns `failed`.
+
+- [ ] **Step 3: Migrate executeWithTracking registry wiring**
+
+Open `internal/worker/pool.go`. In `executeWithTracking` (line 113), restructure so lifecycle is defer-managed:
+
+```go
+func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *queue.Job) {
+    logger := p.cfg.Logger.With("worker_id", workerIndex, "job_id", job.ID)
+    jobCtx, jobCancel := context.WithCancel(ctx)
+    defer jobCancel()
+
+    p.registry.RegisterPending(job.ID, jobCancel)
+    defer p.registry.Remove(job.ID)
+
+    // Race mitigation: close the gap between queue-check and RegisterPending
+    // for both cancel and admin-failed states.
+    if s, _ := p.cfg.Store.Get(job.ID); s != nil &&
+        (s.Status == queue.JobCancelled || s.Status == queue.JobFailed) {
+        jobCancel()
+    }
+
+    wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, workerIndex)
+
+    status := &statusAccumulator{
+        jobID:    job.ID,
+        workerID: wID,
+        alive:    true,
+    }
+
+    var stopReporter chan struct{}
+
+    opts := bot.RunOptions{
+        OnStarted: func(pid int, command string) {
+            status.setPID(pid, command)
+            p.registry.SetStarted(job.ID, pid, command)
+            logger.Info("Agent 已註冊", "phase", "處理中", "pid", pid, "command", command)
+
+            if p.cfg.Status != nil {
+                p.cfg.Status.Report(jobCtx, status.toReport())
+                stopReporter = make(chan struct{})
+                interval := p.cfg.StatusInterval
+                if interval <= 0 {
+                    interval = 5 * time.Second
+                }
+                go p.reportStatus(jobCtx, status, interval, stopReporter)
+            }
+        },
+        OnEvent: func(event queue.StreamEvent) {
+            status.recordEvent(event)
+        },
+    }
+
+    if err := p.cfg.Queue.Ack(jobCtx, job.ID); err != nil {
+        logger.Error("ack failed", "error", err)
+        p.cfg.Results.Publish(ctx, &queue.JobResult{
+            JobID: job.ID, Status: "failed", Error: fmt.Sprintf("ack failed: %v", err),
+        })
+        if stopReporter != nil {
+            close(stopReporter)
+        }
+        return
+    }
+
+    p.cfg.Store.SetWorker(job.ID, wID)
+
+    deps := executionDeps{
+        attachments:   p.cfg.Attachments,
+        repoCache:     p.cfg.RepoCache,
+        runner:        p.cfg.Runner,
+        store:         p.cfg.Store,
+        skillDirs:     p.cfg.SkillDirs,
+        secretKey:     p.cfg.SecretKey,
+        workerSecrets: p.cfg.WorkerSecrets,
+    }
+
+    result := executeJob(jobCtx, job, deps, opts, logger)
+    status.setPrepareSeconds(result.PrepareSeconds)
+
+    status.alive = false
+    if p.cfg.Status != nil {
+        p.cfg.Status.Report(ctx, status.toReport())
+    }
+
+    if stopReporter != nil {
+        close(stopReporter)
+    }
+
+    if result.RepoPath != "" {
+        if err := p.cfg.RepoCache.RemoveWorktree(result.RepoPath); err != nil {
+            logger.Warn("Worktree 清理失敗", "phase", "失敗", "path", result.RepoPath, "error", err)
+        }
+    }
+
+    p.cfg.Store.UpdateStatus(job.ID, queue.JobStatus(result.Status))
+    if err := p.cfg.Results.Publish(ctx, result); err != nil {
+        logger.Error("failed to publish result", "error", err)
+    }
+
+    if result.Status == "cancelled" {
+        logger.Info("工作已取消", "phase", "完成")
+    } else {
+        logger.Info("工作完成", "phase", "完成", "status", result.Status)
+    }
+}
+```
+
+The explicit `p.registry.Remove(job.ID)` at the tail is removed (covered by `defer`).
+
+- [ ] **Step 4: Replace runWorker short-circuit**
+
+In `internal/worker/pool.go runWorker` (around lines 96-104), replace the existing `if err != nil || state.Status == queue.JobFailed { ... continue }` block with:
+
+```go
+state, err := p.cfg.Store.Get(job.ID)
+if err != nil {
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID: job.ID, Status: "failed", Error: "state lookup failed",
+    })
+    continue
+}
+switch state.Status {
+case queue.JobCancelled:
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID: job.ID, Status: "cancelled",
+    })
+    continue
+case queue.JobFailed:
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID: job.ID, Status: "failed", Error: "cancelled before execution",
+    })
+    continue
+}
+p.executeWithTracking(ctx, id, job)
+```
+
+- [ ] **Step 5: Remove the old `Register` method**
+
+Open `internal/queue/registry.go`. Delete the existing `Register(jobID string, pid int, command string, cancel context.CancelFunc)` function.
+
+Open `internal/queue/registry_test.go`. Delete `TestProcessRegistry_RegisterAndKill` and `TestProcessRegistry_RemoveClosesDone` (they exercised the removed API). Keep `TestProcessRegistry_KillNotFound`, `TestProcessRegistry_RegisterPendingThenKill`, `TestProcessRegistry_SetStartedAfterPending`, `TestProcessRegistry_SetStartedWithoutPendingIsNoop`.
+
+- [ ] **Step 6: Verify build**
+
+Run: `go build ./...`
+Expected: exits 0. No remaining `registry.Register` callers.
+
+- [ ] **Step 7: Run worker + queue tests**
+
+Run: `go test ./internal/worker/ ./internal/queue/ -v`
+Expected: all PASS including the three new pool tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/worker/pool.go internal/worker/pool_test.go internal/queue/registry.go internal/queue/registry_test.go
+git commit -m "feat(worker): switch short-circuit, RegisterPending wiring, cancelled log"
+```
+
+---
+
+## Task 11: Result Listener — Design A, handleCancellation, log switch, metrics
+
+**Files:**
+- Modify: `internal/bot/result_listener.go`
+- Modify: `internal/bot/result_listener_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/bot/result_listener_test.go`:
+
+```go
+func TestResultListener_CancelledResultUpdatesSlack(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "jcan", Repo: "o/r", ChannelID: "C1", ThreadTS: "T1", StatusMsgTS: "S1"})
+
+    bundle := queue.NewInMemBundle(10, 3, store)
+    defer bundle.Close()
+
+    slackMock := &mockSlackPoster{}
+    listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil, slog.Default())
+
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    go listener.Listen(ctx)
+
+    bundle.Results.Publish(ctx, &queue.JobResult{JobID: "jcan", Status: "cancelled"})
+    time.Sleep(200 * time.Millisecond)
+
+    slackMock.mu.Lock()
+    defer slackMock.mu.Unlock()
+    found := false
+    for _, msg := range slackMock.messages {
+        if strings.Contains(msg, "已取消") {
+            found = true
+        }
+    }
+    if !found {
+        t.Errorf("expected cancelled message, got %v", slackMock.messages)
+    }
+    if len(slackMock.buttons) != 0 {
+        t.Errorf("no retry button expected, got %v", slackMock.buttons)
+    }
+
+    state, _ := store.Get("jcan")
+    if state.Status != queue.JobCancelled {
+        t.Errorf("store status = %q, want JobCancelled", state.Status)
+    }
+}
+
+func TestResultListener_CompletedResultDeferredToCancellationWhenStoreCancelled(t *testing.T) {
+    store := queue.NewMemJobStore()
+    store.Put(&queue.Job{ID: "jrace", Repo: "o/r", ChannelID: "C1", ThreadTS: "T1", StatusMsgTS: "S1"})
+    store.UpdateStatus("jrace", queue.JobCancelled)
+
+    bundle := queue.NewInMemBundle(10, 3, store)
+    defer bundle.Close()
+
+    slackMock := &mockSlackPoster{}
+    github := &mockIssueCreator{url: "https://github.com/o/r/issues/42"}
+    listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, github, nil, slog.Default())
+
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    go listener.Listen(ctx)
+
+    bundle.Results.Publish(ctx, &queue.JobResult{
+        JobID: "jrace", Status: "completed",
+        Title: "Bug", Body: "b", Confidence: "high", FilesFound: 2,
+    })
+    time.Sleep(200 * time.Millisecond)
+
+    slackMock.mu.Lock()
+    defer slackMock.mu.Unlock()
+
+    for _, msg := range slackMock.messages {
+        if strings.Contains(msg, "issues/42") {
+            t.Errorf("issue URL must not be posted when store says cancelled; messages=%v", slackMock.messages)
+        }
+    }
+    found := false
+    for _, msg := range slackMock.messages {
+        if strings.Contains(msg, "已取消") {
+            found = true
+        }
+    }
+    if !found {
+        t.Errorf("expected cancelled message, got %v", slackMock.messages)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/bot/ -run TestResultListener_Cancelled -v`
+Run: `go test ./internal/bot/ -run TestResultListener_CompletedResultDeferredToCancellation -v`
+Expected: FAIL on both.
+
+- [ ] **Step 3: Add `handleCancellation` and pre-check**
+
+Open `internal/bot/result_listener.go`. Edit `handleResult` (starts line 82). After `r.recordMetrics(...)` and before the `switch` block (currently around line 115), add the store pre-check:
+
+```go
+// Design A: user cancellation dominates, regardless of result.Status.
+if state.Status == queue.JobCancelled || result.Status == "cancelled" {
+    r.handleCancellation(state.Job, state, result)
+    r.attachments.Cleanup(ctx, result.JobID)
+    return
+}
+```
+
+Then adjust the `switch` so it no longer handles `"cancelled"` (the pre-check took that branch) — leave `failed`, `low confidence`, degraded, success as-is.
+
+Also replace the top-level log block (lines 104-113) with a switch:
+
+```go
+logger := r.logger.With("job_id", result.JobID, "repo", job.Repo, "status", result.Status)
+switch result.Status {
+case "failed":
+    truncated := result.RawOutput
+    if len(truncated) > 2000 {
+        truncated = truncated[:2000] + "…(truncated)"
+    }
+    logger.Warn("工作失敗", "phase", "降級", "error", result.Error, "raw_output", truncated)
+case "cancelled":
+    logger.Info("工作已取消", "phase", "完成")
+default:
+    logger.Info("工作完成", "phase", "完成", "title", result.Title, "confidence", result.Confidence, "files_found", result.FilesFound)
+}
+```
+
+After the existing `handleFailure` / `createAndPostIssue` / etc methods, add:
+
+```go
+func (r *ResultListener) handleCancellation(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
+    r.store.UpdateStatus(job.ID, queue.JobCancelled)
+    r.updateStatus(job, ":white_check_mark: 已取消")
+    r.clearDedup(job)
+}
+```
+
+- [ ] **Step 4: Extend metrics branches**
+
+In `recordMetrics`, update the with-AgentStatus branch's status derivation:
+
+```go
+status := "success"
+switch result.Status {
+case "failed":
+    if strings.Contains(result.Error, "timeout") {
+        status = "timeout"
+    } else {
+        status = "error"
+    }
+case "cancelled":
+    status = "cancelled"
+}
+metrics.AgentExecutionsTotal.WithLabelValues(provider, status).Inc()
+```
+
+And the without-AgentStatus else-if chain:
+
+```go
+} else if result.Status == "failed" {
+    metrics.AgentExecutionsTotal.WithLabelValues("unknown", "error").Inc()
+} else if result.Status == "cancelled" {
+    metrics.AgentExecutionsTotal.WithLabelValues("unknown", "cancelled").Inc()
+}
+```
+
+- [ ] **Step 5: Run tests to verify PASS**
+
+Run: `go test ./internal/bot/ -v`
+Expected: all PASS including the two new cancellation tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bot/result_listener.go internal/bot/result_listener_test.go
+git commit -m "feat(bot): handle cancelled results with store-first semantics"
+```
+
+---
+
+## Task 12: App cancel handler — order fix, extended guard, wire CancelTimeout
+
+**Files:**
+- Modify: `cmd/agentdock/app.go`
+
+- [ ] **Step 1: Update the cancel_job handler**
+
+Find the `case strings.HasPrefix(action.ActionID, "cancel_job"):` block (around line 373). Replace with:
+
+```go
+case strings.HasPrefix(action.ActionID, "cancel_job"):
+    jobID := action.Value
+    state, err := jobStore.Get(jobID)
+    if err == nil &&
+        state.Status != queue.JobFailed &&
+        state.Status != queue.JobCompleted &&
+        state.Status != queue.JobCancelled {
+        // Order matters: UpdateStatus BEFORE Send so the worker's classifyResult
+        // observes JobCancelled when ctx cancellation propagates.
+        jobStore.UpdateStatus(jobID, queue.JobCancelled)
+        bundle.Commands.Send(context.Background(), queue.Command{JobID: jobID, Action: "kill"})
+        slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":stop_sign: 正在取消...")
+        handler.ClearThreadDedup(cb.Channel.ID, state.Job.ThreadTS)
+    } else {
+        slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":information_source: 此任務已結束")
+    }
+```
+
+- [ ] **Step 2: Pass CancelTimeout into WatchdogConfig**
+
+Find where `NewWatchdog(...)` is called in `cmd/agentdock/app.go`. Look for the `WatchdogConfig{...}` literal and add the new field:
+
+```go
+WatchdogConfig{
+    JobTimeout:     cfg.Queue.JobTimeout,
+    IdleTimeout:    cfg.Queue.AgentIdleTimeout,
+    PrepareTimeout: cfg.Queue.PrepareTimeout,
+    CancelTimeout:  cfg.Queue.CancelTimeout,
+}
+```
+
+If the exact `WatchdogConfig` construction is in a separate file or helper, edit there. Use `grep -rn "WatchdogConfig{" cmd internal` to locate.
+
+- [ ] **Step 3: Verify build and full test suite**
+
+Run: `go build ./...`
+Expected: exits 0.
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/agentdock/app.go
+git commit -m "fix(app): order UpdateStatus before kill; wire cancel_timeout; guard cancelled"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 2: Race detector**
+
+Run: `go test -race ./internal/worker/ ./internal/queue/ ./internal/bot/`
+Expected: no data races reported.
+
+- [ ] **Step 3: Manual smoke**
+
+Instructions for the operator (not automatable):
+
+1. `make dev` (or equivalent) to run app + worker locally.
+2. Trigger a triage in a test Slack channel (`@bot` in a thread).
+3. While the agent is running, click the 取消 button.
+4. Verify:
+   - Slack updates to `:stop_sign: 正在取消...`.
+   - Within a few seconds, Slack updates to `:white_check_mark: 已取消`.
+   - No retry button.
+   - Worker log line `[Worker][完成] 工作已取消` appears.
+5. Re-tag the bot in the same thread; triage should work (dedup cleared).
+6. Repeat with the click happening during repo clone (submit a large repo with cold cache). Clone completes, then Slack still ends at `:white_check_mark: 已取消`.
+7. Repeat with a cancelled job that never got to a worker (cancel immediately after submission): the queue-pulling worker should publish `cancelled` via the short-circuit; Slack ends at `:white_check_mark: 已取消`.

--- a/docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md
+++ b/docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md
@@ -14,27 +14,36 @@ When a user clicks the "取消" button in Slack, the app sends a `kill` command 
 
 Root cause: `executeJob` in `internal/worker/executor.go` does not inspect `ctx.Err()` before returning a failed result. The app and worker also lack a dedicated `JobCancelled` status, so every code path converges on `JobFailed`.
 
-A secondary, pre-existing defect surfaced during investigation: `ProcessRegistry.Register` is only called from `OnStarted`, so kill commands issued while the worker is still in the prep phase (attachments, repo clone, skill mount) find no PID and are silently dropped. The user's cancellation takes no effect until the agent eventually starts and later receives SIGTERM — or never, if prep succeeds in one shot and the agent runs to normal completion.
+Investigation also surfaced four related defects:
+
+1. **Kill-during-prep gap.** `ProcessRegistry.Register` is only called from `OnStarted`, so kill commands issued while the worker is still in the prep phase (attachments, repo clone, skill mount) find no PID and are silently dropped.
+2. **Provider chain waste on cancel.** `internal/bot/agent.go Run` iterates through providers. When SIGTERM cancels the ctx, the loop continues to the next provider (whose `exec.CommandContext` fails immediately), each emitting `Agent 失敗` warn and ending with `所有 agent 已耗盡` error.
+3. **Completed-before-cancel race.** If the agent finishes just before the user clicks cancel, the completed result can be processed by `ResultListener` before the user's intent is visible in the store, creating a GitHub issue the user did not want.
+4. **Admin force-kill overlaps.** `internal/queue/httpstatus.go` lets an admin force-kill by setting `JobFailed` and sending a kill command. The pool's short-circuit and the worker's classifier need to handle admin kill without treating it as a user cancel.
+5. **Worker crash during cancel.** If the worker dies between receiving the kill and publishing a result, the Slack message stays on `:stop_sign: 正在取消...` indefinitely because nothing else republishes.
+
+This spec addresses all five.
 
 ## Goals
 
 1. A user-initiated cancellation produces a clean Slack state (`:white_check_mark: 已取消`), no retry button, and no spurious failure log.
 2. Cancellation is honoured at every stage: job still in queue, worker in prep, agent running.
-3. Watchdog timeouts and other true failures continue to surface as `failed` with the existing retry affordance.
-4. Metrics distinguish cancelled jobs from errored jobs, so the agent failure rate is not polluted.
+3. The design reaches a terminal state even when the worker crashes mid-cancel — via a watchdog fallback.
+4. Watchdog timeouts, admin force-kills, and true agent failures continue to surface as `failed` with the existing retry affordance.
+5. Metrics distinguish cancelled jobs from errored jobs, so the agent failure rate is not polluted.
 
 ## Non-Goals
 
 - Introducing a separate `timeout` status. Watchdog timeouts remain `failed` (as today).
 - Automatic cancellation based on idle detection or cost caps.
 - Letting the user cancel an already-completed job.
-- Changing `RepoProvider.Prepare` to accept a `context.Context`. Cancellation during clone waits for the next natural checkpoint to avoid leaving partial repo state.
+- Changing `RepoProvider.Prepare` to accept a `context.Context`. Cancellation during an in-flight clone waits for the natural boundary to avoid partial repo state.
 
 ## Design
 
 ### 1. Data Model
 
-**`internal/queue/job.go`** — add a status constant:
+**`internal/queue/job.go`** — add a status constant and a cancelled-timestamp field on `JobState`:
 
 ```go
 const (
@@ -45,13 +54,39 @@ const (
     JobFailed    JobStatus = "failed"
     JobCancelled JobStatus = "cancelled" // NEW
 )
+
+type JobState struct {
+    // ... existing fields ...
+    CancelledAt time.Time // NEW — zero-valued unless Status transitions to JobCancelled
+}
 ```
 
-`JobResult.Status` gains a `"cancelled"` string value. No boolean flag is added on `JobResult`; a single status field is the source of truth. `JobResult.Error` is left empty for cancelled results (no user-facing error to display).
+`JobResult.Status` gains a `"cancelled"` string value. No boolean flag is added; a single status field is the source of truth. `JobResult.Error` is left empty for cancelled results.
 
-### 2. Executor Classification
+### 2. Store Behaviour
 
-In `internal/worker/executor.go`, all failure returns route through a single classifier that distinguishes user cancellation from other context cancellations (e.g., watchdog kill):
+`internal/queue/memstore.go` stamps `CancelledAt` when status transitions to `JobCancelled`, mirroring the existing `StartedAt` pattern:
+
+```go
+func (s *MemJobStore) UpdateStatus(jobID string, status JobStatus) error {
+    // ... existing logic ...
+    state.Status = status
+    if status == JobRunning && state.StartedAt.IsZero() {
+        state.StartedAt = time.Now()
+        state.WaitTime = state.StartedAt.Sub(state.Job.SubmittedAt)
+    }
+    if status == JobCancelled && state.CancelledAt.IsZero() { // NEW
+        state.CancelledAt = time.Now()
+    }
+    return nil
+}
+```
+
+Double-calls to `UpdateStatus(JobCancelled)` from both app and result-listener are idempotent — `CancelledAt` preserves the first value.
+
+### 3. Executor Classification
+
+In `internal/worker/executor.go`, all failure returns route through a single classifier that distinguishes user cancellation from other context cancellations (e.g., watchdog kill, admin force-kill):
 
 ```go
 func classifyResult(job *queue.Job, startedAt time.Time, err error, repoPath string, ctx context.Context, store queue.JobStore) *queue.JobResult {
@@ -74,7 +109,7 @@ func cancelledResult(job *queue.Job, startedAt time.Time, repoPath string) *queu
 }
 ```
 
-The store check is the discriminator: the app sets `JobCancelled` before sending the kill command, so a ctx cancellation with matching store state is a user cancel; any other ctx cancellation (including watchdog kill, which leaves the store at `JobRunning` until after kill) falls through to `failedResult`.
+The store check is the discriminator: the app sets `JobCancelled` before sending the kill command (see §6), so a ctx cancellation with matching store state is a user cancel. Any other ctx cancellation — watchdog kill, admin force-kill — leaves the store at `JobRunning`/`JobFailed` and falls through to `failedResult`.
 
 All existing `failedResult(...)` call sites in `executeJob` switch to `classifyResult(...)`:
 - attachments resolve failure
@@ -86,7 +121,43 @@ All existing `failedResult(...)` call sites in `executeJob` switch to `classifyR
 
 `context.DeadlineExceeded` deliberately falls through to `failedResult` so timeouts remain failures.
 
-### 3. Process Registry Lifecycle
+**Pre-Prepare cancellation check.** `RepoProvider.Prepare` does not consume ctx, so a cancellation that arrives while clone is in progress has to wait. But if ctx is already cancelled before we enter Prepare, we can skip the clone entirely:
+
+```go
+// Check cancellation before the expensive non-cancellable clone.
+if err := ctx.Err(); err != nil {
+    return classifyResult(job, startedAt, err, "", ctx, deps.store)
+}
+
+repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, ghToken)
+```
+
+Only this single guard is added; skill mount and decrypt are fast enough to complete without a check, and `attachments.Resolve(ctx, ...)` / `runner.Run(ctx, ...)` honour ctx themselves.
+
+### 4. Agent Runner
+
+`internal/bot/agent.go Run` short-circuits the provider chain on context cancellation so the `所有 agent 已耗盡` spam no longer fires when the user cancels:
+
+```go
+for i, agent := range r.agents {
+    logger.Info("嘗試 agent", ...)
+    output, err := r.runOne(ctx, logger, agent, workDir, prompt, opts)
+    if err != nil {
+        if ctx.Err() == context.Canceled {
+            logger.Info("Agent 執行已中斷", "phase", "完成", "command", agent.Command, "index", i)
+            return "", fmt.Errorf("cancelled")
+        }
+        logger.Warn("Agent 失敗", "phase", "失敗", ...)
+        errs = append(errs, fmt.Sprintf("%s: %s", agent.Command, err))
+        continue
+    }
+    // ... success path unchanged ...
+}
+```
+
+The runner cannot distinguish user cancel from watchdog kill — both are `ctx.Canceled`. That distinction is made one level up, in `classifyResult`. The error string `"cancelled"` is informational only; classification does not rely on it.
+
+### 5. Process Registry Lifecycle
 
 `internal/queue/registry.go` splits registration into two phases so `Kill` works before the agent starts:
 
@@ -116,50 +187,73 @@ func (r *ProcessRegistry) SetStarted(jobID string, pid int, command string) {
 
 `Kill`, `Remove`, and `Get` are unchanged. `Kill` no longer requires a PID to be set; calling `agent.cancel()` is sufficient to propagate cancellation through `ctx` into any `Resolve` / `Prepare` / `Run` call that honours it.
 
-The existing `Register(jobID, pid, command, cancel)` method is removed; no production code outside this call site should use it.
+The existing `Register(jobID, pid, command, cancel)` method is removed; callers migrate to `RegisterPending` + `SetStarted`.
 
-### 4. Pool Integration
+### 6. Pool Integration
 
-`internal/worker/pool.go executeWithTracking`:
+**`internal/worker/pool.go executeWithTracking`** — registry lifecycle is consolidated around defers:
 
 ```go
 jobCtx, jobCancel := context.WithCancel(ctx)
 defer jobCancel()
 
 p.registry.RegisterPending(job.ID, jobCancel)
-defer p.registry.Remove(job.ID)  // consolidates the explicit Remove at end of function
+defer p.registry.Remove(job.ID) // replaces the explicit Remove at end of function
 
-// ... existing status accumulator and opts setup ...
+// Race mitigation: close the window between queue-check and RegisterPending.
+if state, _ := p.cfg.Store.Get(job.ID); state != nil &&
+    (state.Status == queue.JobCancelled || state.Status == queue.JobFailed) {
+    jobCancel()
+}
+
+// ... existing status accumulator, opts ...
 opts := bot.RunOptions{
     OnStarted: func(pid int, command string) {
         status.setPID(pid, command)
         p.registry.SetStarted(job.ID, pid, command) // was Register(...)
-        // ... status reporting start unchanged ...
+        // ... rest unchanged ...
     },
     // ...
 }
 ```
 
-The manual `p.registry.Remove(job.ID)` at the tail of the function is replaced by the top-level `defer`.
+Re-reading for both `JobCancelled` and `JobFailed` also covers admin force-kill arriving in the same tiny window.
 
-`pool.go runWorker` short-circuit when a job is pulled off the queue after the user already cancelled it:
+**`pool.go runWorker`** — queue short-circuit is split by terminal state so the right status propagates:
 
 ```go
 state, err := p.cfg.Store.Get(job.ID)
-if err != nil || state.Status == queue.JobCancelled { // was JobFailed
+if err != nil {
     p.cfg.Results.Publish(ctx, &queue.JobResult{
-        JobID:  job.ID,
-        Status: "cancelled", // was "failed"
+        JobID: job.ID, Status: "failed", Error: "state lookup failed",
+    })
+    continue
+}
+switch state.Status {
+case queue.JobCancelled:
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID: job.ID, Status: "cancelled",
+    })
+    continue
+case queue.JobFailed:
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID: job.ID, Status: "failed", Error: "cancelled before execution",
     })
     continue
 }
 ```
 
-**Race mitigation (small but cheap):** immediately after `RegisterPending`, re-read the store once. If it is already `JobCancelled` (the app set it between queue-pull and registration), call `jobCancel()` so `executeJob`'s classifier returns `cancelled`.
+**Completion log** — final `logger.Info("工作完成", ...)` becomes issue-compliant:
 
-`Prepare(cloneURL, branch, token string)` signature is not changed. If the user cancels during clone, the clone completes (usually seconds), `classifyResult` is called next, sees `ctx.Err() == Canceled` and the cancelled store state, and returns `cancelled`. This trade keeps partial-clone risk out of the picture.
+```go
+if result.Status == "cancelled" {
+    logger.Info("工作已取消", "phase", "完成")
+} else {
+    logger.Info("工作完成", "phase", "完成", "status", result.Status)
+}
+```
 
-### 5. App-Side Cancel Button
+### 7. App-Side Cancel Button
 
 `cmd/agentdock/app.go` cancel handler:
 
@@ -172,7 +266,7 @@ case strings.HasPrefix(action.ActionID, "cancel_job"):
         state.Status != queue.JobCompleted &&
         state.Status != queue.JobCancelled {
         // Order matters: UpdateStatus BEFORE Send so the worker's classifyResult
-        // can observe JobCancelled when ctx cancellation propagates.
+        // observes JobCancelled when ctx cancellation propagates.
         jobStore.UpdateStatus(jobID, queue.JobCancelled)
         bundle.Commands.Send(context.Background(), queue.Command{JobID: jobID, Action: "kill"})
         slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":stop_sign: 正在取消...")
@@ -182,26 +276,39 @@ case strings.HasPrefix(action.ActionID, "cancel_job"):
     }
 ```
 
-The order reversal is load-bearing: the original code does `Send` then `UpdateStatus`, which races against the worker's `classifyResult` store read. Setting `JobCancelled` first and sending `kill` second guarantees the discriminator observes the cancelled state.
+The ordering is load-bearing: the original code does `Send` then `UpdateStatus`, which races against the worker's `classifyResult` store read. Setting `JobCancelled` first and sending `kill` second guarantees the discriminator observes the cancelled state.
 
-The terminal message `:stop_sign: 正在取消...` stays as the intermediate state; the final `:white_check_mark: 已取消` comes from the result listener when the worker confirms.
+`:stop_sign: 正在取消...` stays as the intermediate feedback; the final `:white_check_mark: 已取消` comes from the result listener when the worker (or the watchdog fallback) confirms.
 
-### 6. Result Listener
+### 8. Result Listener
 
-`internal/bot/result_listener.go handleResult` gains a cancelled branch before the failed branch:
+`internal/bot/result_listener.go handleResult` gets three changes:
+
+**Store-state pre-check (Design A).** Before branching on `result.Status`, read the store. If the user has cancelled since the result was published, honour the cancel regardless of what the worker reported. This closes the completed-before-cancel race: an `in-flight completed result` paired with a recent cancel click does not create a GitHub issue.
 
 ```go
-switch {
-case result.Status == "cancelled":
-    r.handleCancellation(job, state, result)
-case result.Status == "failed":
-    r.handleFailure(job, state, result)
-case result.Confidence == "low":
-    // existing low-confidence path
-case result.FilesFound == 0 || result.Questions >= 5:
-    // existing degraded issue path
-default:
-    // existing success path
+func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResult) {
+    // ... existing dedup guard (processedJobs) ...
+    state, err := r.store.Get(result.JobID)
+    if err != nil {
+        r.logger.Error("找不到工作結果對應的工作", ...)
+        return
+    }
+    // ... recordMetrics ...
+
+    // Design A: user cancellation dominates, regardless of result.Status.
+    if state.Status == queue.JobCancelled || result.Status == "cancelled" {
+        r.handleCancellation(state.Job, state, result)
+        r.attachments.Cleanup(ctx, result.JobID)
+        return
+    }
+
+    switch result.Status {
+    case "failed":
+        r.handleFailure(state.Job, state, result)
+    // ... existing branches: low confidence, degraded, success ...
+    }
+    r.attachments.Cleanup(ctx, result.JobID)
 }
 ```
 
@@ -209,7 +316,7 @@ New helper:
 
 ```go
 func (r *ResultListener) handleCancellation(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
-    r.store.UpdateStatus(job.ID, queue.JobCancelled)
+    r.store.UpdateStatus(job.ID, queue.JobCancelled) // no-op if already set
     r.updateStatus(job, ":white_check_mark: 已取消")
     r.clearDedup(job)
 }
@@ -217,11 +324,23 @@ func (r *ResultListener) handleCancellation(job *queue.Job, state *queue.JobStat
 
 No retry button, no issue creation, no error log. Dedup is cleared so the user can re-tag the bot in the same thread if they change their mind.
 
-The top-level log line in `handleResult` acquires a cancelled branch so `[Worker][完成] 工作已取消` appears per the issue's expected behaviour.
-
-`recordMetrics` extends the `status` derivation for `AgentExecutionsTotal`:
+**Log branch.** The top-level log line uses a switch:
 
 ```go
+switch result.Status {
+case "failed":
+    logger.Warn("工作失敗", "phase", "降級", "error", result.Error, "raw_output", truncated)
+case "cancelled":
+    logger.Info("工作已取消", "phase", "完成")
+default:
+    logger.Info("工作完成", "phase", "完成", "title", result.Title, ...)
+}
+```
+
+**Metrics.** `recordMetrics` extends the `status` derivation for `AgentExecutionsTotal`, covering both the with-AgentStatus and without-AgentStatus paths:
+
+```go
+// When AgentStatus is non-nil
 status := "success"
 switch result.Status {
 case "failed":
@@ -234,33 +353,99 @@ case "cancelled":
     status = "cancelled"
 }
 metrics.AgentExecutionsTotal.WithLabelValues(provider, status).Inc()
-```
 
-`RetryHandler.Handle` is untouched: it already rejects any status other than `JobFailed`, so a cancelled job is naturally ineligible for retry even if someone crafts a retry payload.
-
-### 7. Watchdog Alignment
-
-`internal/queue/watchdog.go` must not overwrite a cancelled job with a timeout failure.
-
-In `check()`:
-
-```go
-if state.Status == JobCompleted || state.Status == JobFailed || state.Status == JobCancelled {
-    continue
+// When AgentStatus is nil (prep-phase cancel, short-circuit, etc.)
+} else if result.Status == "failed" {
+    metrics.AgentExecutionsTotal.WithLabelValues("unknown", "error").Inc()
+} else if result.Status == "cancelled" {
+    metrics.AgentExecutionsTotal.WithLabelValues("unknown", "cancelled").Inc()
 }
 ```
 
-In `killAndPublish()`, re-read the store after sending the kill command but before mutating state. If the user cancelled between `check()` and this point, back off and let the worker publish the cancelled result:
+`RetryHandler.Handle` is untouched: it already rejects any status other than `JobFailed`, so a cancelled job is naturally ineligible for retry.
+
+### 9. Watchdog Alignment
+
+`internal/queue/watchdog.go` must not overwrite a cancelled job with a timeout failure, and must recover when the worker never publishes.
+
+**Config.** Add `CancelTimeout time.Duration` (default 60 seconds) to `WatchdogConfig`. Zero or negative disables the fallback (useful for tests).
+
+**`check()` reordering.** `JobCancelled` is handled ahead of the generic `jobTimeout` / `prepareTimeout` / `idleTimeout` checks so stuck cancels aren't misclassified as timeouts:
 
 ```go
+for _, state := range all {
+    // Already terminal.
+    if state.Status == JobCompleted || state.Status == JobFailed {
+        continue
+    }
+    // Cancelled: wait for worker, fall back after cancelTimeout.
+    if state.Status == JobCancelled {
+        if w.cancelTimeout > 0 && !state.CancelledAt.IsZero() &&
+            now.Sub(state.CancelledAt) > w.cancelTimeout {
+            w.publishCancelledFallback(state)
+        }
+        continue
+    }
+    // Regular timeout checks apply only to pending / preparing / running.
+    if now.Sub(state.Job.SubmittedAt) > w.jobTimeout {
+        w.killAndPublish(state, "job timeout")
+        continue
+    }
+    // ... existing prepare / idle checks ...
+}
+```
+
+**`publishCancelledFallback`** — recovery path when the worker never confirms:
+
+```go
+func (w *Watchdog) publishCancelledFallback(state *JobState) {
+    if w.onKill != nil {
+        w.onKill("cancel fallback")
+    }
+    w.logger.Warn("取消狀態逾時，補發 cancelled result", "phase", "完成",
+        "job_id", state.Job.ID,
+        "cancelled_age", time.Since(state.CancelledAt))
+    if w.results != nil {
+        w.results.Publish(context.Background(), &JobResult{
+            JobID:      state.Job.ID,
+            Status:     "cancelled",
+            FinishedAt: time.Now(),
+        })
+    }
+}
+```
+
+No kill is sent (one has already gone out from the app), and `UpdateStatus` is not called because the store is already `JobCancelled`. `ResultListener.processedJobs` dedup drops any late-arriving worker result.
+
+**`killAndPublish` back-off (belt-and-suspenders).** The `check()` reorder alone prevents `killAndPublish` from being called on a cancelled job, but guarding defensively is cheap and resilient to future edits:
+
+```go
+// Immediately before the existing UpdateStatus(JobFailed) + Publish calls.
 fresh, _ := w.store.Get(state.Job.ID)
 if fresh != nil && fresh.Status == JobCancelled {
     return
 }
-// existing UpdateStatus(JobFailed) + Publish failed result
 ```
 
-When the watchdog legitimately times out a job, it proceeds as today. The worker's executor sees `ctx.Err() == Canceled` and a store status of `JobFailed`, so `classifyResult` returns `failed`. The `ResultListener.processedJobs` dedup map drops whichever of {watchdog-published failed, worker-published failed} arrives second.
+When the watchdog legitimately times out a job, it proceeds as today. The worker's executor sees `ctx.Err() == Canceled` with a store status of `JobFailed`, so `classifyResult` returns `failed`. `ResultListener.processedJobs` dedup drops the loser.
+
+### 10. Config Surface
+
+Add `CancelTimeout time.Duration` to `internal/config/config.Config` (yaml key `cancel_timeout`, default 60s). The app constructs `WatchdogConfig.CancelTimeout` from the config value.
+
+### 11. Admin Endpoint
+
+`internal/queue/httpstatus.go` guard extended so admin force-kill does not overwrite a user cancellation:
+
+```go
+if state.Status == JobCompleted || state.Status == JobFailed || state.Status == JobCancelled {
+    w.WriteHeader(http.StatusConflict)
+    json.NewEncoder(w).Encode(map[string]string{"error": "job not running"})
+    return
+}
+```
+
+Admin force-kill still sets `JobFailed` (distinct intent from user cancel) and sends the kill command. The worker's `classifyResult` sees store `JobFailed` and returns `failed`, which `ResultListener` routes through `handleFailure`.
 
 ## Testing
 
@@ -268,56 +453,84 @@ When the watchdog legitimately times out a job, it proceeds as today. The worker
 
 **`internal/worker/executor_test.go`** (new if absent):
 - `classifyResult`: ctx.Canceled + store `JobCancelled` → `cancelled`.
+- `classifyResult`: ctx.Canceled + store `JobFailed` → `failed` (admin-kill path).
 - `classifyResult`: ctx.Canceled + store `JobRunning` → `failed` (watchdog-kill path).
 - `classifyResult`: ctx.DeadlineExceeded + any store state → `failed`.
 - `classifyResult`: err non-nil, ctx OK → `failed`.
+- Pre-`Prepare` ctx check: cancelled ctx returns cancelled result without invoking `Prepare`.
 
-**`internal/queue/registry_test.go`**:
+**`internal/queue/registry_test.go`** — migrate existing `Register(...)` call sites; add:
 - `RegisterPending` then `Kill` cancels the context without needing `SetStarted`.
 - `RegisterPending` → `SetStarted` → `Kill` still records PID / Command correctly.
-- `Kill` on an unknown job still returns the existing error.
+- `Kill` on an unknown job returns the existing error.
+
+**`internal/queue/memstore_test.go`**:
+- `UpdateStatus(JobCancelled)` stamps `CancelledAt`.
+- Subsequent `UpdateStatus(JobCancelled)` does not overwrite the timestamp.
 
 **`internal/bot/result_listener_test.go`**:
 - `result.Status == "cancelled"` → store `JobCancelled`, Slack updated to `:white_check_mark: 已取消`, dedup cleared, no retry button posted.
-- Metrics emit `AgentExecutionsTotal{status="cancelled"}`.
+- `result.Status == "completed"` + store `JobCancelled` (Design A) → routes to `handleCancellation`, no GitHub issue created.
+- Metrics emit `AgentExecutionsTotal{status="cancelled"}` for both with- and without-AgentStatus paths.
+
+**`internal/bot/agent_test.go`** (if absent — otherwise extend):
+- Ctx cancellation mid-run: `Run` returns `"cancelled"` error, does not try the next provider.
+- Logger emits `Agent 執行已中斷` (info), not `Agent 失敗` (warn).
 
 **`internal/queue/watchdog_test.go`**:
-- A `JobCancelled` state past its timeout is skipped by `check()`.
-- `killAndPublish` observing a `JobCancelled` state in the re-read phase exits without UpdateStatus or Publish.
+- A `JobCancelled` state past `CancelTimeout` triggers `publishCancelledFallback` (cancelled result published, store untouched, `onKill("cancel fallback")` fired).
+- A `JobCancelled` state within `CancelTimeout` is not republished.
+- `JobCancelled` + expired `jobTimeout` does NOT invoke `killAndPublish`.
+- `killAndPublish` back-off: a race-set `JobCancelled` during a watchdog kill skips UpdateStatus/Publish.
 
 ### Integration (`internal/worker/pool_test.go`)
 
 Use a controllable fake `Runner` to exercise timing:
 
-1. **Scenario A — queue hit post-cancel:** Put job, set store to `JobCancelled` before the worker pulls. Assert the published result is `cancelled`.
-2. **Scenario B — prep cancel:** Runner sleeps during prep simulation; call `registry.Kill`. Assert `executeJob` exits with a `cancelled` result.
-3. **Scenario C — agent-running cancel:** Runner enters `Run` then blocks; call `registry.Kill`. Assert `cancelled` result.
-4. **Watchdog regression:** Simulate a watchdog kill (store `JobFailed`, ctx cancel). Assert the result is `failed`, not cancelled.
+1. **Scenario A — queue hit post-cancel:** put a job, set store to `JobCancelled` before the worker pulls; assert published result is `cancelled`.
+2. **Scenario A' — queue hit post-admin-kill:** put a job, set store to `JobFailed` before the worker pulls; assert published result is `failed` with `"cancelled before execution"`.
+3. **Scenario B — prep cancel:** Runner sleeps during prep simulation; call `registry.Kill` and assert cancelled result.
+4. **Scenario B-race — pre-Prepare guard:** set store to `JobCancelled` before Prepare runs; assert `Prepare` is not invoked and the result is cancelled.
+5. **Scenario C — agent-running cancel:** Runner enters `Run` then blocks; call `registry.Kill`; assert cancelled result.
+6. **Watchdog regression:** simulate a watchdog kill (store `JobFailed`, ctx cancel); assert result is `failed`, not cancelled.
+7. **Watchdog fallback:** store `JobCancelled` with `CancelledAt` older than `CancelTimeout` and no worker publish; assert watchdog publishes cancelled.
 
 ### Manual smoke
 
-- `make dev` or equivalent: run app + worker locally, click cancel in Slack mid-agent, confirm:
-  - Worker log line `[Worker][完成] 工作已取消`.
-  - Slack final message `:white_check_mark: 已取消` with no retry button.
-  - Re-tagging the bot in the same thread works (dedup cleared).
+Run app + worker locally, click cancel in Slack mid-agent, confirm:
+- Worker log `[Worker][完成] 工作已取消`.
+- Slack final message `:white_check_mark: 已取消`, no retry button.
+- Re-tagging the bot in the same thread works (dedup cleared).
+- Kill during repo clone: worker waits for clone to finish then reports cancelled.
+- Kill a pending job (not yet pulled by any worker): the worker publishes cancelled on pull.
 
 ## Files Changed
 
-- `internal/queue/job.go` — add `JobCancelled`.
+- `internal/queue/job.go` — add `JobCancelled`; add `CancelledAt` to `JobState`.
+- `internal/queue/memstore.go` — stamp `CancelledAt` on transition to `JobCancelled`.
+- `internal/queue/memstore_test.go` — new assertions.
 - `internal/queue/registry.go` — split `Register` into `RegisterPending` + `SetStarted`; remove `Register`.
-- `internal/queue/registry_test.go` — migrate existing `Register(...)` call sites to `RegisterPending` + `SetStarted`; add cancel-before-start assertions.
-- `internal/queue/watchdog.go` — skip cancelled in `check`, back off in `killAndPublish`.
-- `internal/queue/watchdog_test.go` — new assertions.
-- `internal/worker/executor.go` — `classifyResult` + `cancelledResult`, all failure sites.
+- `internal/queue/registry_test.go` — migrate existing `Register(...)` call sites; add cancel-before-start assertions.
+- `internal/queue/watchdog.go` — reorder `check()`, add `publishCancelledFallback`, add `CancelTimeout` to config, extend `onKill` hook usage.
+- `internal/queue/watchdog_test.go` — new assertions for fallback and reorder.
+- `internal/queue/httpstatus.go` — admin guard includes `JobCancelled`.
+- `internal/worker/executor.go` — `classifyResult` + `cancelledResult`, pre-`Prepare` ctx check, all failure sites migrated.
 - `internal/worker/executor_test.go` — new.
-- `internal/worker/pool.go` — `RegisterPending` / `SetStarted` wiring, queue short-circuit to cancelled, optional race re-read.
-- `internal/worker/pool_test.go` — three scenarios + watchdog regression.
-- `internal/bot/result_listener.go` — `handleCancellation`, metrics branch, log branch.
-- `internal/bot/result_listener_test.go` — cancellation assertions.
-- `cmd/agentdock/app.go` — cancel button sets `JobCancelled`, guard extended.
+- `internal/worker/pool.go` — `RegisterPending` / `SetStarted` wiring, switch-based queue short-circuit (cancelled vs failed), race re-read covering both, cancelled log branch.
+- `internal/worker/pool_test.go` — scenarios A/A'/B/B-race/C + watchdog regression + watchdog fallback.
+- `internal/bot/agent.go` — `ctx.Canceled` early-return in provider chain, different log message.
+- `internal/bot/agent_test.go` — new or extended.
+- `internal/bot/result_listener.go` — store pre-check (Design A), `handleCancellation`, log switch, metrics cancelled branch (both paths).
+- `internal/bot/result_listener_test.go` — cancellation + race assertions.
+- `internal/config/config.go` — `CancelTimeout` field (yaml `cancel_timeout`, default 60s).
+- `internal/config/config_test.go` — default + override assertions.
+- `cmd/agentdock/app.go` — cancel button sets `JobCancelled` before sending kill; guard extended; pass `CancelTimeout` into `WatchdogConfig`.
 
 ## Risks
 
-- **Incomplete clone on cancel during prep.** We deliberately let clone finish instead of wiring ctx through `Prepare`. Worst case: user waits a few extra seconds for their cancel to land; no partial-state footgun.
-- **Watchdog / user-cancel race.** Mitigated by both the skip-list update in `check` and the re-read in `killAndPublish`. If both fire simultaneously, dedup in `ResultListener` drops the loser.
-- **Redis-backed store lag.** `classifyResult`'s discriminator is a store read. In Redis deployments, a stale read could classify a user-cancel as failed. Mitigation: the app's `UpdateStatus(JobCancelled)` happens before `Commands.Send("kill")`, so a worker receiving the kill must already be able to see the state unless Redis replication lag exceeds the command-bus path (unlikely; both traverse the same Redis).
+- **Incomplete clone on cancel during prep.** We deliberately let in-flight clones finish instead of wiring ctx through `Prepare`. The pre-Prepare ctx guard avoids starting new clones when cancel is already known, limiting wasted work to clones already underway.
+- **Watchdog / user-cancel race.** Mitigated by the `check()` reorder and the defensive re-read in `killAndPublish`. If both fire, `ResultListener.processedJobs` dedup drops the loser.
+- **Completed-before-cancel race.** Design A's store pre-check in `handleResult` ensures that once the user cancels, no GitHub issue is created from an in-flight completed result. A very narrow window remains (listener reads store micro-seconds before app's `UpdateStatus` lands), in which the issue gets created anyway. Acceptable given the rarity and the alternative complexity of compensating reversal.
+- **CancelTimeout tuning.** Too short and the watchdog fires before a slow clone finishes (harmless — dedup drops the late worker result, but extra network chatter). Too long and a crashed worker leaves Slack on `:stop_sign:` longer than ideal. Default 60s covers the typical WaitDelay (10s) + clone slack.
+- **Redis-backed store lag.** `classifyResult`'s discriminator is a store read. If Redis replication lag exceeds the command-bus path, a worker could see `JobRunning` instead of `JobCancelled` and classify as `failed`. The app's ordering (UpdateStatus before Send) minimises this; both traverse the same Redis so relative lag is bounded.
+- **Admin force-kill intent drift.** Admin force-kill remains `JobFailed` with retry button. If the product decides admin kill should be indistinguishable from user cancel, change `httpstatus.go` to set `JobCancelled` instead; this spec keeps them separate because the semantic intent differs.

--- a/docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md
+++ b/docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md
@@ -1,0 +1,323 @@
+# Distinguish User Cancellation from Agent Failure
+
+**Date:** 2026-04-17
+**Status:** Approved
+**Issue:** [#36](https://github.com/Ivantseng123/agentdock/issues/36)
+
+## Problem
+
+When a user clicks the "取消" button in Slack, the app sends a `kill` command to the worker, which SIGTERMs the agent process. The agent exits with code 143 (128+15), which the worker currently treats identically to a real agent failure. Consequences:
+
+- Slack shows `:x: 分析失敗: all agents failed` instead of a clean cancellation message.
+- A retry button appears, inviting the user to re-run a job they explicitly cancelled.
+- Worker log reads `[Worker][完成] 工作完成 status=failed`, obscuring operator visibility.
+
+Root cause: `executeJob` in `internal/worker/executor.go` does not inspect `ctx.Err()` before returning a failed result. The app and worker also lack a dedicated `JobCancelled` status, so every code path converges on `JobFailed`.
+
+A secondary, pre-existing defect surfaced during investigation: `ProcessRegistry.Register` is only called from `OnStarted`, so kill commands issued while the worker is still in the prep phase (attachments, repo clone, skill mount) find no PID and are silently dropped. The user's cancellation takes no effect until the agent eventually starts and later receives SIGTERM — or never, if prep succeeds in one shot and the agent runs to normal completion.
+
+## Goals
+
+1. A user-initiated cancellation produces a clean Slack state (`:white_check_mark: 已取消`), no retry button, and no spurious failure log.
+2. Cancellation is honoured at every stage: job still in queue, worker in prep, agent running.
+3. Watchdog timeouts and other true failures continue to surface as `failed` with the existing retry affordance.
+4. Metrics distinguish cancelled jobs from errored jobs, so the agent failure rate is not polluted.
+
+## Non-Goals
+
+- Introducing a separate `timeout` status. Watchdog timeouts remain `failed` (as today).
+- Automatic cancellation based on idle detection or cost caps.
+- Letting the user cancel an already-completed job.
+- Changing `RepoProvider.Prepare` to accept a `context.Context`. Cancellation during clone waits for the next natural checkpoint to avoid leaving partial repo state.
+
+## Design
+
+### 1. Data Model
+
+**`internal/queue/job.go`** — add a status constant:
+
+```go
+const (
+    JobPending   JobStatus = "pending"
+    JobPreparing JobStatus = "preparing"
+    JobRunning   JobStatus = "running"
+    JobCompleted JobStatus = "completed"
+    JobFailed    JobStatus = "failed"
+    JobCancelled JobStatus = "cancelled" // NEW
+)
+```
+
+`JobResult.Status` gains a `"cancelled"` string value. No boolean flag is added on `JobResult`; a single status field is the source of truth. `JobResult.Error` is left empty for cancelled results (no user-facing error to display).
+
+### 2. Executor Classification
+
+In `internal/worker/executor.go`, all failure returns route through a single classifier that distinguishes user cancellation from other context cancellations (e.g., watchdog kill):
+
+```go
+func classifyResult(job *queue.Job, startedAt time.Time, err error, repoPath string, ctx context.Context, store queue.JobStore) *queue.JobResult {
+    if ctx.Err() == context.Canceled {
+        if state, lookupErr := store.Get(job.ID); lookupErr == nil && state.Status == queue.JobCancelled {
+            return cancelledResult(job, startedAt, repoPath)
+        }
+    }
+    return failedResult(job, startedAt, err, repoPath)
+}
+
+func cancelledResult(job *queue.Job, startedAt time.Time, repoPath string) *queue.JobResult {
+    return &queue.JobResult{
+        JobID:      job.ID,
+        Status:     "cancelled",
+        RepoPath:   repoPath,
+        StartedAt:  startedAt,
+        FinishedAt: time.Now(),
+    }
+}
+```
+
+The store check is the discriminator: the app sets `JobCancelled` before sending the kill command, so a ctx cancellation with matching store state is a user cancel; any other ctx cancellation (including watchdog kill, which leaves the store at `JobRunning` until after kill) falls through to `failedResult`.
+
+All existing `failedResult(...)` call sites in `executeJob` switch to `classifyResult(...)`:
+- attachments resolve failure
+- secret key missing / decrypt / unmarshal
+- repo prepare
+- skill mount
+- `runner.Run` return (the original issue site)
+- agent output parse
+
+`context.DeadlineExceeded` deliberately falls through to `failedResult` so timeouts remain failures.
+
+### 3. Process Registry Lifecycle
+
+`internal/queue/registry.go` splits registration into two phases so `Kill` works before the agent starts:
+
+```go
+// Called at the start of executeWithTracking — stores the jobCancel function only.
+func (r *ProcessRegistry) RegisterPending(jobID string, cancel context.CancelFunc) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.processes[jobID] = &RunningAgent{
+        JobID:  jobID,
+        cancel: cancel,
+        done:   make(chan struct{}),
+    }
+}
+
+// Called from OnStarted — fills in the process details.
+func (r *ProcessRegistry) SetStarted(jobID string, pid int, command string) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    if a, ok := r.processes[jobID]; ok {
+        a.PID = pid
+        a.Command = command
+        a.StartedAt = time.Now()
+    }
+}
+```
+
+`Kill`, `Remove`, and `Get` are unchanged. `Kill` no longer requires a PID to be set; calling `agent.cancel()` is sufficient to propagate cancellation through `ctx` into any `Resolve` / `Prepare` / `Run` call that honours it.
+
+The existing `Register(jobID, pid, command, cancel)` method is removed; no production code outside this call site should use it.
+
+### 4. Pool Integration
+
+`internal/worker/pool.go executeWithTracking`:
+
+```go
+jobCtx, jobCancel := context.WithCancel(ctx)
+defer jobCancel()
+
+p.registry.RegisterPending(job.ID, jobCancel)
+defer p.registry.Remove(job.ID)  // consolidates the explicit Remove at end of function
+
+// ... existing status accumulator and opts setup ...
+opts := bot.RunOptions{
+    OnStarted: func(pid int, command string) {
+        status.setPID(pid, command)
+        p.registry.SetStarted(job.ID, pid, command) // was Register(...)
+        // ... status reporting start unchanged ...
+    },
+    // ...
+}
+```
+
+The manual `p.registry.Remove(job.ID)` at the tail of the function is replaced by the top-level `defer`.
+
+`pool.go runWorker` short-circuit when a job is pulled off the queue after the user already cancelled it:
+
+```go
+state, err := p.cfg.Store.Get(job.ID)
+if err != nil || state.Status == queue.JobCancelled { // was JobFailed
+    p.cfg.Results.Publish(ctx, &queue.JobResult{
+        JobID:  job.ID,
+        Status: "cancelled", // was "failed"
+    })
+    continue
+}
+```
+
+**Race mitigation (small but cheap):** immediately after `RegisterPending`, re-read the store once. If it is already `JobCancelled` (the app set it between queue-pull and registration), call `jobCancel()` so `executeJob`'s classifier returns `cancelled`.
+
+`Prepare(cloneURL, branch, token string)` signature is not changed. If the user cancels during clone, the clone completes (usually seconds), `classifyResult` is called next, sees `ctx.Err() == Canceled` and the cancelled store state, and returns `cancelled`. This trade keeps partial-clone risk out of the picture.
+
+### 5. App-Side Cancel Button
+
+`cmd/agentdock/app.go` cancel handler:
+
+```go
+case strings.HasPrefix(action.ActionID, "cancel_job"):
+    jobID := action.Value
+    state, err := jobStore.Get(jobID)
+    if err == nil &&
+        state.Status != queue.JobFailed &&
+        state.Status != queue.JobCompleted &&
+        state.Status != queue.JobCancelled {
+        // Order matters: UpdateStatus BEFORE Send so the worker's classifyResult
+        // can observe JobCancelled when ctx cancellation propagates.
+        jobStore.UpdateStatus(jobID, queue.JobCancelled)
+        bundle.Commands.Send(context.Background(), queue.Command{JobID: jobID, Action: "kill"})
+        slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":stop_sign: 正在取消...")
+        handler.ClearThreadDedup(cb.Channel.ID, state.Job.ThreadTS)
+    } else {
+        slackClient.UpdateMessage(cb.Channel.ID, selectorTS, ":information_source: 此任務已結束")
+    }
+```
+
+The order reversal is load-bearing: the original code does `Send` then `UpdateStatus`, which races against the worker's `classifyResult` store read. Setting `JobCancelled` first and sending `kill` second guarantees the discriminator observes the cancelled state.
+
+The terminal message `:stop_sign: 正在取消...` stays as the intermediate state; the final `:white_check_mark: 已取消` comes from the result listener when the worker confirms.
+
+### 6. Result Listener
+
+`internal/bot/result_listener.go handleResult` gains a cancelled branch before the failed branch:
+
+```go
+switch {
+case result.Status == "cancelled":
+    r.handleCancellation(job, state, result)
+case result.Status == "failed":
+    r.handleFailure(job, state, result)
+case result.Confidence == "low":
+    // existing low-confidence path
+case result.FilesFound == 0 || result.Questions >= 5:
+    // existing degraded issue path
+default:
+    // existing success path
+}
+```
+
+New helper:
+
+```go
+func (r *ResultListener) handleCancellation(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
+    r.store.UpdateStatus(job.ID, queue.JobCancelled)
+    r.updateStatus(job, ":white_check_mark: 已取消")
+    r.clearDedup(job)
+}
+```
+
+No retry button, no issue creation, no error log. Dedup is cleared so the user can re-tag the bot in the same thread if they change their mind.
+
+The top-level log line in `handleResult` acquires a cancelled branch so `[Worker][完成] 工作已取消` appears per the issue's expected behaviour.
+
+`recordMetrics` extends the `status` derivation for `AgentExecutionsTotal`:
+
+```go
+status := "success"
+switch result.Status {
+case "failed":
+    if strings.Contains(result.Error, "timeout") {
+        status = "timeout"
+    } else {
+        status = "error"
+    }
+case "cancelled":
+    status = "cancelled"
+}
+metrics.AgentExecutionsTotal.WithLabelValues(provider, status).Inc()
+```
+
+`RetryHandler.Handle` is untouched: it already rejects any status other than `JobFailed`, so a cancelled job is naturally ineligible for retry even if someone crafts a retry payload.
+
+### 7. Watchdog Alignment
+
+`internal/queue/watchdog.go` must not overwrite a cancelled job with a timeout failure.
+
+In `check()`:
+
+```go
+if state.Status == JobCompleted || state.Status == JobFailed || state.Status == JobCancelled {
+    continue
+}
+```
+
+In `killAndPublish()`, re-read the store after sending the kill command but before mutating state. If the user cancelled between `check()` and this point, back off and let the worker publish the cancelled result:
+
+```go
+fresh, _ := w.store.Get(state.Job.ID)
+if fresh != nil && fresh.Status == JobCancelled {
+    return
+}
+// existing UpdateStatus(JobFailed) + Publish failed result
+```
+
+When the watchdog legitimately times out a job, it proceeds as today. The worker's executor sees `ctx.Err() == Canceled` and a store status of `JobFailed`, so `classifyResult` returns `failed`. The `ResultListener.processedJobs` dedup map drops whichever of {watchdog-published failed, worker-published failed} arrives second.
+
+## Testing
+
+### Unit
+
+**`internal/worker/executor_test.go`** (new if absent):
+- `classifyResult`: ctx.Canceled + store `JobCancelled` → `cancelled`.
+- `classifyResult`: ctx.Canceled + store `JobRunning` → `failed` (watchdog-kill path).
+- `classifyResult`: ctx.DeadlineExceeded + any store state → `failed`.
+- `classifyResult`: err non-nil, ctx OK → `failed`.
+
+**`internal/queue/registry_test.go`**:
+- `RegisterPending` then `Kill` cancels the context without needing `SetStarted`.
+- `RegisterPending` → `SetStarted` → `Kill` still records PID / Command correctly.
+- `Kill` on an unknown job still returns the existing error.
+
+**`internal/bot/result_listener_test.go`**:
+- `result.Status == "cancelled"` → store `JobCancelled`, Slack updated to `:white_check_mark: 已取消`, dedup cleared, no retry button posted.
+- Metrics emit `AgentExecutionsTotal{status="cancelled"}`.
+
+**`internal/queue/watchdog_test.go`**:
+- A `JobCancelled` state past its timeout is skipped by `check()`.
+- `killAndPublish` observing a `JobCancelled` state in the re-read phase exits without UpdateStatus or Publish.
+
+### Integration (`internal/worker/pool_test.go`)
+
+Use a controllable fake `Runner` to exercise timing:
+
+1. **Scenario A — queue hit post-cancel:** Put job, set store to `JobCancelled` before the worker pulls. Assert the published result is `cancelled`.
+2. **Scenario B — prep cancel:** Runner sleeps during prep simulation; call `registry.Kill`. Assert `executeJob` exits with a `cancelled` result.
+3. **Scenario C — agent-running cancel:** Runner enters `Run` then blocks; call `registry.Kill`. Assert `cancelled` result.
+4. **Watchdog regression:** Simulate a watchdog kill (store `JobFailed`, ctx cancel). Assert the result is `failed`, not cancelled.
+
+### Manual smoke
+
+- `make dev` or equivalent: run app + worker locally, click cancel in Slack mid-agent, confirm:
+  - Worker log line `[Worker][完成] 工作已取消`.
+  - Slack final message `:white_check_mark: 已取消` with no retry button.
+  - Re-tagging the bot in the same thread works (dedup cleared).
+
+## Files Changed
+
+- `internal/queue/job.go` — add `JobCancelled`.
+- `internal/queue/registry.go` — split `Register` into `RegisterPending` + `SetStarted`; remove `Register`.
+- `internal/queue/registry_test.go` — migrate existing `Register(...)` call sites to `RegisterPending` + `SetStarted`; add cancel-before-start assertions.
+- `internal/queue/watchdog.go` — skip cancelled in `check`, back off in `killAndPublish`.
+- `internal/queue/watchdog_test.go` — new assertions.
+- `internal/worker/executor.go` — `classifyResult` + `cancelledResult`, all failure sites.
+- `internal/worker/executor_test.go` — new.
+- `internal/worker/pool.go` — `RegisterPending` / `SetStarted` wiring, queue short-circuit to cancelled, optional race re-read.
+- `internal/worker/pool_test.go` — three scenarios + watchdog regression.
+- `internal/bot/result_listener.go` — `handleCancellation`, metrics branch, log branch.
+- `internal/bot/result_listener_test.go` — cancellation assertions.
+- `cmd/agentdock/app.go` — cancel button sets `JobCancelled`, guard extended.
+
+## Risks
+
+- **Incomplete clone on cancel during prep.** We deliberately let clone finish instead of wiring ctx through `Prepare`. Worst case: user waits a few extra seconds for their cancel to land; no partial-state footgun.
+- **Watchdog / user-cancel race.** Mitigated by both the skip-list update in `check` and the re-read in `killAndPublish`. If both fire simultaneously, dedup in `ResultListener` drops the loser.
+- **Redis-backed store lag.** `classifyResult`'s discriminator is a store read. In Redis deployments, a stale read could classify a user-cancel as failed. Mitigation: the app's `UpdateStatus(JobCancelled)` happens before `Commands.Send("kill")`, so a worker receiving the kill must already be able to see the state unless Redis replication lag exceeds the command-bus path (unlikely; both traverse the same Redis).

--- a/internal/bot/agent.go
+++ b/internal/bot/agent.go
@@ -58,6 +58,10 @@ func (r *AgentRunner) Run(ctx context.Context, logger *slog.Logger, workDir, pro
 		logger.Info("嘗試 agent", "phase", "處理中", "command", agent.Command, "index", i, "total", len(r.agents), "timeout", agent.Timeout)
 		output, err := r.runOne(ctx, logger, agent, workDir, prompt, opts)
 		if err != nil {
+			if ctx.Err() == context.Canceled {
+				logger.Info("Agent 執行已中斷", "phase", "完成", "command", agent.Command, "index", i)
+				return "", fmt.Errorf("cancelled")
+			}
 			logger.Warn("Agent 失敗", "phase", "失敗", "command", agent.Command, "index", i, "error", err)
 			errs = append(errs, fmt.Sprintf("%s: %s", agent.Command, err))
 			continue

--- a/internal/bot/agent_test.go
+++ b/internal/bot/agent_test.go
@@ -156,3 +156,22 @@ echo "padding padding padding padding padding padding padding"
 		t.Errorf("githubToken fallback not working: %q", output)
 	}
 }
+
+func TestAgentRunner_CancelShortCircuitsProviderChain(t *testing.T) {
+	runner := &AgentRunner{
+		agents: []config.AgentConfig{
+			{Command: "nonexistent-agent-one", Args: []string{"{prompt}"}, Timeout: time.Second},
+			{Command: "nonexistent-agent-two", Args: []string{"{prompt}"}, Timeout: time.Second},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := runner.Run(ctx, slog.Default(), t.TempDir(), "noop", RunOptions{})
+	if err == nil {
+		t.Fatal("expected error on cancelled ctx")
+	}
+	if err.Error() != "cancelled" {
+		t.Errorf("err = %q, want \"cancelled\" (chain must not try the second agent)", err.Error())
+	}
+}

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -101,14 +101,24 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 	job := state.Job
 	owner, repo := splitRepo(job.Repo)
 
+	// Design A: user cancellation dominates, regardless of result.Status.
+	if state.Status == queue.JobCancelled || result.Status == "cancelled" {
+		r.handleCancellation(state.Job, state, result)
+		r.attachments.Cleanup(ctx, result.JobID)
+		return
+	}
+
 	logger := r.logger.With("job_id", result.JobID, "repo", job.Repo, "status", result.Status)
-	if result.Status == "failed" {
+	switch result.Status {
+	case "failed":
 		truncated := result.RawOutput
 		if len(truncated) > 2000 {
 			truncated = truncated[:2000] + "…(truncated)"
 		}
 		logger.Warn("工作失敗", "phase", "降級", "error", result.Error, "raw_output", truncated)
-	} else {
+	case "cancelled":
+		logger.Info("工作已取消", "phase", "完成")
+	default:
 		logger.Info("工作完成", "phase", "完成", "title", result.Title, "confidence", result.Confidence, "files_found", result.FilesFound)
 	}
 
@@ -172,12 +182,15 @@ func (r *ResultListener) recordMetrics(state *queue.JobState, result *queue.JobR
 
 		// Execution outcome.
 		status := "success"
-		if result.Status == "failed" {
+		switch result.Status {
+		case "failed":
 			if strings.Contains(result.Error, "timeout") {
 				status = "timeout"
 			} else {
 				status = "error"
 			}
+		case "cancelled":
+			status = "cancelled"
 		}
 		metrics.AgentExecutionsTotal.WithLabelValues(provider, status).Inc()
 
@@ -202,6 +215,8 @@ func (r *ResultListener) recordMetrics(state *queue.JobState, result *queue.JobR
 	} else if result.Status == "failed" {
 		// No agent status — job failed before agent started.
 		metrics.AgentExecutionsTotal.WithLabelValues("unknown", "error").Inc()
+	} else if result.Status == "cancelled" {
+		metrics.AgentExecutionsTotal.WithLabelValues("unknown", "cancelled").Inc()
 	}
 }
 
@@ -243,6 +258,12 @@ func (r *ResultListener) handleFailure(job *queue.Job, state *queue.JobState, re
 		r.updateStatus(job, text)
 		r.clearDedup(job)
 	}
+}
+
+func (r *ResultListener) handleCancellation(job *queue.Job, state *queue.JobState, result *queue.JobResult) {
+	r.store.UpdateStatus(job.ID, queue.JobCancelled)
+	r.updateStatus(job, ":white_check_mark: 已取消")
+	r.clearDedup(job)
 }
 
 func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job, owner, repo string, result *queue.JobResult, degraded bool) {

--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -116,8 +116,6 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 			truncated = truncated[:2000] + "…(truncated)"
 		}
 		logger.Warn("工作失敗", "phase", "降級", "error", result.Error, "raw_output", truncated)
-	case "cancelled":
-		logger.Info("工作已取消", "phase", "完成")
 	default:
 		logger.Info("工作完成", "phase", "完成", "title", result.Title, "confidence", result.Confidence, "files_found", result.FilesFound)
 	}

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -243,6 +243,85 @@ func TestResultListener_FailedNoButtonAfterRetry(t *testing.T) {
 	}
 }
 
+func TestResultListener_CancelledResultUpdatesSlack(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "jcan", Repo: "o/r", ChannelID: "C1", ThreadTS: "T1", StatusMsgTS: "S1"})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{JobID: "jcan", Status: "cancelled"})
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	found := false
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "已取消") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected cancelled message, got %v", slackMock.messages)
+	}
+	if len(slackMock.buttons) != 0 {
+		t.Errorf("no retry button expected, got %v", slackMock.buttons)
+	}
+
+	state, _ := store.Get("jcan")
+	if state.Status != queue.JobCancelled {
+		t.Errorf("store status = %q, want JobCancelled", state.Status)
+	}
+}
+
+func TestResultListener_CompletedResultDeferredToCancellationWhenStoreCancelled(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "jrace", Repo: "o/r", ChannelID: "C1", ThreadTS: "T1", StatusMsgTS: "S1"})
+	store.UpdateStatus("jrace", queue.JobCancelled)
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	github := &mockIssueCreator{url: "https://github.com/o/r/issues/42"}
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, github, nil, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID: "jrace", Status: "completed",
+		Title: "Bug", Body: "b", Confidence: "high", FilesFound: 2,
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "issues/42") {
+			t.Errorf("issue URL must not be posted when store says cancelled; messages=%v", slackMock.messages)
+		}
+	}
+	found := false
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "已取消") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected cancelled message, got %v", slackMock.messages)
+	}
+}
+
 func TestResultListener_DedupDropsDuplicateResult(t *testing.T) {
 	store := queue.NewMemJobStore()
 	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1"})

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -167,10 +167,15 @@ func TestResultListener_FailedShowsRetryButton(t *testing.T) {
 	defer bundle.Close()
 
 	slackMock := &mockSlackPoster{}
+	var dedupMu sync.Mutex
 	dedupCleared := false
 
 	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
-		func(channelID, threadTS string) { dedupCleared = true }, slog.Default())
+		func(channelID, threadTS string) {
+			dedupMu.Lock()
+			dedupCleared = true
+			dedupMu.Unlock()
+		}, slog.Default())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -193,7 +198,10 @@ func TestResultListener_FailedShowsRetryButton(t *testing.T) {
 	if slackMock.buttons[0] != "retry_job:j1" {
 		t.Errorf("button = %q, want retry_job:j1", slackMock.buttons[0])
 	}
-	if dedupCleared {
+	dedupMu.Lock()
+	actualDedup := dedupCleared
+	dedupMu.Unlock()
+	if actualDedup {
 		t.Error("dedup should NOT be cleared when retry button is shown")
 	}
 }
@@ -206,10 +214,15 @@ func TestResultListener_FailedNoButtonAfterRetry(t *testing.T) {
 	defer bundle.Close()
 
 	slackMock := &mockSlackPoster{}
+	var dedupMu sync.Mutex
 	dedupCleared := false
 
 	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil,
-		func(channelID, threadTS string) { dedupCleared = true }, slog.Default())
+		func(channelID, threadTS string) {
+			dedupMu.Lock()
+			dedupCleared = true
+			dedupMu.Unlock()
+		}, slog.Default())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -238,7 +251,10 @@ func TestResultListener_FailedNoButtonAfterRetry(t *testing.T) {
 	if !found {
 		t.Errorf("expected retry-exhausted message, got %v", slackMock.messages)
 	}
-	if !dedupCleared {
+	dedupMu.Lock()
+	actualDedup := dedupCleared
+	dedupMu.Unlock()
+	if !actualDedup {
 		t.Error("dedup should be cleared when no retry button")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type QueueConfig struct {
 	JobTimeout       time.Duration `yaml:"job_timeout"`
 	AgentIdleTimeout time.Duration `yaml:"agent_idle_timeout"`
 	PrepareTimeout   time.Duration `yaml:"prepare_timeout"`
+	CancelTimeout    time.Duration `yaml:"cancel_timeout"`
 	StatusInterval   time.Duration `yaml:"status_interval"`
 }
 
@@ -201,6 +202,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Queue.PrepareTimeout <= 0 {
 		cfg.Queue.PrepareTimeout = 3 * time.Minute
+	}
+	if cfg.Queue.CancelTimeout <= 0 {
+		cfg.Queue.CancelTimeout = 60 * time.Second
 	}
 	if cfg.Queue.StatusInterval <= 0 {
 		cfg.Queue.StatusInterval = 5 * time.Second

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -505,3 +505,27 @@ func TestValidateSecretKey_Invalid(t *testing.T) {
 		}
 	}
 }
+
+func TestLoad_CancelTimeoutDefault(t *testing.T) {
+	cfg := loadFromString(t, `
+agents:
+  claude:
+    command: claude
+`)
+	if cfg.Queue.CancelTimeout != 60*time.Second {
+		t.Errorf("default cancel_timeout = %v, want 60s", cfg.Queue.CancelTimeout)
+	}
+}
+
+func TestLoad_CancelTimeoutOverride(t *testing.T) {
+	cfg := loadFromString(t, `
+queue:
+  cancel_timeout: 20s
+agents:
+  claude:
+    command: claude
+`)
+	if cfg.Queue.CancelTimeout != 20*time.Second {
+		t.Errorf("cancel_timeout = %v, want 20s", cfg.Queue.CancelTimeout)
+	}
+}

--- a/internal/queue/httpstatus.go
+++ b/internal/queue/httpstatus.go
@@ -175,7 +175,7 @@ func KillHandler(store JobStore, commands CommandBus) http.HandlerFunc {
 			return
 		}
 
-		if state.Status == JobCompleted || state.Status == JobFailed {
+		if state.Status == JobCompleted || state.Status == JobFailed || state.Status == JobCancelled {
 			w.WriteHeader(http.StatusConflict)
 			json.NewEncoder(w).Encode(map[string]string{"error": "job not running"})
 			return

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -13,6 +13,7 @@ const (
 	JobRunning   JobStatus = "running"
 	JobCompleted JobStatus = "completed"
 	JobFailed    JobStatus = "failed"
+	JobCancelled JobStatus = "cancelled"
 )
 
 type SkillPayload struct {
@@ -90,6 +91,7 @@ type JobState struct {
 	StartedAt   time.Time
 	WaitTime    time.Duration
 	AgentStatus *StatusReport
+	CancelledAt time.Time
 }
 
 type WorkerInfo struct {

--- a/internal/queue/memstore.go
+++ b/internal/queue/memstore.go
@@ -67,6 +67,9 @@ func (s *MemJobStore) UpdateStatus(jobID string, status JobStatus) error {
 		state.StartedAt = time.Now()
 		state.WaitTime = state.StartedAt.Sub(state.Job.SubmittedAt)
 	}
+	if status == JobCancelled && state.CancelledAt.IsZero() {
+		state.CancelledAt = time.Now()
+	}
 	return nil
 }
 

--- a/internal/queue/memstore_test.go
+++ b/internal/queue/memstore_test.go
@@ -77,3 +77,37 @@ func TestMemJobStore_GetNotFound(t *testing.T) {
 		t.Error("expected error for nonexistent job")
 	}
 }
+
+func TestMemJobStore_UpdateStatus_StampsCancelledAt(t *testing.T) {
+	s := NewMemJobStore()
+	s.Put(&Job{ID: "j1"})
+
+	before := time.Now()
+	if err := s.UpdateStatus("j1", JobCancelled); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	state, _ := s.Get("j1")
+	if state.CancelledAt.IsZero() {
+		t.Fatal("CancelledAt should be stamped")
+	}
+	if state.CancelledAt.Before(before) {
+		t.Errorf("CancelledAt (%v) earlier than call start (%v)", state.CancelledAt, before)
+	}
+}
+
+func TestMemJobStore_UpdateStatus_CancelledAtIdempotent(t *testing.T) {
+	s := NewMemJobStore()
+	s.Put(&Job{ID: "j1"})
+
+	s.UpdateStatus("j1", JobCancelled)
+	state, _ := s.Get("j1")
+	first := state.CancelledAt
+
+	time.Sleep(5 * time.Millisecond)
+	s.UpdateStatus("j1", JobCancelled)
+	state, _ = s.Get("j1")
+
+	if !state.CancelledAt.Equal(first) {
+		t.Errorf("second UpdateStatus should not re-stamp; first=%v second=%v", first, state.CancelledAt)
+	}
+}

--- a/internal/queue/registry.go
+++ b/internal/queue/registry.go
@@ -44,6 +44,26 @@ func (r *ProcessRegistry) Register(jobID string, pid int, command string, cancel
 	}
 }
 
+func (r *ProcessRegistry) RegisterPending(jobID string, cancel context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.processes[jobID] = &RunningAgent{
+		JobID:  jobID,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+}
+
+func (r *ProcessRegistry) SetStarted(jobID string, pid int, command string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if a, ok := r.processes[jobID]; ok {
+		a.PID = pid
+		a.Command = command
+		a.StartedAt = time.Now()
+	}
+}
+
 func (r *ProcessRegistry) Remove(jobID string) {
 	r.mu.Lock()
 	agent, ok := r.processes[jobID]

--- a/internal/queue/registry.go
+++ b/internal/queue/registry.go
@@ -31,19 +31,6 @@ func NewProcessRegistry() *ProcessRegistry {
 	}
 }
 
-func (r *ProcessRegistry) Register(jobID string, pid int, command string, cancel context.CancelFunc) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.processes[jobID] = &RunningAgent{
-		JobID:     jobID,
-		PID:       pid,
-		Command:   command,
-		StartedAt: time.Now(),
-		cancel:    cancel,
-		done:      make(chan struct{}),
-	}
-}
-
 func (r *ProcessRegistry) RegisterPending(jobID string, cancel context.CancelFunc) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/queue/registry_test.go
+++ b/internal/queue/registry_test.go
@@ -59,3 +59,53 @@ func TestProcessRegistry_KillNotFound(t *testing.T) {
 		t.Error("expected error for nonexistent job")
 	}
 }
+
+func TestProcessRegistry_RegisterPendingThenKill(t *testing.T) {
+	reg := NewProcessRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reg.RegisterPending("j1", cancel)
+
+	go func() {
+		<-ctx.Done()
+		time.Sleep(10 * time.Millisecond)
+		reg.Remove("j1")
+	}()
+
+	if err := reg.Kill("j1"); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if ctx.Err() == nil {
+		t.Error("context should be cancelled after Kill on pending entry")
+	}
+}
+
+func TestProcessRegistry_SetStartedAfterPending(t *testing.T) {
+	reg := NewProcessRegistry()
+	_, cancel := context.WithCancel(context.Background())
+
+	reg.RegisterPending("j1", cancel)
+	reg.SetStarted("j1", 42, "claude")
+
+	agent, ok := reg.Get("j1")
+	if !ok {
+		t.Fatal("expected agent entry")
+	}
+	if agent.PID != 42 {
+		t.Errorf("PID = %d, want 42", agent.PID)
+	}
+	if agent.Command != "claude" {
+		t.Errorf("Command = %q, want claude", agent.Command)
+	}
+	if agent.StartedAt.IsZero() {
+		t.Error("StartedAt should be set by SetStarted")
+	}
+}
+
+func TestProcessRegistry_SetStartedWithoutPendingIsNoop(t *testing.T) {
+	reg := NewProcessRegistry()
+	reg.SetStarted("unknown", 1, "x") // must not panic
+	if _, ok := reg.Get("unknown"); ok {
+		t.Error("SetStarted without RegisterPending should not create an entry")
+	}
+}

--- a/internal/queue/registry_test.go
+++ b/internal/queue/registry_test.go
@@ -6,52 +6,6 @@ import (
 	"time"
 )
 
-func TestProcessRegistry_RegisterAndKill(t *testing.T) {
-	reg := NewProcessRegistry()
-	ctx, cancel := context.WithCancel(context.Background())
-	reg.Register("j1", 12345, "claude", cancel)
-
-	agent, ok := reg.Get("j1")
-	if !ok {
-		t.Fatal("expected agent to be registered")
-	}
-	if agent.PID != 12345 {
-		t.Errorf("PID = %d, want 12345", agent.PID)
-	}
-
-	// Simulate process exit after cancel
-	go func() {
-		<-ctx.Done()
-		time.Sleep(10 * time.Millisecond)
-		reg.Remove("j1")
-	}()
-
-	err := reg.Kill("j1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ctx.Err() == nil {
-		t.Error("expected context to be cancelled after kill")
-	}
-}
-
-func TestProcessRegistry_RemoveClosesDone(t *testing.T) {
-	reg := NewProcessRegistry()
-	_, cancel := context.WithCancel(context.Background())
-	reg.Register("j1", 100, "claude", cancel)
-
-	agent, _ := reg.Get("j1")
-	done := agent.Done()
-
-	reg.Remove("j1")
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("done channel not closed after Remove")
-	}
-}
-
 func TestProcessRegistry_KillNotFound(t *testing.T) {
 	reg := NewProcessRegistry()
 	err := reg.Kill("nonexistent")

--- a/internal/queue/watchdog.go
+++ b/internal/queue/watchdog.go
@@ -11,6 +11,7 @@ type WatchdogConfig struct {
 	JobTimeout     time.Duration
 	IdleTimeout    time.Duration
 	PrepareTimeout time.Duration
+	CancelTimeout  time.Duration
 }
 
 type Watchdog struct {
@@ -20,6 +21,7 @@ type Watchdog struct {
 	jobTimeout     time.Duration
 	idleTimeout    time.Duration
 	prepareTimeout time.Duration
+	cancelTimeout  time.Duration
 	interval       time.Duration
 	logger         *slog.Logger
 	onKill         func(reason string) // optional metric hook
@@ -47,6 +49,7 @@ func NewWatchdog(store JobStore, commands CommandBus, results ResultBus, cfg Wat
 		jobTimeout:     cfg.JobTimeout,
 		idleTimeout:    cfg.IdleTimeout,
 		prepareTimeout: cfg.PrepareTimeout,
+		cancelTimeout:  cfg.CancelTimeout,
 		interval:       interval,
 		logger:         logger,
 	}
@@ -87,7 +90,17 @@ func (w *Watchdog) check() {
 
 	now := time.Now()
 	for _, state := range all {
+		// Terminal states (no action needed).
 		if state.Status == JobCompleted || state.Status == JobFailed {
+			continue
+		}
+
+		// Cancelled: wait for worker, fall back after cancelTimeout.
+		if state.Status == JobCancelled {
+			if w.cancelTimeout > 0 && !state.CancelledAt.IsZero() &&
+				now.Sub(state.CancelledAt) > w.cancelTimeout {
+				w.publishCancelledFallback(state)
+			}
 			continue
 		}
 
@@ -114,7 +127,28 @@ func (w *Watchdog) check() {
 	}
 }
 
+func (w *Watchdog) publishCancelledFallback(state *JobState) {
+	if w.onKill != nil {
+		w.onKill("cancel fallback")
+	}
+	w.logger.Warn("取消狀態逾時，補發 cancelled result", "phase", "完成",
+		"job_id", state.Job.ID,
+		"cancelled_age", time.Since(state.CancelledAt))
+	if w.results != nil {
+		w.results.Publish(context.Background(), &JobResult{
+			JobID:      state.Job.ID,
+			Status:     "cancelled",
+			FinishedAt: time.Now(),
+		})
+	}
+}
+
 func (w *Watchdog) killAndPublish(state *JobState, reason string) {
+	// Back off if the job was cancelled in the race window.
+	if fresh, _ := w.store.Get(state.Job.ID); fresh != nil && fresh.Status == JobCancelled {
+		return
+	}
+
 	if w.onKill != nil {
 		w.onKill(reason)
 	}

--- a/internal/queue/watchdog.go
+++ b/internal/queue/watchdog.go
@@ -67,6 +67,7 @@ func (w *Watchdog) Start(stop <-chan struct{}) {
 		"job_timeout", w.jobTimeout,
 		"idle_timeout", w.idleTimeout,
 		"prepare_timeout", w.prepareTimeout,
+		"cancel_timeout", w.cancelTimeout,
 		"check_interval", w.interval,
 	)
 

--- a/internal/queue/watchdog_test.go
+++ b/internal/queue/watchdog_test.go
@@ -50,3 +50,132 @@ func TestWatchdog_PublishesFailedResultOnTimeout(t *testing.T) {
 		t.Errorf("store status = %q, want failed", state.Status)
 	}
 }
+
+func TestWatchdog_CancelFallbackAfterTimeout(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+	store.UpdateStatus("j1", JobCancelled)
+	// Force CancelledAt older than cancelTimeout
+	state, _ := store.Get("j1")
+	state.CancelledAt = time.Now().Add(-2 * time.Minute)
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	var onKillReasons []string
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{
+		JobTimeout:    10 * time.Minute,
+		CancelTimeout: 60 * time.Second,
+	}, slog.Default(), WithWatchdogKillHook(func(r string) { onKillReasons = append(onKillReasons, r) }))
+
+	wd.check()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ch, _ := results.Subscribe(ctx)
+
+	select {
+	case r := <-ch:
+		if r.Status != "cancelled" {
+			t.Errorf("status = %q, want cancelled", r.Status)
+		}
+	case <-ctx.Done():
+		t.Fatal("no result published")
+	}
+	if len(onKillReasons) != 1 || onKillReasons[0] != "cancel fallback" {
+		t.Errorf("onKill reasons = %v, want [cancel fallback]", onKillReasons)
+	}
+
+	// Store status should remain JobCancelled (not flipped to JobFailed)
+	state, _ = store.Get("j1")
+	if state.Status != JobCancelled {
+		t.Errorf("store status = %q, want JobCancelled", state.Status)
+	}
+}
+
+func TestWatchdog_CancelWithinTimeoutDoesNotFire(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+	store.UpdateStatus("j1", JobCancelled) // CancelledAt is now()
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{
+		JobTimeout:    10 * time.Minute,
+		CancelTimeout: 60 * time.Second,
+	}, slog.Default())
+
+	wd.check()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	ch, _ := results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		t.Fatalf("unexpected publish: %+v", r)
+	case <-ctx.Done():
+		// ok
+	}
+}
+
+func TestWatchdog_CancelStatePreemptsJobTimeout(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-30 * time.Minute)})
+	store.UpdateStatus("j1", JobCancelled)
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{
+		JobTimeout:    1 * time.Minute, // already exceeded
+		CancelTimeout: 0,               // disable fallback
+	}, slog.Default())
+
+	wd.check()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	ch, _ := results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		t.Fatalf("expected no publish, got %+v", r)
+	case <-ctx.Done():
+		// ok — cancelled state must not trigger jobTimeout killAndPublish
+	}
+	state, _ := store.Get("j1")
+	if state.Status != JobCancelled {
+		t.Errorf("store flipped to %q, should stay JobCancelled", state.Status)
+	}
+}
+
+func TestWatchdog_KillAndPublishBackOffOnRaceCancel(t *testing.T) {
+	store := NewMemJobStore()
+	store.Put(&Job{ID: "j1", SubmittedAt: time.Now().Add(-5 * time.Minute)})
+	store.UpdateStatus("j1", JobRunning)
+
+	results := NewInMemResultBus(10)
+	defer results.Close()
+	commands := NewInMemCommandBus(10)
+	defer commands.Close()
+
+	wd := NewWatchdog(store, commands, results, WatchdogConfig{}, slog.Default())
+
+	// Simulate race: caller flips to JobCancelled between check() and killAndPublish.
+	store.UpdateStatus("j1", JobCancelled)
+
+	state, _ := store.Get("j1")
+	wd.killAndPublish(state, "job timeout")
+
+	// Store must remain JobCancelled (back-off kicked in).
+	state, _ = store.Get("j1")
+	if state.Status != JobCancelled {
+		t.Errorf("store flipped to %q, back-off failed", state.Status)
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -188,6 +188,25 @@ func writeAttachments(attachments []queue.AttachmentReady, dir string) ([]bot.At
 	return infos, nil
 }
 
+func classifyResult(job *queue.Job, startedAt time.Time, err error, repoPath string, ctx context.Context, store queue.JobStore) *queue.JobResult {
+	if ctx.Err() == context.Canceled {
+		if state, lookupErr := store.Get(job.ID); lookupErr == nil && state.Status == queue.JobCancelled {
+			return cancelledResult(job, startedAt, repoPath)
+		}
+	}
+	return failedResult(job, startedAt, err, repoPath)
+}
+
+func cancelledResult(job *queue.Job, startedAt time.Time, repoPath string) *queue.JobResult {
+	return &queue.JobResult{
+		JobID:      job.ID,
+		Status:     "cancelled",
+		RepoPath:   repoPath,
+		StartedAt:  startedAt,
+		FinishedAt: time.Now(),
+	}
+}
+
 func failedResult(job *queue.Job, startedAt time.Time, err error, repoPath string) *queue.JobResult {
 	return &queue.JobResult{
 		JobID:      job.ID,

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -49,7 +49,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 		var err error
 		attachments, err = deps.attachments.Resolve(ctx, job.ID)
 		if err != nil {
-			return failedResult(job, startedAt, fmt.Errorf("attachments failed: %w", err), "")
+			return classifyResult(job, startedAt, fmt.Errorf("attachments failed: %w", err), "", ctx, deps.store)
 		}
 	}
 
@@ -57,15 +57,15 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	var mergedSecrets map[string]string
 	if len(job.EncryptedSecrets) > 0 {
 		if len(deps.secretKey) == 0 {
-			return failedResult(job, startedAt, fmt.Errorf("job has encrypted secrets but worker has no secret_key configured"), "")
+			return classifyResult(job, startedAt, fmt.Errorf("job has encrypted secrets but worker has no secret_key configured"), "", ctx, deps.store)
 		}
 		decrypted, err := crypto.Decrypt(deps.secretKey, job.EncryptedSecrets)
 		if err != nil {
-			return failedResult(job, startedAt, fmt.Errorf("decrypt secrets: %w", err), "")
+			return classifyResult(job, startedAt, fmt.Errorf("decrypt secrets: %w", err), "", ctx, deps.store)
 		}
 		var appSecrets map[string]string
 		if err := json.Unmarshal(decrypted, &appSecrets); err != nil {
-			return failedResult(job, startedAt, fmt.Errorf("unmarshal secrets: %w", err), "")
+			return classifyResult(job, startedAt, fmt.Errorf("unmarshal secrets: %w", err), "", ctx, deps.store)
 		}
 		mergedSecrets = appSecrets
 	}
@@ -86,9 +86,12 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	if mergedSecrets != nil {
 		ghToken = mergedSecrets["GH_TOKEN"]
 	}
+	if err := ctx.Err(); err != nil {
+		return classifyResult(job, startedAt, err, "", ctx, deps.store)
+	}
 	repoPath, err := deps.repoCache.Prepare(job.CloneURL, job.Branch, ghToken)
 	if err != nil {
-		return failedResult(job, startedAt, fmt.Errorf("repo prepare failed: %w", err), "")
+		return classifyResult(job, startedAt, fmt.Errorf("repo prepare failed: %w", err), "", ctx, deps.store)
 	}
 	prepareSeconds := time.Since(prepareStart).Seconds()
 	logger.Info("Repo 已就緒", "phase", "處理中", "path", repoPath, "prepare_seconds", prepareSeconds)
@@ -111,7 +114,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 		logger.Info("掛載 skill 中", "phase", "處理中", "count", len(job.Skills), "skill_dirs", deps.skillDirs)
 		for _, sd := range deps.skillDirs {
 			if err := mountSkills(repoPath, job.Skills, sd); err != nil {
-				return failedResult(job, startedAt, fmt.Errorf("skill mount failed: %w", err), repoPath)
+				return classifyResult(job, startedAt, fmt.Errorf("skill mount failed: %w", err), repoPath, ctx, deps.store)
 			}
 			defer cleanupSkills(repoPath, job.Skills, sd)
 		}
@@ -125,7 +128,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	opts.Secrets = mergedSecrets
 	output, err := deps.runner.Run(ctx, repoPath, prompt, opts)
 	if err != nil {
-		return failedResult(job, startedAt, err, repoPath)
+		return classifyResult(job, startedAt, err, repoPath, ctx, deps.store)
 	}
 	logger.Info("Agent 執行完成", "phase", "完成", "output_len", len(output))
 
@@ -137,7 +140,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 			truncated = truncated[:2000] + "…(truncated)"
 		}
 		logger.Warn("解析失敗，輸出原始內容", "phase", "失敗", "output", truncated)
-		return failedResult(job, startedAt, fmt.Errorf("parse failed: %w", err), repoPath)
+		return classifyResult(job, startedAt, fmt.Errorf("parse failed: %w", err), repoPath, ctx, deps.store)
 	}
 	logger.Info("解析成功", "phase", "完成", "status", parsed.Status, "confidence", parsed.Confidence, "files_found", parsed.FilesFound)
 

--- a/internal/worker/executor_test.go
+++ b/internal/worker/executor_test.go
@@ -1,0 +1,97 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"agentdock/internal/queue"
+)
+
+func TestClassifyResult_UserCancel(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobCancelled)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	job := &queue.Job{ID: "j1"}
+	result := classifyResult(job, time.Now(), fmt.Errorf("killed"), "/tmp/repo", ctx, store)
+
+	if result.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", result.Status)
+	}
+	if result.RepoPath != "/tmp/repo" {
+		t.Errorf("RepoPath = %q, want /tmp/repo", result.RepoPath)
+	}
+	if result.Error != "" {
+		t.Errorf("Error should be empty for cancelled, got %q", result.Error)
+	}
+}
+
+func TestClassifyResult_WatchdogKillFallsThroughToFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobFailed)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+		fmt.Errorf("killed"), "/tmp/repo", ctx, store)
+
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed", result.Status)
+	}
+	if result.Error == "" {
+		t.Error("Error should be populated for failed")
+	}
+}
+
+func TestClassifyResult_RunningStoreIsFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+		errors.New("exit 143"), "/tmp/repo", ctx, store)
+
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed (store not yet JobCancelled)", result.Status)
+	}
+}
+
+func TestClassifyResult_DeadlineExceededIsFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobCancelled) // even with cancelled store…
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+		fmt.Errorf("timeout"), "/tmp/repo", ctx, store)
+
+	if result.Status != "failed" {
+		t.Errorf("DeadlineExceeded must yield failed, got %q", result.Status)
+	}
+}
+
+func TestClassifyResult_NoErrorRoutesToFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "j1"})
+
+	ctx := context.Background()
+	result := classifyResult(&queue.Job{ID: "j1"}, time.Now(),
+		errors.New("parse failed"), "/tmp/repo", ctx, store)
+
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed", result.Status)
+	}
+}

--- a/internal/worker/executor_test.go
+++ b/internal/worker/executor_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"agentdock/internal/bot"
 	"agentdock/internal/queue"
 )
 
@@ -93,5 +95,41 @@ func TestClassifyResult_NoErrorRoutesToFailed(t *testing.T) {
 
 	if result.Status != "failed" {
 		t.Errorf("status = %q, want failed", result.Status)
+	}
+}
+
+// Scenario 6 — Admin kill path: store=JobFailed + ctx cancel yields "failed", not "cancelled".
+// Covered by TestClassifyResult_WatchdogKillFallsThroughToFailed above, which also
+// asserts result.Error is non-empty.
+
+// Scenario B-race — Pre-Prepare ctx guard: store set to JobCancelled before Prepare runs
+// → Prepare is not invoked and the result is cancelled.
+func TestExecuteJob_PrePrepareGuardSkipsClone(t *testing.T) {
+	store := queue.NewMemJobStore()
+	job := &queue.Job{ID: "jguard", Repo: "o/r"}
+	store.Put(job)
+	store.UpdateStatus("jguard", queue.JobCancelled)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	prepareCalled := false
+	deps := executionDeps{
+		attachments: queue.NewInMemAttachmentStore(),
+		repoCache: &mockRepo{
+			path:        "/tmp/r",
+			prepareHook: func() { prepareCalled = true },
+		},
+		runner: &mockRunner{},
+		store:  store,
+	}
+
+	result := executeJob(ctx, job, deps, bot.RunOptions{}, slog.Default())
+
+	if prepareCalled {
+		t.Error("Prepare must not be invoked when ctx is cancelled before prep")
+	}
+	if result.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", result.Status)
 	}
 }

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -110,7 +110,7 @@ func (p *Pool) runWorker(ctx context.Context, id int) {
 				continue
 			case queue.JobFailed:
 				p.cfg.Results.Publish(ctx, &queue.JobResult{
-					JobID: job.ID, Status: "failed", Error: "cancelled before execution",
+					JobID: job.ID, Status: "failed", Error: "terminated before execution",
 				})
 				continue
 			}

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -96,7 +96,19 @@ func (p *Pool) runWorker(ctx context.Context, id int) {
 			}
 			// Check if cancelled while pending.
 			state, err := p.cfg.Store.Get(job.ID)
-			if err != nil || state.Status == queue.JobFailed {
+			if err != nil {
+				p.cfg.Results.Publish(ctx, &queue.JobResult{
+					JobID: job.ID, Status: "failed", Error: "state lookup failed",
+				})
+				continue
+			}
+			switch state.Status {
+			case queue.JobCancelled:
+				p.cfg.Results.Publish(ctx, &queue.JobResult{
+					JobID: job.ID, Status: "cancelled",
+				})
+				continue
+			case queue.JobFailed:
 				p.cfg.Results.Publish(ctx, &queue.JobResult{
 					JobID: job.ID, Status: "failed", Error: "cancelled before execution",
 				})
@@ -115,6 +127,16 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	jobCtx, jobCancel := context.WithCancel(ctx)
 	defer jobCancel()
 
+	p.registry.RegisterPending(job.ID, jobCancel)
+	defer p.registry.Remove(job.ID)
+
+	// Race mitigation: close the gap between queue-check and RegisterPending
+	// for both cancel and admin-failed states.
+	if s, _ := p.cfg.Store.Get(job.ID); s != nil &&
+		(s.Status == queue.JobCancelled || s.Status == queue.JobFailed) {
+		jobCancel()
+	}
+
 	wID := fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, workerIndex)
 
 	status := &statusAccumulator{
@@ -129,7 +151,7 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	opts := bot.RunOptions{
 		OnStarted: func(pid int, command string) {
 			status.setPID(pid, command)
-			p.registry.Register(job.ID, pid, command, jobCancel)
+			p.registry.SetStarted(job.ID, pid, command)
 			logger.Info("Agent 已註冊", "phase", "處理中", "pid", pid, "command", command)
 
 			// Now that we have a PID, send first report immediately + start periodic.
@@ -184,7 +206,6 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	if stopReporter != nil {
 		close(stopReporter)
 	}
-	p.registry.Remove(job.ID)
 
 	// Clean up this job's worktree.
 	if result.RepoPath != "" {
@@ -197,7 +218,12 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	if err := p.cfg.Results.Publish(ctx, result); err != nil {
 		logger.Error("failed to publish result", "error", err)
 	}
-	logger.Info("工作完成", "phase", "完成", "status", result.Status)
+
+	if result.Status == "cancelled" {
+		logger.Info("工作已取消", "phase", "完成")
+	} else {
+		logger.Info("工作完成", "phase", "完成", "status", result.Status)
+	}
 }
 
 func (p *Pool) workerHeartbeat(ctx context.Context) {

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -29,9 +29,13 @@ type mockRepo struct {
 	removedWorktrees []string
 	cleanAllCalled   bool
 	purgedStale      bool
+	prepareHook      func()
 }
 
 func (m *mockRepo) Prepare(cloneURL, branch, token string) (string, error) {
+	if m.prepareHook != nil {
+		m.prepareHook()
+	}
 	return m.path, m.err
 }
 
@@ -382,6 +386,66 @@ func (b *blockingRunner) Run(ctx context.Context, workDir, prompt string, opts b
 	<-ctx.Done()
 	return "", ctx.Err()
 }
+
+// prepBlockingRunner blocks inside Run (simulating prep-like work) until ctx is cancelled.
+// It does NOT call OnStarted so the process registry never transitions to "started".
+type prepBlockingRunner struct {
+	started chan struct{}
+}
+
+func (b *prepBlockingRunner) Run(ctx context.Context, workDir, prompt string, opts bot.RunOptions) (string, error) {
+	close(b.started)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+// Scenario B — Kill arrives while runner is blocked during prep-like work (before OnStarted).
+func TestPool_KillDuringPrepProducesCancelledResult(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	job := &queue.Job{ID: "jprep", Repo: "o/r", SubmittedAt: time.Now()}
+
+	runner := &prepBlockingRunner{started: make(chan struct{})}
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      runner,
+		RepoCache:   &mockRepo{path: "/tmp/r"},
+		Commands:    bundle.Commands,
+		WorkerCount: 1,
+		Logger:      slog.Default(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	pool.Start(ctx)
+
+	if err := bundle.Queue.Submit(ctx, job); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	<-runner.started
+	store.UpdateStatus("jprep", queue.JobCancelled)
+	bundle.Commands.Send(ctx, queue.Command{JobID: "jprep", Action: "kill"})
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		if r.Status != "cancelled" {
+			t.Errorf("status = %q, want cancelled", r.Status)
+		}
+	case <-ctx.Done():
+		t.Fatal("no result")
+	}
+}
+
+// Scenario 7 — Watchdog-level cancel fallback (JobCancelled + CancelledAt past timeout + no worker publish)
+// is covered by TestWatchdog_CancelFallbackAfterTimeout in internal/queue/watchdog_test.go.
+// No pool-level duplication needed.
 
 func TestPool_KillOnRunningAgentProducesCancelledResult(t *testing.T) {
 	store := queue.NewMemJobStore()

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -287,3 +287,142 @@ func TestExecuteJob_NoSecretKey_EncryptedSecrets_Fails(t *testing.T) {
 		t.Error("expected job to fail when EncryptedSecrets present but no secretKey")
 	}
 }
+
+func TestPool_ShortCircuitsCancelledJobAsCancelled(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	job := &queue.Job{ID: "jc", Repo: "o/r", SubmittedAt: time.Now()}
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      &mockRunner{},
+		RepoCache:   &mockRepo{},
+		WorkerCount: 1,
+		Logger:      slog.Default(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Submit first (puts job in store as pending), then mark cancelled before
+	// starting the pool so the worker sees cancelled status deterministically.
+	if err := bundle.Queue.Submit(ctx, job); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	store.UpdateStatus("jc", queue.JobCancelled)
+
+	pool.Start(ctx)
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		if r.Status != "cancelled" {
+			t.Errorf("status = %q, want cancelled", r.Status)
+		}
+	case <-ctx.Done():
+		t.Fatal("no result")
+	}
+}
+
+func TestPool_ShortCircuitsFailedJobAsFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	job := &queue.Job{ID: "jf", Repo: "o/r", SubmittedAt: time.Now()}
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      &mockRunner{},
+		RepoCache:   &mockRepo{},
+		WorkerCount: 1,
+		Logger:      slog.Default(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Submit first (puts job in store as pending), then mark failed before
+	// starting the pool so the worker sees failed status deterministically.
+	if err := bundle.Queue.Submit(ctx, job); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	store.UpdateStatus("jf", queue.JobFailed)
+
+	pool.Start(ctx)
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		if r.Status != "failed" {
+			t.Errorf("status = %q, want failed", r.Status)
+		}
+	case <-ctx.Done():
+		t.Fatal("no result")
+	}
+}
+
+type blockingRunner struct {
+	started chan struct{}
+}
+
+func (b *blockingRunner) Run(ctx context.Context, workDir, prompt string, opts bot.RunOptions) (string, error) {
+	if opts.OnStarted != nil {
+		opts.OnStarted(1234, "fake")
+	}
+	close(b.started)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func TestPool_KillOnRunningAgentProducesCancelledResult(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	job := &queue.Job{ID: "jrun", Repo: "o/r", SubmittedAt: time.Now()}
+
+	runner := &blockingRunner{started: make(chan struct{})}
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      runner,
+		RepoCache:   &mockRepo{path: "/tmp/r"},
+		Commands:    bundle.Commands,
+		WorkerCount: 1,
+		Logger:      slog.Default(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	pool.Start(ctx)
+
+	if err := bundle.Queue.Submit(ctx, job); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	<-runner.started
+	// User cancel: mark store then send kill.
+	store.UpdateStatus("jrun", queue.JobCancelled)
+	bundle.Commands.Send(ctx, queue.Command{JobID: "jrun", Action: "kill"})
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case r := <-ch:
+		if r.Status != "cancelled" {
+			t.Errorf("status = %q, want cancelled", r.Status)
+		}
+	case <-ctx.Done():
+		t.Fatal("no result")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #36.

使用者按 Slack 取消按鈕時，Worker 過去把 SIGTERM 當成「agent 真失敗」。這個 PR 把「使用者取消」和「agent 失敗」在資料模型、執行流程、UX、metrics 上完整分開。

### 核心改動
- 新增 `JobCancelled` status + `CancelledAt` 時戳
- Executor `classifyResult` 用 store 狀態當 discriminator（user cancel vs watchdog kill vs admin force-kill）
- Registry 拆 `RegisterPending` + `SetStarted`，修掉 kill-during-prep 空洞
- Watchdog 加 `cancel_timeout` fallback（worker 掛掉 60s 後補發 cancelled result），`check()` 重排順序避開 `jobTimeout` 誤殺
- Result listener Design A：store 狀態 pre-check，completed-before-cancel race 時也走 cancelled 路徑，不建 issue
- App cancel handler 調順序：`UpdateStatus(JobCancelled)` 必須在 `Send(kill)` 之前，保證 classifier 讀得到
- Admin endpoint guard 補 `JobCancelled`；`publishCancelledFallback` 呼叫 `onKill("cancel fallback")` 供 metrics 觀察

### 預期行為
- 使用者取消 → Slack `:white_check_mark: 已取消`、無重試按鈕、log `[Worker][完成] 工作已取消`
- Metrics：`agent_executions_total{status="cancelled"}` 區分取消量；`watchdog_kills_total{reason="cancel fallback"}` 觀察 worker 故障頻率

## Test plan

- [x] `go test ./...` PASS（257 tests）
- [x] `go test -race ./...` PASS
- [x] Unit tests 覆蓋 classifier 5 個分支、registry 兩階段、memstore stamp、watchdog fallback/back-off/reorder、result_listener Design A + cancelled metrics
- [x] Integration: pool 短路 cancelled/failed、agent 執行中 Kill、prep 階段 Kill、pre-Prepare ctx guard 跳過 clone
- [ ] Manual smoke（需實機）：app+worker 本機跑，Slack 按取消 → `:white_check_mark: 已取消` + log `工作已取消`；cancel 期間 repo 大 clone 完成後才收到 cancelled；取消後 re-tag 重試正常

Spec: `docs/superpowers/specs/2026-04-17-cancel-vs-failure-design.md`
Plan: `docs/superpowers/plans/2026-04-17-cancel-vs-failure.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)