### PR TITLE
fix(repo): validate repo_cache.dir and use detached worktrees

### DIFF
--- a/cmd/agentdock/validate.go
+++ b/cmd/agentdock/validate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"agentdock/internal/config"
@@ -50,6 +51,15 @@ func validate(cfg *config.Config) error {
 	}
 	if cfg.Logging.RetentionDays < 1 {
 		errs = append(errs, "logging.retention_days must be >= 1")
+	}
+	// repo_cache.dir must be absolute — relative/empty leaks clones into cwd.
+	if cfg.RepoCache.Dir == "" {
+		errs = append(errs, "repo_cache.dir must not be empty; delete the line to use the default, or set an absolute path")
+	} else if !filepath.IsAbs(cfg.RepoCache.Dir) {
+		errs = append(errs, fmt.Sprintf("repo_cache.dir must be an absolute path, got %q", cfg.RepoCache.Dir))
+	}
+	if cfg.RepoCache.MaxAge <= 0 {
+		errs = append(errs, "repo_cache.max_age must be > 0")
 	}
 
 	if len(errs) > 0 {

--- a/cmd/agentdock/validate_test.go
+++ b/cmd/agentdock/validate_test.go
@@ -33,6 +33,33 @@ func TestValidate_WorkersZero_RedisTransport(t *testing.T) {
 	}
 }
 
