### PR TITLE
fix(bot): update job store status on success paths

### DIFF
--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -126,6 +126,7 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 
 	case result.Confidence == "low":
 		metrics.IssueRejectedTotal.WithLabelValues("low_confidence").Inc()
+		r.store.UpdateStatus(job.ID, queue.JobCompleted)
 		r.updateStatus(job, ":warning: 判斷不屬於此 repo，已跳過")
 		r.clearDedup(job)
 
@@ -284,6 +285,7 @@ func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job,
 
 	url, err := r.github.CreateIssue(ctx, owner, repo, result.Title, body, result.Labels)
 	if err != nil {
+		r.store.UpdateStatus(job.ID, queue.JobFailed)
 		r.updateStatus(job, fmt.Sprintf(":warning: Triage 完成但建立 issue 失敗: %v", err))
 		return
 	}
@@ -294,6 +296,7 @@ func (r *ResultListener) createAndPostIssue(ctx context.Context, job *queue.Job,
 	}
 	metrics.IssueCreatedTotal.WithLabelValues(confidence, strconv.FormatBool(degraded)).Inc()
 
+	r.store.UpdateStatus(job.ID, queue.JobCompleted)
 	r.updateStatus(job, fmt.Sprintf(":white_check_mark: Issue created%s: %s", branchInfo, url))
 }
 

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
@@ -10,6 +11,8 @@ import (
 
 	"agentdock/internal/queue"
 )
+
+var errBoomGitHub = errors.New("github down")
 
 type mockSlackPoster struct {
 	mu       sync.Mutex
@@ -85,6 +88,39 @@ func TestResultListener_CompletedCreatesIssue(t *testing.T) {
 	if !found {
 		t.Errorf("expected issue URL in messages, got %v", slackMock.messages)
 	}
+
+	state, _ := store.Get("j1")
+	if state.Status != queue.JobCompleted {
+		t.Errorf("store status = %q, want JobCompleted", state.Status)
+	}
+}
+
+func TestResultListener_IssueCreationFailureMarksJobFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "jcerr", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1"})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	githubMock := &mockIssueCreator{err: errBoomGitHub}
+
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, githubMock, nil, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID: "jcerr", Status: "completed",
+		Title: "Bug", Body: "body", Confidence: "high", FilesFound: 2,
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	state, _ := store.Get("jcerr")
+	if state.Status != queue.JobFailed {
+		t.Errorf("store status = %q, want JobFailed", state.Status)
+	}
 }
 
 func TestResultListener_FailedPostsError(t *testing.T) {
@@ -156,6 +192,11 @@ func TestResultListener_LowConfidenceRejects(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected rejection in messages, got %v", slackMock.messages)
+	}
+
+	state, _ := store.Get("j1")
+	if state.Status != queue.JobCompleted {
+		t.Errorf("store status = %q, want JobCompleted", state.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

`ResultListener` only wrote a terminal status to the app-side `JobStore` on failure and cancellation. The three success-ish branches — issue created, low-confidence skip, and triage completed but `CreateIssue` errored — all left `JobState.Status` stuck at whatever `Submit` had put there (`JobPending`).

## The symptom

From a real run:

```
06:36:23 [Agent][完成] 工作完成 job_id=20260417-063029-0ff4 status=completed ...
06:36:23 [GitHub][完成] Issue 建立成功 url=.../issues/1471 duration_ms=610
06:42:53 [Queue][失敗] 強制終止逾時工作 job_id=20260417-063029-0ff4 status=pending reason=agent idle timeout
14:42:53 [Worker][失敗] 終止指令失敗 error=no running agent for job ...
```

Five minutes after the agent's last status report, Watchdog sees the store status is still non-terminal, fires \`agent idle timeout\`, sends \`kill\` to the worker (whose agent is long gone), stamps the store as \`JobFailed\`, and republishes a spurious failed result. The dedup guard in \`handleResult\` drops the extra result so Slack stays clean, but the permanent record in \`/jobs\` + metrics flips from \`completed\` (worker's view) to \`failed\` (watchdog's view).

## Changes

- `internal/bot/result_listener.go:129` — low-confidence skip → \`JobCompleted\`
- `internal/bot/result_listener.go:287` — \`CreateIssue\` error → \`JobFailed\` (delivery failed even though agent succeeded)
- `internal/bot/result_listener.go:297` — successful issue post → \`JobCompleted\`

Sibling paths \`handleFailure\` (:222) and \`handleCancellation\` (:262) already wrote their terminal status correctly; this brings the success side in line.

## Test plan

- [x] \`go test ./internal/bot/... -run ResultListener\` — extended 2 existing tests (\`CompletedCreatesIssue\`, \`LowConfidenceRejects\`) with store-state assertions and added 1 new case (\`IssueCreationFailureMarksJobFailed\`)
- [x] \`go test ./...\` — 264/264 pass
- [x] \`go build ./...\`
- [ ] Validate in a dev env: complete a triage end-to-end, confirm \`/jobs\` shows \`completed\` and watchdog does not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)