### PR TITLE
docs: scrub inmem / pre-v1 references from user-facing docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 AI agent dispatch platform — receives requests from any source, dispatches to CLI agents (claude/codex/opencode) for execution, returns structured results. Currently supports Slack → codebase triage → GitHub Issue workflow.
 
-Single Go binary backed by three independent modules:
+Single Go binary (`agentdock` with `app` / `worker` subcommands). Redis is the only transport today; `queue.transport` stays as the extension point for future backends. Repo contains three independent Go modules:
 
 - [`app/`](app/README.en.md) — Slack orchestrator
 - [`worker/`](worker/README.en.md) — agent CLI executor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 AI agent 調度平台 — 從任何來源接收請求，分派給 CLI agent（claude/codex/opencode）執行，回傳結構化結果。目前支援 Slack → codebase triage → GitHub Issue 流程。
 
-Go 單一 binary，支援 in-memory 和 Redis 兩種 transport。Repo 內有 3 個獨立 module：
+Go 單一 binary（`agentdock` with `app` / `worker` 兩個子命令）。Transport 以 Redis 為主，`queue.transport` 是保留的擴充點供未來新增 backend。Repo 內有 3 個獨立 Go module：
 
 - [`app/`](app/README.md) — Slack orchestrator
 - [`worker/`](worker/README.md) — agent CLI executor

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,5 +1,8 @@
 # Session Handoff — Queue Decoupling + Agent Tracking
 
+> **Historical document (pre-v2).** Paths in this file (`internal/queue/...`, `internal/worker/...`, `cmd/bot/...`, `config.yaml`, `transport: inmem`) reflect the queue-decoupling session from 2026-04-10, before the v1 cobra migration and v2 app/worker module split. For current architecture see `README.md`, `docs/configuration.md`, and `shared/queue/` / `app/` / `worker/`. Kept for history.
+
+
 ## What Was Done
 
 Two major features implemented end-to-end in this session:

--- a/docs/deployment.en.md
+++ b/docs/deployment.en.md
@@ -2,25 +2,23 @@
 
 [繁體中文](deployment.md)
 
-## Local (In-Memory Mode)
+## Local
 
-```bash
-./run.sh
-# or
-go build -o bot ./cmd/bot/ && ./bot -config config.yaml
-```
-
-## Local (Redis Mode)
+App and worker are always two separate processes communicating over Redis.
 
 ```bash
 # Start Redis
 redis-server --daemonize yes
 
-# App (handles Slack events, creates issues)
-./bot -config config.yaml   # config: queue.transport: redis
+# Scaffold configs (interactive mode walks you through Slack/GitHub/Redis)
+agentdock init app -i
+agentdock init worker -i
 
-# Worker (consumes jobs, runs agents) — can run multiple
-./bot worker -config worker.yaml
+# App (Slack side)
+agentdock app -c ~/.config/agentdock/app.yaml
+
+# Worker (agent executor) — run multiple; each consumes jobs independently
+agentdock worker -c ~/.config/agentdock/worker.yaml
 ```
 
 ## External Worker (Teammate's Machine)
@@ -29,19 +27,19 @@ Teammates don't need any config files, just binary + env vars:
 
 ```bash
 # Prerequisites: agent CLI installed and logged in (e.g. claude login)
-REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx ./bot worker
+REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx agentdock worker
 ```
 
 Custom agent:
 ```bash
-REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx PROVIDERS=codex ./bot worker
+REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx PROVIDERS=codex agentdock worker
 ```
 
 Workers have built-in default configs for three agents (claude/codex/opencode), no YAML needed. Redis address and tokens via env vars.
 
 ### External Worker Dependencies
 
-If you download the binary from GitHub Release and run `bot worker` on an external machine, the **binary is not self-contained**. Workers `exec` the following CLIs — install them and ensure they're in `PATH`:
+If you download the binary from GitHub Release and run `agentdock worker` on an external machine, the **binary is not self-contained**. Workers `exec` the following CLIs — install them and ensure they're in `PATH`:
 
 - **At least one agent CLI** (whichever is configured):
   - `@anthropic-ai/claude-code` (npm)
@@ -99,7 +97,7 @@ docker run -e REDIS_ADDR=redis:6379 \
 
 | Execution | Auth Method | Use Case |
 |-----------|-------------|----------|
-| Native binary (`./bot worker`) | OAuth login (`claude login` etc.) | Personal machine, own Pro/Max quota |
+| Native binary (`agentdock worker`) | OAuth login (`claude login` etc.) | Personal machine, own Pro/Max quota |
 | Docker / k8s | API key (env var) | Automated deployment, company API quota |
 
 ### Agent Selection & API Key

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,25 +2,23 @@
 
 [English](deployment.en.md)
 