+func TestValidate_RepoCacheDirEmpty(t *testing.T) {
+	cfg := goodConfig()
+	cfg.RepoCache.Dir = ""
+	err := validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "repo_cache.dir must not be empty") {
+		t.Errorf("expected repo_cache.dir empty error, got %v", err)
+	}
+}
+
+func TestValidate_RepoCacheDirRelative(t *testing.T) {
+	cfg := goodConfig()
+	cfg.RepoCache.Dir = "relative/path"
+	err := validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		t.Errorf("expected repo_cache.dir absolute-path error, got %v", err)
+	}
+}
+
+func TestValidate_RepoCacheMaxAgeZero(t *testing.T) {
+	cfg := goodConfig()
+	cfg.RepoCache.MaxAge = 0
+	err := validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "repo_cache.max_age must be > 0") {
+		t.Errorf("expected repo_cache.max_age error, got %v", err)
+	}
+}
+
 func TestValidate_MultipleErrors_ListedAtOnce(t *testing.T) {
 	cfg := goodConfig()
 	cfg.Workers.Count = 0
@@ -69,5 +96,6 @@ func goodConfig() *config.Config {
 		MaxThreadMessages: 50,
 		SemaphoreTimeout:  30 * time.Second,
 		Logging:           config.LoggingConfig{RetentionDays: 30},
+		RepoCache:         config.RepoCacheConfig{Dir: "/tmp/agentdock-repos", MaxAge: 10 * time.Minute},
 	}
 }

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -22,6 +22,12 @@ type RepoCache struct {
 }
 
 func NewRepoCache(dir string, maxAge time.Duration, githubPAT string, logger *slog.Logger) *RepoCache {
+	// Abs-resolve so relative paths don't leak clones into the worker's cwd.
+	if dir != "" {
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+	}
 	return &RepoCache{
 		dir:       dir,
 		maxAge:    maxAge,
@@ -183,16 +189,19 @@ func (rc *RepoCache) Checkout(repoPath, branch string) error {
 	return nil
 }
 
-// AddWorktree creates an isolated working directory from a bare cache.
-// If branch is empty, checks out the default branch (HEAD).
+// AddWorktree creates a detached-HEAD worktree from a bare cache. --detach
+// avoids locking the branch so concurrent jobs on the same branch coexist and
+// a prior crash's orphan admin record can't block new adds. Prunes first to
+// clear any orphan <bare>/worktrees/NAME records left by past crashes.
 func (rc *RepoCache) AddWorktree(barePath, branch, worktreePath string) error {
-	var cmd *exec.Cmd
-	if branch == "" {
-		cmd = exec.Command("git", "-C", barePath, "worktree", "add", worktreePath, "HEAD")
-	} else {
-		// Bare repo branches are in refs/heads/, not refs/remotes/origin/.
-		cmd = exec.Command("git", "-C", barePath, "worktree", "add", worktreePath, branch)
+	pruneCmd := exec.Command("git", "-C", barePath, "worktree", "prune")
+	_, _ = pruneCmd.CombinedOutput() // best-effort
+
+	ref := "HEAD"
+	if branch != "" {
+		ref = branch
 	}
+	cmd := exec.Command("git", "-C", barePath, "worktree", "add", "--detach", worktreePath, ref)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %w\n%s", err, out)
 	}

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -148,6 +149,88 @@ func TestRepoCache_BareCloneAndWorktree(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
 		t.Error("worktree dir should be deleted")
+	}
+}
+
+func TestRepoCache_AddWorktree_SameBranchTwice(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+
+	sourceDir := t.TempDir()
+	run(t, sourceDir, "git", "init", "--bare")
+
+	workDir := t.TempDir()
+	run(t, workDir, "git", "clone", sourceDir, ".")
+	os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main"), 0644)
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "init")
+	run(t, workDir, "git", "push")
+
+	cacheDir := t.TempDir()
+	cache := NewRepoCache(cacheDir, time.Hour, "", slog.Default())
+
+	barePath, err := cache.EnsureRepo("file://"+sourceDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	// Discover the branch name the source repo actually used (main vs master).
+	out, err := exec.Command("git", "-C", barePath, "symbolic-ref", "--short", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	branch := strings.TrimSpace(string(out))
+
+	wt1 := filepath.Join(t.TempDir(), "wt1")
+	if err := cache.AddWorktree(barePath, branch, wt1); err != nil {
+		t.Fatalf("first AddWorktree(%q) failed: %v", branch, err)
+	}
+	wt2 := filepath.Join(t.TempDir(), "wt2")
+	if err := cache.AddWorktree(barePath, branch, wt2); err != nil {
+		t.Fatalf("second AddWorktree(%q) failed: %v", branch, err)
+	}
+}
+
+func TestRepoCache_AddWorktree_PrunesStaleAdminRecord(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+
+	sourceDir := t.TempDir()
+	run(t, sourceDir, "git", "init", "--bare")
+
+	workDir := t.TempDir()
+	run(t, workDir, "git", "clone", sourceDir, ".")
+	os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main"), 0644)
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "init")
+	run(t, workDir, "git", "push")
+
+	cacheDir := t.TempDir()
+	cache := NewRepoCache(cacheDir, time.Hour, "", slog.Default())
+	barePath, err := cache.EnsureRepo("file://"+sourceDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	// Simulate a crashed worker: create worktree, then rm working dir but
+	// leave the admin record at <bare>/worktrees/NAME behind.
+	doomed := filepath.Join(t.TempDir(), "doomed")
+	if err := cache.AddWorktree(barePath, "", doomed); err != nil {
+		t.Fatalf("AddWorktree(doomed) failed: %v", err)
+	}
+	if err := os.RemoveAll(doomed); err != nil {
+		t.Fatalf("rm doomed: %v", err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(barePath, "worktrees"))
+	if len(entries) == 0 {
+		t.Fatal("expected leftover admin record for test setup")
+	}
+
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	if err := cache.AddWorktree(barePath, "", fresh); err != nil {
+		t.Fatalf("AddWorktree(fresh) after stale admin: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 症狀

```
error=repo prepare failed: git worktree add: exit status 128
fatal: 'main' is already used by worktree at
'/Users/ivantseng/local_file/slack-issue-bot/8c0db23302ae37c7/worktrees/triage-repo-4185577299'
```

以及同時出現：
- 啟動時 `啟動時清理舊 repo 快取失敗 error=mkdir : no such file or directory`
- Bare clones 跟 worktrees/ 長在 worker 啟動的工作目錄底下（像是專案根目錄）
- Agent 讀到同目錄的其他 repo

## 根因

設定檔中存在 `repo_cache.dir: ""` 這種空字串，會在 koanf file layer 蓋掉 defaults。一旦 `rc.dir=""`：

- `filepath.Join("", hash)` → `"<hash>"`（相對路徑）→ `git clone` / `git worktree add` 在 worker cwd 執行，clone 散落到啟動位置
- `PurgeStale` 的 `os.MkdirAll("")` 直接噴 `mkdir : no such file or directory`，Worktree 殘骸永遠留著
- 殘骸裡的 `worktrees/NAME` 還綁定著 `main` branch → 下一次 `git worktree add ... main` 直接失敗

## 修法

分成共用跟 worker 兩部分：

**共用（app + worker）**
- `validate()` 拒絕空 / 相對路徑的 `repo_cache.dir`、以及 `repo_cache.max_age <= 0`。空值給可操作的建議：「刪掉這行讓 default 生效，或填絕對路徑」
- `NewRepoCache` 防禦性 `filepath.Abs`，避免任何漏網的相對路徑再把 clone 丟到 cwd

**Worker 端**
- `AddWorktree` 先跑 `git worktree prune` 清殘骸，然後用 `--detach <ref>`
  - Triage 是唯讀操作（agent 只探索，不 push），detached HEAD 足夠
  - 兩個 job 同時抓同一 branch 不再互撞
  - 過去 crash 留下的 `worktrees/NAME` 孤兒記錄不會卡新的 add

App 的 `RepoCache` 只用在 branch 清單（read-only），不經過 `AddWorktree`，行為不受 `--detach` 影響。

## 使用者側需要做的

你本機的 `~/.config/agentdock/config.yaml` 目前有：

```yaml
repo_cache:
    dir: ""
    max_age: 0s
```

升級後啟動會直接 fail with 明確訊息。解法二選一：
1. 把整個 `repo_cache` 區塊刪掉，讓 `applyDefaults` 自動補 `~/Library/Caches/agentdock/repos` + `10m`
2. 手動填絕對路徑跟合理的 `max_age`

另外專案根目錄下的 `4bc00917742ce26d/`、`8c0db23302ae37c7/` 是之前洩漏出來的 bare clones，可以直接 `rm -rf` 清掉。

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` — 269 passed（包含 3 個新 validate tests + 2 個新 worktree tests）
- [x] 新測試涵蓋：
  - `TestValidate_RepoCacheDirEmpty` / `DirRelative` / `MaxAgeZero`
  - `TestRepoCache_AddWorktree_SameBranchTwice`（同 branch 兩個 worktree 共存）
  - `TestRepoCache_AddWorktree_PrunesStaleAdminRecord`（殘骸自動清理）
- [ ] 手動：用壞掉的 config 跑 `agentdock worker`，確認錯誤訊息清楚
- [ ] 手動：連續 kill + restart worker 多次，確認同一 repo+branch 的後續 job 不再卡 `already used`

🤖 Generated with [Claude Code](https://claude.com/claude-code)