### PR TITLE
fix(bot): reject CREATED triage results with empty title

### DIFF
--- a/internal/bot/parser.go
+++ b/internal/bot/parser.go
@@ -76,6 +76,13 @@ func ParseAgentOutput(output string) (TriageResult, error) {
 		jsonStr := extractJSON(result)
 		var tr TriageResult
 		if err := json.Unmarshal([]byte(jsonStr), &tr); err == nil && tr.Status != "" {
+			// CREATED payloads are fed directly into CreateIssue — an empty
+			// title causes GitHub to 422 mid-flight with "title can't be
+			// blank", burning retries and confusing the user. Catch it here
+			// so the failure surfaces as a clear parse error instead.
+			if tr.Status == "CREATED" && strings.TrimSpace(tr.Title) == "" {
+				return TriageResult{}, fmt.Errorf("CREATED result missing required title")
+			}
 			return tr, nil
 		}
 	}

--- a/internal/bot/parser_test.go
+++ b/internal/bot/parser_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -87,6 +88,49 @@ func TestParseAgentOutput_LabelsEmptyString(t *testing.T) {
 	}
 	if len(result.Labels) != 0 {
 		t.Errorf("empty string should yield no labels, got %v", result.Labels)
+	}
+}
+
+func TestParseAgentOutput_CreatedRequiresTitle_Empty(t *testing.T) {
+	// Agent emits Status=CREATED but an empty title — previously the bot
+	// happily sent the request and GitHub rejected with 422 "title can't be
+	// blank". Parser must reject it up-front.
+	output := "x\n\n===TRIAGE_RESULT===\n" + `{"status":"CREATED","title":"","body":"b","labels":["bug"]}`
+	_, err := ParseAgentOutput(output)
+	if err == nil {
+		t.Fatal("expected error for CREATED with empty title")
+	}
+	if !strings.Contains(err.Error(), "title") {
+		t.Errorf("error should mention title, got: %v", err)
+	}
+}
+
+func TestParseAgentOutput_CreatedRequiresTitle_Missing(t *testing.T) {
+	output := "x\n\n===TRIAGE_RESULT===\n" + `{"status":"CREATED","body":"b"}`
+	_, err := ParseAgentOutput(output)
+	if err == nil {
+		t.Fatal("expected error for CREATED without title field")
+	}
+}
+
+func TestParseAgentOutput_CreatedRequiresTitle_WhitespaceOnly(t *testing.T) {
+	output := "x\n\n===TRIAGE_RESULT===\n" + `{"status":"CREATED","title":"   \n\t","body":"b"}`
+	_, err := ParseAgentOutput(output)
+	if err == nil {
+		t.Fatal("expected error for CREATED with whitespace-only title")
+	}
+}
+
+func TestParseAgentOutput_CreatedLegacyURLNoTitleOK(t *testing.T) {
+	// Legacy "CREATED: <url>" path doesn't need a title — the issue already
+	// exists, CreateIssue won't be called, so no validation should apply.
+	output := "done.\n\n===TRIAGE_RESULT===\nCREATED: https://github.com/o/r/issues/1"
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("legacy CREATED should pass: %v", err)
+	}
+	if result.Status != "CREATED" || result.IssueURL == "" {
+		t.Errorf("unexpected result: %+v", result)
 	}
 }
 


### PR DESCRIPTION
## Symptom

Observed on a \`fglife-admin-ui\` triage using **codex** (PR #75 only patched the labels angle):

\`\`\`
[Agent][完成] 工作完成 ... status=completed title= confidence= files_found=0
[GitHub][失敗] Issue 建立失敗 ... 422 Validation Failed
  [{Resource:Issue Field:title Code:invalid Message:title can't be blank}]
\`\`\`

The agent output ends up with \`Status=\"CREATED\"\` but \`Title=\"\"\`, the bot routes it to \`CreateIssue\`, GitHub rejects with 422. User sees a cryptic backend error message.

## Fix

Client-side gate in \`ParseAgentOutput\`: \`Status=\"CREATED\"\` + blank/whitespace-only \`Title\` is now an immediate parse error (\`\"CREATED result missing required title\"\`). Benefits:

- No wasted GitHub round-trip
- Clearer user-facing failure reason (\`parse failed\` instead of \`422 title can't be blank\`)
- Catches this class of bug for any agent, not just codex

Legacy \`CREATED: <url>\` path is exempt — issue already exists, no CreateIssue call, no validation needed. Covered by \`TestParseAgentOutput_CreatedLegacyURLNoTitleOK\`.

Scope stays narrow: only CREATED + Title. REJECTED/ERROR required-field checks aren't added — YAGNI until a production case shows up.

## Suspected upstream cause (not fixed here)

codex uses the \`-o {output_file}\` wiring from PR #72 — \`--output-last-message\` writes *only the last agent message* to the temp file. If codex's final message is a wrap-up like \"完成\" and the \`===TRIAGE_RESULT===\` block was an earlier message, the temp file won't contain the full JSON — we see just enough (\`{\"status\":\"CREATED\"}\`) to pass Unmarshal + Status check, but body/title empty.

Follow-up options for a separate PR:

1. Audit whether codex's \`--output-last-message\` reliably contains the triage JSON (prompt the skill to put TRIAGE_RESULT strictly last).
2. Switch codex to stdout + marker parsing like opencode did post-PR #73 (accept the chrome noise, rely on \`strings.LastIndex(\"===TRIAGE_RESULT===\")\`).

Either way, **this PR is still worth merging on its own** — it defends the bot against any agent emitting a malformed CREATED payload, not just codex today.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — 280 pass (+4 new)
- [x] New tests:
  - \`TestParseAgentOutput_CreatedRequiresTitle_Empty\` — \`\"title\": \"\"\`
  - \`TestParseAgentOutput_CreatedRequiresTitle_Missing\` — field absent
  - \`TestParseAgentOutput_CreatedRequiresTitle_WhitespaceOnly\` — \`\" \\n\\t\"\`
  - \`TestParseAgentOutput_CreatedLegacyURLNoTitleOK\` — \`CREATED: <url>\` exempt
- [ ] Manual: rerun the codex triage that produced the 422 — should now fail as \`parse failed\` with a meaningful reason, not blow up in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)