### PR TITLE
fix(github): inject token into cleaned https github.com URL

### DIFF
--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -32,15 +32,24 @@ func NewRepoCache(dir string, maxAge time.Duration, githubPAT string, logger *sl
 }
 
 // resolveURLWithToken builds a clone URL. Uses perCallToken if non-empty,
-// otherwise falls back to rc.githubPAT. Full URLs (http/git@/file://) pass
-// through unchanged — callers must ensure they don't contain stale tokens.
+// otherwise falls back to rc.githubPAT. For bare slugs (owner/repo), builds a
+// github.com HTTPS URL and injects the token. For full github.com HTTPS URLs
+// without userinfo, injects the token in place. URLs that already carry
+// credentials, non-github hosts, git@ SSH, and file:// all pass through.
 func (rc *RepoCache) resolveURLWithToken(repoRef, perCallToken string) string {
-	if strings.HasPrefix(repoRef, "http") || strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
-		return repoRef
-	}
 	token := perCallToken
 	if token == "" {
 		token = rc.githubPAT
+	}
+	if strings.HasPrefix(repoRef, "git@") || strings.HasPrefix(repoRef, "file://") {
+		return repoRef
+	}
+	const githubPrefix = "https://github.com/"
+	if strings.HasPrefix(repoRef, "http") {
+		if token != "" && strings.HasPrefix(repoRef, githubPrefix) {
+			return "https://" + token + "@github.com/" + strings.TrimPrefix(repoRef, githubPrefix)
+		}
+		return repoRef
 	}
 	if token != "" {
 		return fmt.Sprintf("https://%s@github.com/%s.git", token, repoRef)

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -210,6 +210,62 @@ func TestRepoCache_ResolveURLWithToken_NoToken(t *testing.T) {
 	}
 }
 
+func TestRepoCache_ResolveURLWithToken_FullGithubURLInjectsToken(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "", slog.Default())
+	url := rc.resolveURLWithToken("https://github.com/owner/repo.git", "ghp_percall")
+	if url != "https://ghp_percall@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_FullGithubURLFallbackPAT(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "ghp_default", slog.Default())
+	url := rc.resolveURLWithToken("https://github.com/owner/repo.git", "")
+	if url != "https://ghp_default@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_FullGithubURLNoTokenPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "", slog.Default())
+	url := rc.resolveURLWithToken("https://github.com/owner/repo.git", "")
+	if url != "https://github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_URLWithExistingUserinfoPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "ghp_default", slog.Default())
+	url := rc.resolveURLWithToken("https://ghp_old@github.com/owner/repo.git", "ghp_new")
+	if url != "https://ghp_old@github.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_NonGithubHostPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "ghp_default", slog.Default())
+	url := rc.resolveURLWithToken("https://gitlab.com/owner/repo.git", "ghp_percall")
+	if url != "https://gitlab.com/owner/repo.git" {
+		t.Errorf("got %q", url)
+	}
+}
+
+func TestRepoCache_ResolveURLWithToken_SSHAndFilePassthrough(t *testing.T) {
+	dir := t.TempDir()
+	rc := NewRepoCache(dir, 0, "ghp_default", slog.Default())
+	if got := rc.resolveURLWithToken("git@github.com:owner/repo.git", "ghp_x"); got != "git@github.com:owner/repo.git" {
+		t.Errorf("git@: got %q", got)
+	}
+	if got := rc.resolveURLWithToken("file:///tmp/repo", "ghp_x"); got != "file:///tmp/repo" {
+		t.Errorf("file://: got %q", got)
+	}
+}
+
 func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)


### PR DESCRIPTION
## Summary

- Worker-side `git clone` against private repos failed with `exit status 128` because `resolveURLWithToken` dropped the token whenever `repoRef` already had an `http` prefix.
- After `cd74421` the workflow stores `CloneURL` in the clean form (`https://github.com/owner/repo.git`) with the token carried separately in encrypted secrets. The early-return was leftover from the pre-refactor world where tokens lived inside the URL.
- Now `https://github.com/...` URLs without userinfo get the token injected in place; URLs already carrying credentials, non-GitHub hosts, `git@` SSH, and `file://` still pass through untouched.

## Root cause log line

```
14:05:55 INFO  [GitHub][處理中] 開始 clone repo repo=https://github.com/softleader/jasmine-cki-fir.git ...
14:05:56 INFO  [Worker][完成] 工作完成 worker_id=2 status=failed
...
06:05:56 WARN  [Agent][降級] 工作失敗 error=repo prepare failed: git clone failed: exit status 128 raw_output=
```

Clean URL in the worker log (no `***@` prefix) is the fingerprint — app-side clone at `06:05:44` succeeded because it passes the bare slug, which hits the token-injecting branch.

## Test plan

- [x] `go test ./internal/github/...` — added 6 new cases covering full URL injection (per-call / fallback PAT / no token), existing userinfo passthrough, non-github host passthrough, SSH + `file://` passthrough
- [x] `go test ./internal/bot/... ./internal/worker/...` — no regressions
- [x] `go build ./...`
- [ ] Validate in a dev/staging env: trigger a triage against a private repo, confirm worker clone succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)