### PR TITLE
fix(bot): tolerate non-array labels + prevent null labels to GitHub

### DIFF
--- a/internal/bot/parser.go
+++ b/internal/bot/parser.go
@@ -11,17 +11,45 @@ const (
 	minOutputLength = 10
 )
 
+// Labels is a JSON-tolerant []string. Accepts array, single string, or null —
+// some agent/model combos (observed with opencode + minimax) emit a bare string
+// like "bug" instead of ["bug"], which previously failed TriageResult unmarshal
+// and zeroed every other field.
+type Labels []string
+
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*l = nil
+		return nil
+	}
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*l = arr
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s == "" {
+			*l = nil
+		} else {
+			*l = []string{s}
+		}
+		return nil
+	}
+	return fmt.Errorf("labels must be string or array, got %s", string(data))
+}
+
 // TriageResult is the parsed result from agent output.
 type TriageResult struct {
-	Status     string   `json:"status"`
-	IssueURL   string   `json:"issue_url,omitempty"`
-	Message    string   `json:"message,omitempty"`
-	Title      string   `json:"title,omitempty"`
-	Body       string   `json:"body,omitempty"`
-	Labels     []string `json:"labels,omitempty"`
-	Confidence string   `json:"confidence,omitempty"`
-	FilesFound int      `json:"files_found,omitempty"`
-	Questions  int      `json:"open_questions,omitempty"`
+	Status     string `json:"status"`
+	IssueURL   string `json:"issue_url,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Body       string `json:"body,omitempty"`
+	Labels     Labels `json:"labels,omitempty"`
+	Confidence string `json:"confidence,omitempty"`
+	FilesFound int    `json:"files_found,omitempty"`
+	Questions  int    `json:"open_questions,omitempty"`
 }
 
 // ParseAgentOutput extracts the triage result from agent stdout.

--- a/internal/bot/parser_test.go
+++ b/internal/bot/parser_test.go
@@ -35,6 +35,61 @@ func TestParseAgentOutput_JSONCreated(t *testing.T) {
 	}
 }
 
+func TestParseAgentOutput_LabelsAsString(t *testing.T) {
+	// Some agents (observed with opencode + minimax) emit labels as a single
+	// string instead of an array. Parser must accept it and preserve the rest
+	// of the struct — prior behavior was a type error that zeroed everything.
+	output := "Investigation done.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "T",
+  "body": "B",
+  "labels": "bug",
+  "confidence": "high",
+  "files_found": 3
+}`
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if result.Status != "CREATED" || result.Title != "T" || result.Confidence != "high" || result.FilesFound != 3 {
+		t.Errorf("non-labels fields lost: %+v", result)
+	}
+	if len(result.Labels) != 1 || result.Labels[0] != "bug" {
+		t.Errorf("labels = %v, want [bug]", result.Labels)
+	}
+}
+
+func TestParseAgentOutput_LabelsAsNullOrMissing(t *testing.T) {
+	cases := []string{
+		`{"status":"CREATED","title":"T","body":"B","labels":null,"confidence":"high"}`,
+		`{"status":"CREATED","title":"T","body":"B","confidence":"high"}`,
+	}
+	for i, jsonBody := range cases {
+		output := "x\n\n===TRIAGE_RESULT===\n" + jsonBody
+		result, err := ParseAgentOutput(output)
+		if err != nil {
+			t.Fatalf("case %d parse failed: %v", i, err)
+		}
+		if result.Status != "CREATED" || result.Title != "T" {
+			t.Errorf("case %d: fields lost: %+v", i, result)
+		}
+		if result.Labels != nil && len(result.Labels) != 0 {
+			t.Errorf("case %d: labels should be nil/empty, got %v", i, result.Labels)
+		}
+	}
+}
+
+func TestParseAgentOutput_LabelsEmptyString(t *testing.T) {
+	output := "x\n\n===TRIAGE_RESULT===\n" + `{"status":"CREATED","title":"T","body":"B","labels":""}`
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(result.Labels) != 0 {
+		t.Errorf("empty string should yield no labels, got %v", result.Labels)
+	}
+}
+
 func TestParseAgentOutput_JSONRejected(t *testing.T) {
 	output := "Investigation complete.\n\n===TRIAGE_RESULT===\n" + `{
   "status": "REJECTED",

--- a/internal/github/issue.go
+++ b/internal/github/issue.go
@@ -29,10 +29,11 @@ func NewIssueClient(token string, logger *slog.Logger) *IssueClient {
 // Returns the issue HTML URL.
 func (ic *IssueClient) CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (string, error) {
 	start := time.Now()
+	normalized := normalizeLabels(labels)
 	req := &gh.IssueRequest{
 		Title:  gh.String(title),
 		Body:   gh.String(body),
-		Labels: &labels,
+		Labels: &normalized,
 	}
 
 	issue, _, err := ic.client.Issues.Create(ctx, owner, repo, req)
@@ -45,4 +46,14 @@ func (ic *IssueClient) CreateIssue(ctx context.Context, owner, repo, title, body
 
 	ic.logger.Info("Issue 建立成功", "phase", "完成", "owner", owner, "repo", repo, "url", issue.GetHTMLURL(), "duration_ms", time.Since(start).Milliseconds())
 	return issue.GetHTMLURL(), nil
+}
+
+// normalizeLabels ensures the value sent to GitHub is a non-nil slice.
+// go-github marshals a nil []string into JSON null, which GitHub rejects with
+// "For 'properties/labels', nil is not an array." (422).
+func normalizeLabels(labels []string) []string {
+	if labels == nil {
+		return []string{}
+	}
+	return labels
 }

--- a/internal/github/issue_test.go
+++ b/internal/github/issue_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestNormalizeLabels_NilBecomesEmptySlice(t *testing.T) {
+	out := normalizeLabels(nil)
+	if out == nil {
+		t.Fatal("normalizeLabels(nil) must not return nil — GitHub rejects null labels")
+	}
+	if len(out) != 0 {
+		t.Errorf("normalizeLabels(nil) = %v, want []", out)
+	}
+}
+
+func TestNormalizeLabels_PreservesExisting(t *testing.T) {
+	in := []string{"bug", "mobile"}
+	out := normalizeLabels(in)
+	if len(out) != 2 || out[0] != "bug" || out[1] != "mobile" {
+		t.Errorf("normalizeLabels(%v) = %v", in, out)
+	}
+}
+
 func TestIssueBody_WithHeader(t *testing.T) {
 	header := "**Channel**: #general\n**Reporter**: alice\n**Branch**: main\n\n---\n\n"
 	agentBody := "## Summary\n\nLogin page broken."


### PR DESCRIPTION
## Symptom

\`\`\`
[Agent][完成] 工作完成 ... status=completed title= confidence= files_found=0
[GitHub][失敗] Issue 建立失敗 ... 422 Invalid request.
  For 'properties/labels', nil is not an array. []
\`\`\`

Every TriageResult field was empty **except** Status, and the issue-create request sent \`null\` for labels.

## Root cause (two independent bugs chaining)

### 1. labels string vs []string

Agent JSON had \`\"labels\": \"bug\"\`; \`TriageResult.Labels\` was \`[]string\`. \`json.Unmarshal\` fails the **entire** struct on a single field type mismatch, so Title / Body / Confidence / FilesFound all zeroed.

Seen with opencode + \`minimax-m2.5-free\` — claude has happened to always emit an array so we never hit it before.

### 2. nil []string → JSON null

\`go-github\` marshals a nil \`*[]string\` as JSON \`null\`. GitHub's API rejects that with 422. To mean \"no labels\" you must send \`[]\` or omit the field.

Even after fix #1, a triage result that legitimately has no labels would still 422.

## Fix

- \`TriageResult.Labels\` becomes a new \`Labels\` type (underlying \`[]string\`, so no ripple changes). Its \`UnmarshalJSON\` accepts array, single string, empty string, and null. The rest of the struct survives when an agent goes off-schema.
- \`github.CreateIssue\` routes through \`normalizeLabels(labels)\` which turns nil into \`[]string{}\` before the request is built.

Both fixes earn their keep — either bug alone still triggers the 422.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` — 276 pass (+5 new)
- [x] New tests:
  - \`TestParseAgentOutput_LabelsAsString\` — \`\"bug\"\` → \`[\"bug\"]\`, other fields intact
  - \`TestParseAgentOutput_LabelsAsNullOrMissing\` — \`null\` + missing both OK
  - \`TestParseAgentOutput_LabelsEmptyString\` — \`\"\"\` → nil/empty
  - \`TestNormalizeLabels_NilBecomesEmptySlice\`
  - \`TestNormalizeLabels_PreservesExisting\`
- [ ] Manual: re-run the same triage that produced the 422 — should now create the issue with \`[\"bug\"]\` (or no labels at all, not 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)