### PR TITLE
fix(bot): revert opencode to default format; drop unused stream_format

### DIFF
--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -21,10 +21,9 @@ agents:
     stream: true                      # enable real-time event tracking
   opencode:
     command: opencode
-    args: ["run", "--format", "json", "{prompt}"]
+    args: ["run", "{prompt}"]
     timeout: 5m
     skill_dir: ".opencode/skills"
-    stream_format: "opencode"         # parse opencode NDJSON; keep text events only
 
 active_agent: claude
 providers: [claude, opencode]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,10 +21,9 @@ agents:
     stream: true                      # 啟用即時事件追蹤
   opencode:
     command: opencode
-    args: ["run", "--format", "json", "{prompt}"]
+    args: ["run", "{prompt}"]
     timeout: 5m
     skill_dir: ".opencode/skills"
-    stream_format: "opencode"         # 解析 opencode NDJSON，只取 text events
 
 active_agent: claude
 providers: [claude, opencode]

--- a/internal/bot/agent.go
+++ b/internal/bot/agent.go
@@ -168,16 +168,12 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 	logger.Info("Agent process 已啟動", "phase", "處理中", "command", agent.Command, "pid", cmd.Process.Pid)
 
 	// Read stdout in a goroutine; wait for it before cmd.Wait().
-	format := agent.StreamFormat
-	if format == "" && agent.Stream {
-		format = "claude"
-	}
 	var output string
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		output = readOutput(ctx, stdoutPipe, format, opts.OnEvent)
+		output = readOutput(ctx, stdoutPipe, agent.Stream, opts.OnEvent)
 	}()
 	wg.Wait()
 
@@ -201,10 +197,9 @@ func (r *AgentRunner) runOne(ctx context.Context, logger *slog.Logger, agent con
 	return strings.TrimSpace(output), nil
 }
 