-## Local（In-Memory 模式）
+## Local
 
-```bash
-./run.sh
-# 或
-go build -o bot ./cmd/bot/ && ./bot -config config.yaml
-```
-
-## Local（Redis 模式）
+App 與 worker 永遠是兩個獨立 process，透過 Redis 溝通。
 
 ```bash
 # 啟動 Redis
 redis-server --daemonize yes
 
-# App（處理 Slack 事件、建 issue）
-./bot -config config.yaml   # config 裡 queue.transport: redis
+# 建 config（互動模式會幫你填 Slack/GitHub/Redis）
+agentdock init app -i
+agentdock init worker -i
 
-# Worker（消費 job、跑 agent）— 可以開多個
-./bot worker -config worker.yaml
+# App（Slack 端）
+agentdock app -c ~/.config/agentdock/app.yaml
+
+# Worker（agent 執行端）— 可以開多個，彼此獨立消費 job
+agentdock worker -c ~/.config/agentdock/worker.yaml
 ```
 
 ## 外部 Worker（同事電腦）
@@ -29,19 +27,19 @@ redis-server --daemonize yes
 
 ```bash
 # 前置條件：已安裝 agent CLI 並登入（例如 claude login）
-REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx ./bot worker
+REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx agentdock worker
 ```
 
 自訂 agent：
 ```bash
-REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx PROVIDERS=codex ./bot worker
+REDIS_ADDR=redis.company.com:6379 GITHUB_TOKEN=ghp_xxx PROVIDERS=codex agentdock worker
 ```
 
 Worker 內建三個 agent 的預設 config（claude/codex/opencode），不需要 YAML。Redis 地址和 token 透過環境變數傳入。
 
 ### External Worker 依賴
 
-如果你下載 GitHub Release 附的 binary 在外部機器跑 `bot worker`，**binary 不是 self-contained**。Worker 會 `exec` 以下 CLI，請先自行安裝並確認在 `PATH` 中：
+如果你下載 GitHub Release 附的 binary 在外部機器跑 `agentdock worker`，**binary 不是 self-contained**。Worker 會 `exec` 以下 CLI，請先自行安裝並確認在 `PATH` 中：
 
 - **至少一個 agent CLI**（config 裡選定的那個）：
   - `@anthropic-ai/claude-code`（npm）
@@ -99,7 +97,7 @@ docker run -e REDIS_ADDR=redis:6379 \
 
 | 執行方式 | 認證方式 | 適用場景 |
 |---------|---------|---------|
-| Native binary (`./bot worker`) | OAuth 登入（`claude login` 等） | 個人電腦，用自己的 Pro/Max 額度 |
+| Native binary (`agentdock worker`) | OAuth 登入（`claude login` 等） | 個人電腦，用自己的 Pro/Max 額度 |
 | Docker / k8s | API key（環境變數） | 自動化部署，公司付費的 API 額度 |
 
 ### Agent 選擇與 API Key


### PR DESCRIPTION
## Summary

Post-v2.1 sweep of live docs that still mentioned inmem transport or the pre-v1 \`./bot\` binary name. Caught via **README.md:9** which still said \"Go 單一 binary，支援 in-memory 和 Redis 兩種 transport\" after #98 removed inmem.

## Files touched

- \`README.md\` / \`README.en.md\` — intro line rewritten: Redis-only today, \`queue.transport\` preserved as the extension point
- \`docs/deployment.md\` / \`.en.md\` — \"Local (In-Memory Mode)\" section deleted; \`./bot\` / \`./cmd/bot/\` replaced with \`agentdock app\` / \`agentdock worker\`; OAuth-vs-Docker table fixed
- \`docs/HANDOFF.md\` — banner added marking it as pre-v2 historical (not rewriting a session handoff from 2026-04-10)

## Not touched (intentional)

- \`CHANGELOG.md\` — auto-generated, historical record
- \`docs/superpowers/*\` — historical specs/plans
- \`docs/MIGRATION-v2.md\` FAQ — correctly explains inmem removal to upgraders
- \`docs/SESSION-HANDOFF-2026-04-03.md\` — references a \"in-memory diagnosis cache\" feature, unrelated to inmem transport

## Test plan

- [x] \`grep -rn 'in-memory\\|In-Memory\\|inmem' --include='*.md'\` returns only expected historical / FAQ / CHANGELOG matches
- [x] \`grep -rn '\\./bot\\|cmd/bot' --include='*.md'\` clean in user-facing docs