### PR TITLE
fix(bot): correct opencode/codex CLI flags and extract clean output

### DIFF
--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -21,9 +21,10 @@ agents:
     stream: true                      # enable real-time event tracking
   opencode:
     command: opencode
-    args: ["--prompt", "{prompt}"]
+    args: ["run", "--format", "json", "{prompt}"]
     timeout: 5m
     skill_dir: ".opencode/skills"
+    stream_format: "opencode"         # parse opencode NDJSON; keep text events only
 
 active_agent: claude
 providers: [claude, opencode]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,9 +21,10 @@ agents:
     stream: true                      # 啟用即時事件追蹤
   opencode:
     command: opencode
-    args: ["--prompt", "{prompt}"]
+    args: ["run", "--format", "json", "{prompt}"]
     timeout: 5m
     skill_dir: ".opencode/skills"
+    stream_format: "opencode"         # 解析 opencode NDJSON，只取 text events
 
 active_agent: claude
 providers: [claude, opencode]

--- a/internal/bot/agent.go
+++ b/internal/bot/agent.go
@@ -83,27 +83,47 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 
 	const maxArgLen = 32 * 1024 // 32KB safe limit for command args
 
-	// Check if prompt fits in args or needs stdin fallback.
-	hasPlaceholder := false
+	hasPromptPlaceholder := false
+	hasOutputFilePlaceholder := false
 	for _, a := range agent.Args {
 		if strings.Contains(a, "{prompt}") {
-			hasPlaceholder = true
-			break
+			hasPromptPlaceholder = true
+		}
+		if strings.Contains(a, "{output_file}") {
+			hasOutputFilePlaceholder = true
 		}
 	}
 
-	useStdin := !hasPlaceholder || len(prompt) >= maxArgLen
+	// Some CLIs (e.g. `codex exec -o <file>`) write their final message to a
+	// path instead of stdout. Allocate a temp file and let the caller read from
+	// it after the process exits; the {output_file} placeholder opts into this.
+	var outputFile string
+	if hasOutputFilePlaceholder {
+		f, err := os.CreateTemp("", "agentdock-output-*.txt")
+		if err != nil {
+			return "", fmt.Errorf("create output file: %w", err)
+		}
+		outputFile = f.Name()
+		_ = f.Close()
+		defer os.Remove(outputFile)
+	}
+
+	useStdin := !hasPromptPlaceholder || len(prompt) >= maxArgLen
 	var args []string
-	if useStdin && hasPlaceholder {
-		// Prompt too large for args — drop the placeholder arg, use stdin instead.
+	if useStdin && hasPromptPlaceholder {
+		// Prompt too large for args — drop the prompt arg, use stdin instead.
 		for _, a := range agent.Args {
-			if !strings.Contains(a, "{prompt}") {
-				args = append(args, a)
+			if strings.Contains(a, "{prompt}") {
+				continue
 			}
+			args = append(args, strings.ReplaceAll(a, "{output_file}", outputFile))
 		}
 		logger.Info("Prompt 過大，改用 stdin", "phase", "處理中", "prompt_len", len(prompt))
 	} else {
-		args = substitutePrompt(agent.Args, prompt)
+		args = substitutePlaceholders(agent.Args, map[string]string{
+			"{prompt}":      prompt,
+			"{output_file}": outputFile,
+		})
 	}
 
 	cmd := exec.CommandContext(ctx, agent.Command, args...)
@@ -148,12 +168,16 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 	logger.Info("Agent process 已啟動", "phase", "處理中", "command", agent.Command, "pid", cmd.Process.Pid)
 
 	// Read stdout in a goroutine; wait for it before cmd.Wait().
+	format := agent.StreamFormat
+	if format == "" && agent.Stream {
+		format = "claude"
+	}
 	var output string
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		output = readOutput(ctx, stdoutPipe, agent.Stream, opts.OnEvent)
+		output = readOutput(ctx, stdoutPipe, format, opts.OnEvent)
 	}()
 	wg.Wait()
 
@@ -167,12 +191,20 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 		}
 		return "", err
 	}
