### PR TITLE
fix(bot): route REJECTED/ERROR parser results to skip/fail lanes

### DIFF
--- a/internal/bot/result_listener.go
+++ b/internal/bot/result_listener.go
@@ -127,7 +127,11 @@ func (r *ResultListener) handleResult(ctx context.Context, result *queue.JobResu
 	case result.Confidence == "low":
 		metrics.IssueRejectedTotal.WithLabelValues("low_confidence").Inc()
 		r.store.UpdateStatus(job.ID, queue.JobCompleted)
-		r.updateStatus(job, ":warning: 判斷不屬於此 repo，已跳過")
+		text := ":warning: 判斷不屬於此 repo，已跳過"
+		if result.Message != "" {
+			text = text + "\n> " + result.Message
+		}
+		r.updateStatus(job, text)
 		r.clearDedup(job)
 
 	case result.FilesFound == 0 || result.Questions >= 5:

--- a/internal/bot/result_listener_test.go
+++ b/internal/bot/result_listener_test.go
@@ -200,6 +200,44 @@ func TestResultListener_LowConfidenceRejects(t *testing.T) {
 	}
 }
 
+// REJECTED results carry the agent's reason in Message — the listener must
+// surface it so the user knows *why* we skipped, not just that we did.
+func TestResultListener_LowConfidenceIncludesMessage(t *testing.T) {
+	store := queue.NewMemJobStore()
+	store.Put(&queue.Job{ID: "jmsg", Repo: "o/r", ChannelID: "C1", ThreadTS: "T1"})
+
+	bundle := queue.NewInMemBundle(10, 3, store)
+	defer bundle.Close()
+
+	slackMock := &mockSlackPoster{}
+	listener := NewResultListener(bundle.Results, store, bundle.Attachments, slackMock, nil, nil, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go listener.Listen(ctx)
+
+	bundle.Results.Publish(ctx, &queue.JobResult{
+		JobID:      "jmsg",
+		Status:     "completed",
+		Confidence: "low",
+		Message:    "repo has no login page code",
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	slackMock.mu.Lock()
+	defer slackMock.mu.Unlock()
+	found := false
+	for _, msg := range slackMock.messages {
+		if strings.Contains(msg, "repo has no login page code") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected message in Slack text, got %v", slackMock.messages)
+	}
+}
+
 func TestResultListener_FailedShowsRetryButton(t *testing.T) {
 	store := queue.NewMemJobStore()
 	store.Put(&queue.Job{ID: "j1", Repo: "owner/repo", ChannelID: "C1", ThreadTS: "T1", RetryCount: 0})

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -59,6 +59,7 @@ type JobResult struct {
 	Confidence   string    `json:"confidence"`
 	FilesFound   int       `json:"files_found"`
 	Questions    int       `json:"open_questions"`
+	Message      string    `json:"message,omitempty"`
 	RawOutput    string    `json:"raw_output"`
 	Error        string    `json:"error"`
 	StartedAt    time.Time `json:"started_at"`

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -144,6 +144,35 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts bo
 	}
 	logger.Info("解析成功", "phase", "完成", "status", parsed.Status, "confidence", parsed.Confidence, "files_found", parsed.FilesFound)
 
+	// Agent said "not our bug" — short-circuit into the existing "low
+	// confidence skipped" lane in result_listener. Dropping parsed.Status
+	// here is what caused empty-title 422s: the worker turned every parse
+	// success into Status="completed" with empty Title, and the listener
+	// then tried to create an issue with that.
+	if parsed.Status == "REJECTED" {
+		return &queue.JobResult{
+			JobID:          job.ID,
+			Status:         "completed",
+			Confidence:     "low",
+			Message:        parsed.Message,
+			RawOutput:      output,
+			RepoPath:       repoPath,
+			StartedAt:      startedAt,
+			FinishedAt:     time.Now(),
+			PrepareSeconds: prepareSeconds,
+		}
+	}
+
+	// Agent self-reported ERROR — route to failure so the user gets a retry
+	// button and a clear reason instead of a silent 422.
+	if parsed.Status == "ERROR" {
+		msg := parsed.Message
+		if msg == "" {
+			msg = "agent reported ERROR without message"
+		}
+		return failedResult(job, startedAt, fmt.Errorf("agent error: %s", msg), repoPath)
+	}
+
 	return &queue.JobResult{
 		JobID:          job.ID,
 		Status:         "completed",

--- a/internal/worker/executor_test.go
+++ b/internal/worker/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,6 +102,65 @@ func TestClassifyResult_NoErrorRoutesToFailed(t *testing.T) {
 // Scenario 6 — Admin kill path: store=JobFailed + ctx cancel yields "failed", not "cancelled".
 // Covered by TestClassifyResult_WatchdogKillFallsThroughToFailed above, which also
 // asserts result.Error is non-empty.
+
+// Agent emitted a JSON-format REJECTED ("not our bug") — worker must stamp
+// Confidence=low and carry the message so the listener's existing "skipped"
+// lane fires instead of trying to create an issue with an empty title.
+func TestExecuteJob_AgentRejectedRoutesToLowConfidence(t *testing.T) {
+	store := queue.NewMemJobStore()
+	job := &queue.Job{ID: "jrej", Repo: "o/r"}
+	store.Put(job)
+
+	output := "done.\n\n===TRIAGE_RESULT===\n" + `{"status":"REJECTED","message":"not our repo"}`
+
+	deps := executionDeps{
+		attachments: queue.NewInMemAttachmentStore(),
+		repoCache:   &mockRepo{path: "/tmp/r"},
+		runner:      &mockRunner{output: output},
+		store:       store,
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+
+	if result.Status != "completed" {
+		t.Errorf("status = %q, want completed", result.Status)
+	}
+	if result.Confidence != "low" {
+		t.Errorf("confidence = %q, want low (so listener skips issue creation)", result.Confidence)
+	}
+	if result.Title != "" {
+		t.Errorf("title must stay empty for REJECTED, got %q", result.Title)
+	}
+	if result.Message != "not our repo" {
+		t.Errorf("message = %q, want 'not our repo'", result.Message)
+	}
+}
+
+// Agent emitted a JSON-format ERROR — worker must route to failed so the
+// user sees the reason and gets a retry button, not a 422 "title blank".
+func TestExecuteJob_AgentErrorRoutesToFailed(t *testing.T) {
+	store := queue.NewMemJobStore()
+	job := &queue.Job{ID: "jerr", Repo: "o/r"}
+	store.Put(job)
+
+	output := "done.\n\n===TRIAGE_RESULT===\n" + `{"status":"ERROR","message":"gh exploded"}`
+
+	deps := executionDeps{
+		attachments: queue.NewInMemAttachmentStore(),
+		repoCache:   &mockRepo{path: "/tmp/r"},
+		runner:      &mockRunner{output: output},
+		store:       store,
+	}
+
+	result := executeJob(context.Background(), job, deps, bot.RunOptions{}, slog.Default())
+
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "gh exploded") {
+		t.Errorf("error = %q, want to mention 'gh exploded'", result.Error)
+	}
+}
 
 // Scenario B-race — Pre-Prepare ctx guard: store set to JobCancelled before Prepare runs
 // → Prepare is not invoked and the result is cancelled.


### PR DESCRIPTION
## Problem

Production log:
\`\`\`
[Agent][完成] 工作完成 status=completed title= confidence= files_found=0
[GitHub][失敗] Issue 建立失敗 ... 422 Validation Failed ... title can't be blank
\`\`\`

The worker silently flattened parser \`Status=REJECTED\` into JobResult \`Status="completed"\` with empty \`Title/Confidence\`. The listener then hit \`FilesFound==0\` and called \`CreateIssue\` with \`""\` title → 422.

Previous fix (bf73615) only guarded \`CREATED + empty title\`. After the skill was updated to emit \`{status:REJECTED, message}\` without a \`confidence\` field, the existing \`Confidence==low\` skip lane never fired and every \"not our bug\" reply ended up 422'ing.

## Changes

- **internal/worker/executor.go**: branch on \`parsed.Status\` after \`ParseAgentOutput\`:
  - \`REJECTED\` → \`JobResult{Status:completed, Confidence:low, Message}\` (reuses existing skip lane)
  - \`ERROR\` → \`failedResult\` with agent message (retry button + reason)
  - \`CREATED\` path unchanged
- **internal/bot/result_listener.go**: append \`result.Message\` to the \"judged unrelated, 跳過\" Slack post
- **internal/queue/job.go**: add \`Message\` field to JobResult (worker→app transport)

## Validation

- 283/283 unit tests pass (\`go test ./...\`)
- new: \`TestExecuteJob_AgentRejectedRoutesToLowConfidence\`, \`TestExecuteJob_AgentErrorRoutesToFailed\`, \`TestResultListener_LowConfidenceIncludesMessage\`
- **End-to-end validated locally against real CLI output**: ran \`codex exec --skip-git-repo-check --color never\` and \`claude --print --output-format stream-json -p\` against a probe repo; fed 374-line codex stdout and 90KB claude stream-json through the bot's real \`ReadRawOutput\` / \`ReadStreamJSON\` + \`ParseAgentOutput\` + the new executor routing — both land on \`completed/Confidence=low\` with Message preserved, no empty-title GitHub call.
- Pre-fix reproduction test confirms the exact 422 path on the same real output.

## Test plan

- [ ] CI green
- [ ] Trigger triage against a repo the skill will reject (empty or unrelated) — expect \`:warning: 判斷不屬於此 repo，已跳過\` followed by agent's reason, no 422 error
- [ ] Trigger normal triage on a real bug — happy path unchanged (issue still created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)