-// readOutput routes stdout through the appropriate reader based on format.
-// "" => raw text; "claude" => claude stream-json; "opencode" => opencode --format json.
-func readOutput(ctx context.Context, r io.Reader, format string, onEvent func(queue.StreamEvent)) string {
-	if format == "" {
+// readOutput routes stdout through the appropriate reader based on stream config.
+func readOutput(ctx context.Context, r io.Reader, stream bool, onEvent func(queue.StreamEvent)) string {
+	if !stream {
 		return queue.ReadRawOutput(r)
 	}
 
@@ -234,12 +229,7 @@ func readOutput(ctx context.Context, r io.Reader, format string, onEvent func(qu
 		}
 	}()
 
-	switch format {
-	case "opencode":
-		result = queue.ReadOpenCodeJSON(r, eventCh)
-	default:
-		result = queue.ReadStreamJSON(r, eventCh)
-	}
+	result = queue.ReadStreamJSON(r, eventCh)
 	close(eventCh)
 	wg.Wait()
 	return result

--- a/internal/config/builtin_agents.go
+++ b/internal/config/builtin_agents.go
@@ -23,10 +23,9 @@ var BuiltinAgents = map[string]AgentConfig{
 		SkillDir: ".codex/skills",
 	},
 	"opencode": {
-		Command:      "opencode",
-		Args:         []string{"run", "--format", "json", "{prompt}"},
-		Timeout:      15 * time.Minute,
-		SkillDir:     ".opencode/skills",
-		StreamFormat: "opencode",
+		Command:  "opencode",
+		Args:     []string{"run", "{prompt}"},
+		Timeout:  15 * time.Minute,
+		SkillDir: ".opencode/skills",
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,9 +60,6 @@ type AgentConfig struct {
 	Timeout  time.Duration `yaml:"timeout"`
 	SkillDir string        `yaml:"skill_dir"`
 	Stream   bool          `yaml:"stream"`
-	// StreamFormat picks the stdout parser: "claude" (stream-json), "opencode"
-	// (--format json), or "" (raw). Empty + Stream=true legacy-maps to "claude".
-	StreamFormat string `yaml:"stream_format"`
 }
 
 type QueueConfig struct {

--- a/internal/queue/stream.go
+++ b/internal/queue/stream.go
@@ -94,55 +94,6 @@ func ReadStreamJSON(r io.Reader, eventCh chan<- StreamEvent) string {
 	return reassembled.String()
 }
 
-// ReadOpenCodeJSON reads NDJSON from `opencode run --format json`.
-// Event shape: {"type":"<event>","timestamp":...,"sessionID":"...", part/error: ...}.
-// Strategy: accumulate every "text" event's part.text; emit tool_use for visibility.
-// Tool output and CLI chrome that normally pollute stdout are ignored.
-func ReadOpenCodeJSON(r io.Reader, eventCh chan<- StreamEvent) string {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-
-	var buf strings.Builder
-	for scanner.Scan() {
-		line := scanner.Text()
-		var raw map[string]any
-		if json.Unmarshal([]byte(line), &raw) != nil {
-			continue
-		}
-		eventType, _ := raw["type"].(string)
-		switch eventType {
-		case "text":
-			part, _ := raw["part"].(map[string]any)
-			if part == nil {
-				continue
-			}
-			text, _ := part["text"].(string)
-			if text == "" {
-				continue
-			}
-			if buf.Len() > 0 {
-				buf.WriteString("\n\n")
-			}
-			buf.WriteString(text)
-			select {
-			case eventCh <- StreamEvent{Type: "message_delta", TextBytes: len(text)}:
-			default:
-			}
-		case "tool_use":
-			part, _ := raw["part"].(map[string]any)
-			if part == nil {
-				continue
-			}
-			tool, _ := part["tool"].(string)
-			select {
-			case eventCh <- StreamEvent{Type: "tool_use", ToolName: tool}:
-			default:
-			}
-		}
-	}
-	return buf.String()
-}
-
 // ReadRawOutput reads plain text stdout (non-stream agents).
 func ReadRawOutput(r io.Reader) string {
 	scanner := bufio.NewScanner(r)

--- a/internal/queue/stream_test.go
+++ b/internal/queue/stream_test.go
@@ -66,55 +66,6 @@ func TestReadStreamJSON_FallbackToReassembly(t *testing.T) {
 	}
 }
 
-func TestReadOpenCodeJSON_AccumulatesTextParts(t *testing.T) {
-	// opencode `run --format json` emits one NDJSON line per event.
-	// Shape: {"type":"<event>","timestamp":...,"sessionID":"...", ...}
-	// Text parts arrive via {"type":"text","part":{"type":"text","text":"..."}}
-	input := `{"type":"step_start","timestamp":1,"sessionID":"s1","part":{}}
-{"type":"tool_use","timestamp":2,"sessionID":"s1","part":{"type":"tool","tool":"bash","state":{"status":"completed"}}}
-{"type":"text","timestamp":3,"sessionID":"s1","part":{"type":"text","text":"First paragraph."}}
-{"type":"tool_use","timestamp":4,"sessionID":"s1","part":{"type":"tool","tool":"read","state":{"status":"completed"}}}
-{"type":"text","timestamp":5,"sessionID":"s1","part":{"type":"text","text":"Second paragraph."}}
-{"type":"step_finish","timestamp":6,"sessionID":"s1","part":{}}`
-
-	r := strings.NewReader(input)
-	eventCh := make(chan StreamEvent, 100)
-	text := ReadOpenCodeJSON(r, eventCh)
-	close(eventCh)
-
-	if !strings.Contains(text, "First paragraph.") || !strings.Contains(text, "Second paragraph.") {
-		t.Errorf("text missing paragraphs: %q", text)
-	}
-	if strings.Contains(text, "bash") || strings.Contains(text, "tool_use") {
-		t.Errorf("text should not contain tool noise: %q", text)
-	}
-
-	var tools []string
-	for e := range eventCh {
-		if e.Type == "tool_use" {
-			tools = append(tools, e.ToolName)
-		}
-	}
-	if len(tools) != 2 || tools[0] != "bash" || tools[1] != "read" {
-		t.Errorf("expected [bash, read] tool_use events, got %v", tools)
-	}
-}
-
-func TestReadOpenCodeJSON_IgnoresMalformedLines(t *testing.T) {
-	input := `not json at all
-{"type":"text","part":{"type":"text","text":"kept"}}
-{broken json
-`
-	r := strings.NewReader(input)
-	eventCh := make(chan StreamEvent, 10)
-	text := ReadOpenCodeJSON(r, eventCh)
-	close(eventCh)
-
-	if !strings.Contains(text, "kept") {
-		t.Errorf("should keep valid text event: %q", text)
-	}
-}
-
 func TestReadRawOutput(t *testing.T) {
 	input := "line1\nline2\nline3"
 	r := strings.NewReader(input)


### PR DESCRIPTION
## Symptom

Real opencode job fails with:

\`\`\`
status=failed error=parse failed: no triage result found in agent output raw_output=
\`\`\`

\`raw_output=\` is empty. The LLM clearly did reply (user pasted a well-formed \`===TRIAGE_RESULT===\` JSON block from the same prompt run manually), but the bot's capture was 0 bytes.

## Root cause

PR #72 set opencode to \`run --format json\` and added a custom NDJSON parser (\`ReadOpenCodeJSON\`) that kept only \`text\` events. In practice:

- opencode's upstream \`loop()\` at \`packages/opencode/src/cli/cmd/run.ts:634\` is fire-and-forget while \`sdk.session.prompt()\` is awaited — when \`process.exit()\` fires in the finally block, trailing SSE events can be dropped before any \`text\` event lands.
- And/or the inferred event schema doesn't match opencode 1.3.5 exactly.

Either way, the parser returned \`\"\"\` and the marker parser upstream found no \`===TRIAGE_RESULT===\`.

**The fix was also the wrong fix.** \`bot.ParseAgentOutput\` is already marker-based:

\`\`\`go
idx := strings.LastIndex(output, resultSeparator)
\`\`\`

Stdout can carry any amount of CLI chrome / tool trace / stderr bleed — the marker parser slices out the JSON tail. Chasing a \"clean output\" abstraction for opencode was solving a problem we didn't have.

## This PR

- **opencode**: \`run \"{prompt}\"\` with default format, \`Stream: false\` (raw stdout → \`ReadRawOutput\` → marker parser handles the noise).
- **Drop \`AgentConfig.StreamFormat\`, \`ReadOpenCodeJSON\`, and the format dispatch in \`agent.go\`.** Unused after opencode reverts; leaving the field around invited users to re-enable the broken path.
- **Keep** \`{output_file}\` placeholder + codex \`exec -o {output_file}\` from PR #72. That mechanism is independent and codex genuinely needs it (codex exec's default stdout mixes headers + tool output + footer, and codex has no SSE race like opencode).
- Docs / local \`config.yaml\` synced.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` — 271 pass (the two \`ReadOpenCodeJSON\` tests go away with the function; the two \`{output_file}\` tests from PR #72 stay and still pass)
- [ ] Manual smoke: re-run the same triage job (\`softleader/fglife-admin-ui\`, \`PROVIDERS=opencode\`) and confirm \`===TRIAGE_RESULT===\` JSON comes through — marker parser should slice it out regardless of the opencode header / tool-trace prefix
- [ ] Manual smoke: \`PROVIDERS=codex\` still clean (codex path unchanged)

## Notes

- If you want to keep observability of opencode's tool calls (previously emitted as \`tool_use\` events into the stream-event channel), that's gone. It wasn't wired into metrics anyway — \`queue.StreamEvent\` callbacks are only consumed for claude cost/token accounting today. Can add back if needed, but separately and only once opencode's \`--format json\` is proven to actually ship all events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)