+	if outputFile != "" {
+		data, readErr := os.ReadFile(outputFile)
+		if readErr != nil {
+			return "", fmt.Errorf("read output file: %w", readErr)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
 	return strings.TrimSpace(output), nil
 }
 
-// readOutput routes stdout through the appropriate reader based on stream config.
-func readOutput(ctx context.Context, r io.Reader, stream bool, onEvent func(queue.StreamEvent)) string {
-	if !stream {
+// readOutput routes stdout through the appropriate reader based on format.
+// "" => raw text; "claude" => claude stream-json; "opencode" => opencode --format json.
+func readOutput(ctx context.Context, r io.Reader, format string, onEvent func(queue.StreamEvent)) string {
+	if format == "" {
 		return queue.ReadRawOutput(r)
 	}
 
@@ -202,16 +234,24 @@ func readOutput(ctx context.Context, r io.Reader, stream bool, onEvent func(queu
 		}
 	}()
 
-	result = queue.ReadStreamJSON(r, eventCh)
+	switch format {
+	case "opencode":
+		result = queue.ReadOpenCodeJSON(r, eventCh)
+	default:
+		result = queue.ReadStreamJSON(r, eventCh)
+	}
 	close(eventCh)
 	wg.Wait()
 	return result
 }
 
-func substitutePrompt(args []string, prompt string) []string {
+func substitutePlaceholders(args []string, values map[string]string) []string {
 	result := make([]string, 0, len(args))
 	for _, a := range args {
-		result = append(result, strings.ReplaceAll(a, "{prompt}", prompt))
+		for k, v := range values {
+			a = strings.ReplaceAll(a, k, v)
+		}
+		result = append(result, a)
 	}
 	return result
 }

--- a/internal/bot/agent_test.go
+++ b/internal/bot/agent_test.go
@@ -157,6 +157,59 @@ echo "padding padding padding padding padding padding padding"
 	}
 }
 
+func TestAgentRunner_OutputFilePlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "outfile-agent")
+	// Script writes clean text to $2 (the -o path) and prints noise to stdout.
+	// Runner must return the file content, not the stdout noise.
+	os.WriteFile(script, []byte(`#!/bin/sh
+echo "noisy stdout header"
+printf '%s' "clean answer from file" > "$2"
+echo "noisy stdout footer"
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"-o", "{output_file}", "{prompt}"}, Timeout: 5 * time.Second},
+	})
+
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test prompt", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if output != "clean answer from file" {
+		t.Errorf("expected file content, got: %q", output)
+	}
+	if strings.Contains(output, "noisy") {
+		t.Errorf("output must not contain stdout noise, got: %q", output)
+	}
+}
+
+func TestAgentRunner_OutputFileCleanedUp(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "outfile-agent")
+	os.WriteFile(script, []byte(`#!/bin/sh
+printf 'x' > "$2"
+echo "$2" > `+filepath.Join(dir, "captured-path.txt")+`
+`), 0755)
+
+	runner := NewAgentRunner([]config.AgentConfig{
+		{Command: script, Args: []string{"-o", "{output_file}", "{prompt}"}, Timeout: 5 * time.Second},
+	})
+
+	_, err := runner.Run(context.Background(), slog.Default(), dir, "p", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	captured, err := os.ReadFile(filepath.Join(dir, "captured-path.txt"))
+	if err != nil {
+		t.Fatalf("read captured path: %v", err)
+	}
+	tmpPath := strings.TrimSpace(string(captured))
+	if _, statErr := os.Stat(tmpPath); !os.IsNotExist(statErr) {
+		t.Errorf("temp output file %q should have been removed, statErr=%v", tmpPath, statErr)
+	}
+}
+
 func TestAgentRunner_CancelShortCircuitsProviderChain(t *testing.T) {
 	runner := &AgentRunner{
 		agents: []config.AgentConfig{

--- a/internal/config/builtin_agents.go
+++ b/internal/config/builtin_agents.go
@@ -18,15 +18,15 @@ var BuiltinAgents = map[string]AgentConfig{
 	},
 	"codex": {
 		Command:  "codex",
-		Args:     []string{"--print", "--output-format", "stream-json", "-p", "{prompt}"},
+		Args:     []string{"exec", "--skip-git-repo-check", "-o", "{output_file}", "{prompt}"},
 		Timeout:  15 * time.Minute,
 		SkillDir: ".codex/skills",
-		Stream:   true,
 	},
 	"opencode": {
-		Command:  "opencode",
-		Args:     []string{"--prompt", "{prompt}"},
-		Timeout:  15 * time.Minute,
-		SkillDir: ".opencode/skills",
+		Command:      "opencode",
+		Args:         []string{"run", "--format", "json", "{prompt}"},
+		Timeout:      15 * time.Minute,
+		SkillDir:     ".opencode/skills",
+		StreamFormat: "opencode",
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,9 @@ type AgentConfig struct {
 	Timeout  time.Duration `yaml:"timeout"`
 	SkillDir string        `yaml:"skill_dir"`
 	Stream   bool          `yaml:"stream"`
+	// StreamFormat picks the stdout parser: "claude" (stream-json), "opencode"
+	// (--format json), or "" (raw). Empty + Stream=true legacy-maps to "claude".
+	StreamFormat string `yaml:"stream_format"`
 }
 
 type QueueConfig struct {

--- a/internal/queue/stream.go
+++ b/internal/queue/stream.go
@@ -94,6 +94,55 @@ func ReadStreamJSON(r io.Reader, eventCh chan<- StreamEvent) string {
 	return reassembled.String()
 }
 
+// ReadOpenCodeJSON reads NDJSON from `opencode run --format json`.
+// Event shape: {"type":"<event>","timestamp":...,"sessionID":"...", part/error: ...}.
+// Strategy: accumulate every "text" event's part.text; emit tool_use for visibility.
+// Tool output and CLI chrome that normally pollute stdout are ignored.
+func ReadOpenCodeJSON(r io.Reader, eventCh chan<- StreamEvent) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var buf strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		var raw map[string]any
+		if json.Unmarshal([]byte(line), &raw) != nil {
+			continue
+		}
+		eventType, _ := raw["type"].(string)
+		switch eventType {
+		case "text":
+			part, _ := raw["part"].(map[string]any)
+			if part == nil {
+				continue
+			}
+			text, _ := part["text"].(string)
+			if text == "" {
+				continue
+			}
+			if buf.Len() > 0 {
+				buf.WriteString("\n\n")
+			}
+			buf.WriteString(text)
+			select {
+			case eventCh <- StreamEvent{Type: "message_delta", TextBytes: len(text)}:
+			default:
+			}
+		case "tool_use":
+			part, _ := raw["part"].(map[string]any)
+			if part == nil {
+				continue
+			}
+			tool, _ := part["tool"].(string)
+			select {
+			case eventCh <- StreamEvent{Type: "tool_use", ToolName: tool}:
+			default:
+			}
+		}
+	}
+	return buf.String()
+}
+
 // ReadRawOutput reads plain text stdout (non-stream agents).
 func ReadRawOutput(r io.Reader) string {
 	scanner := bufio.NewScanner(r)

--- a/internal/queue/stream_test.go
+++ b/internal/queue/stream_test.go
@@ -66,6 +66,55 @@ func TestReadStreamJSON_FallbackToReassembly(t *testing.T) {
 	}
 }
 
+func TestReadOpenCodeJSON_AccumulatesTextParts(t *testing.T) {
+	// opencode `run --format json` emits one NDJSON line per event.
+	// Shape: {"type":"<event>","timestamp":...,"sessionID":"...", ...}
+	// Text parts arrive via {"type":"text","part":{"type":"text","text":"..."}}
+	input := `{"type":"step_start","timestamp":1,"sessionID":"s1","part":{}}
+{"type":"tool_use","timestamp":2,"sessionID":"s1","part":{"type":"tool","tool":"bash","state":{"status":"completed"}}}
+{"type":"text","timestamp":3,"sessionID":"s1","part":{"type":"text","text":"First paragraph."}}
+{"type":"tool_use","timestamp":4,"sessionID":"s1","part":{"type":"tool","tool":"read","state":{"status":"completed"}}}
+{"type":"text","timestamp":5,"sessionID":"s1","part":{"type":"text","text":"Second paragraph."}}
+{"type":"step_finish","timestamp":6,"sessionID":"s1","part":{}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 100)
+	text := ReadOpenCodeJSON(r, eventCh)
+	close(eventCh)
+
+	if !strings.Contains(text, "First paragraph.") || !strings.Contains(text, "Second paragraph.") {
+		t.Errorf("text missing paragraphs: %q", text)
+	}
+	if strings.Contains(text, "bash") || strings.Contains(text, "tool_use") {
+		t.Errorf("text should not contain tool noise: %q", text)
+	}
+
+	var tools []string
+	for e := range eventCh {
+		if e.Type == "tool_use" {
+			tools = append(tools, e.ToolName)
+		}
+	}
+	if len(tools) != 2 || tools[0] != "bash" || tools[1] != "read" {
+		t.Errorf("expected [bash, read] tool_use events, got %v", tools)
+	}
+}
+
+func TestReadOpenCodeJSON_IgnoresMalformedLines(t *testing.T) {
+	input := `not json at all
+{"type":"text","part":{"type":"text","text":"kept"}}
+{broken json
+`
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	text := ReadOpenCodeJSON(r, eventCh)
+	close(eventCh)
+
+	if !strings.Contains(text, "kept") {
+		t.Errorf("should keep valid text event: %q", text)
+	}
+}
+
 func TestReadRawOutput(t *testing.T) {
 	input := "line1\nline2\nline3"
 	r := strings.NewReader(input)


### PR DESCRIPTION
## Summary

- **opencode**: the bot was calling `opencode --prompt "..."`, which actually invokes the default TUI command with `--prompt` as the initial-message flag. The TUI never EOFs / never writes the LLM reply to stdout, so `cmd.Wait()` blocked until the 15-minute context timeout. Now we call the proper non-interactive subcommand `opencode run --format json "{prompt}"` and parse the NDJSON event stream, keeping only `text` events.
- **codex**: the previous invocation `codex --print --output-format stream-json -p "{prompt}"` is all wrong — none of `--print` / `--output-format` exist, and `-p` is `--profile` (so our prompt was being interpreted as a profile name). Now we call `codex exec --skip-git-repo-check -o {output_file} "{prompt}"` and read the final agent message out of the output file, so the human-readable headers / tool traces / `tokens used` footer never pollute the issue body.
- **Generic mechanism, not codex-specific**: `AgentRunner` now understands a `{output_file}` placeholder. Any CLI that can write its final message to a path can opt in without leaking CLI knowledge into the runner.
- **Config schema**: `AgentConfig` gains `stream_format` (`"claude"` / `"opencode"` / `""`). The legacy `stream: true` still works and maps to `"claude"`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 273 tests pass, including two new parser tests for `ReadOpenCodeJSON` and two new runner tests covering the `{output_file}` placeholder lifecycle (content capture + temp-file cleanup)
- [ ] Manual smoke: run a real worker with `PROVIDERS=opencode` against a thread and confirm the issue body is clean text with no `> orchestrator · model` header or tool-trace lines
- [ ] Manual smoke: same with `PROVIDERS=codex`, confirm `OpenAI Codex v...` header and `tokens used` footer do not appear in the final output

## Notes / follow-ups not in this PR

- `codex exec` still defaults to per-command approval in non-interactive mode. If the worker env is already sandboxed you'll likely want to add `--full-auto` or `--dangerously-bypass-approvals-and-sandbox` in the deployment's config override — left as a posture decision.
- opencode upstream has a latent race in `packages/opencode/src/cli/cmd/run.ts:634` where `loop()` is fire-and-forget while `sdk.session.prompt()` is awaited — if the final SSE events aren't drained before `process.exit()`, we may miss trailing text. Switching to `--format json` still depends on the same loop, so if you see truncated output in practice we can look at a workaround (e.g. `opencode serve` + direct HTTP) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)