### PR TITLE
fix(bot): switch codex to stdout+marker, drop --output-last-message

### DIFF
--- a/internal/config/builtin_agents.go
+++ b/internal/config/builtin_agents.go
@@ -18,7 +18,7 @@ var BuiltinAgents = map[string]AgentConfig{
 	},
 	"codex": {
 		Command:  "codex",
-		Args:     []string{"exec", "--skip-git-repo-check", "-o", "{output_file}", "{prompt}"},
+		Args:     []string{"exec", "--skip-git-repo-check", "--color", "never", "{prompt}"},
 		Timeout:  15 * time.Minute,
 		SkillDir: ".codex/skills",
 	},


### PR DESCRIPTION
## Per docs research (developers.openai.com/codex/cli/reference)

\`\`\`
--output-last-message <path>
  Write the assistant's final message to a file.
\`\`\`

Key word: **\"final message\"** = the single last assistant turn, not the whole transcript.

\`--output-schema\` looked promising but docs state it validates \"tool output\", not the assistant message — wrong flag for this job.

\`--json\` emits NDJSON events but the docs don't publish the event schema, so we can't commit to parsing it reliably.

## Why \`-o\` was wrong for triage

The agent's triage session can look like:

\`\`\`
msg 1 (assistant): \"Let me investigate...\"
tool call (bash)
msg 2 (assistant): \"===TRIAGE_RESULT===\\n{JSON}\"
tool call (write issue body file)
msg 3 (assistant, final): \"完成，已記錄結果。\"
\`\`\`

\`-o\` writes only msg 3. The JSON we need was in msg 2 — invisible to the parser.

Observed in production (codex + fglife-admin-ui):

\`\`\`
[Agent][完成] 工作完成 ... status=completed title= confidence= files_found=0
[GitHub][失敗] 422 Validation Failed [title can't be blank]
\`\`\`

Either msg 3 contained a stripped \`===TRIAGE_RESULT===\\n{\"status\":\"CREATED\"}\` skeleton, or parse found nothing but upstream code path still pushed CREATED — either way, unreliable.

## Fix

Switch codex to **stdout + marker** — same strategy opencode uses since PR #73:

\`\`\`diff
- \"exec\", \"--skip-git-repo-check\", \"-o\", \"{output_file}\", \"{prompt}\"
+ \"exec\", \"--skip-git-repo-check\", \"--color\", \"never\", \"{prompt}\"
\`\`\`

\`ParseAgentOutput\` uses \`strings.LastIndex(\"===TRIAGE_RESULT===\")\`, which doesn't care about the codex banner / tool traces / \`tokens used\` footer noise around the JSON. The marker-based parser is purpose-built for exactly this.

\`--color never\` defensively disables ANSI in case codex doesn't auto-disable when stdout is piped to a non-TTY.

## What this PR **doesn't** do

- The \`{output_file}\` placeholder machinery in \`internal/bot/agent.go\` is technically dead code after this change. Keeping it — removing it is a separate, reversible cleanup once we're sure we won't want it for \`--output-schema\` or a future CLI.
- PR #78 (reject CREATED with empty title) stays on its own merits — defensive backstop for any agent (today or future) emitting half-baked CREATED payloads.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — 280 pass (no new tests; behavior change only, existing marker-parser tests cover the path)
- [ ] Manual: run the fglife-admin-ui triage with \`PROVIDERS=codex\` — expect \`[Worker][完成] 解析成功 status=CREATED title=<non-empty>\` and a successful GitHub issue create
- [ ] Manual: confirm codex stdout noise (banner, \"tokens used\", tool traces) doesn't leak into the GitHub issue body — the parser slices starting from the last marker occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)