### PR TITLE
fix(worker): add --pure to opencode CLI invocation

### DIFF
--- a/worker/config/builtin_agents.go
+++ b/worker/config/builtin_agents.go
@@ -25,8 +25,13 @@ var BuiltinAgents = map[string]AgentConfig{
 		SkillDir: ".agents/skills",
 	},
 	"opencode": {
-		Command:  "opencode",
-		Args:     []string{"run", "{prompt}"},
+		Command: "opencode",
+		// --pure skips external plugins (oh-my-openagent et al). Without it,
+		// project-level plugins that dispatch sub-agents via an async
+		// BackgroundManager cause `opencode run` to exit on the main agent's
+		// first "I dispatched" text — before the sub-agents return a parseable
+		// TRIAGE_RESULT. Internal auth plugins still load, so credentials stay intact.
+		Args:     []string{"run", "--pure", "{prompt}"},
 		Timeout:  15 * time.Minute,
 		SkillDir: ".opencode/skills",
 	},


### PR DESCRIPTION
## Summary

- Worker's `opencode` agent now runs `opencode run --pure …` instead of `opencode run …`.
- `--pure` skips external plugins (e.g. oh-my-openagent/oh-my-opencode) that target repos may ship via `.opencode/opencode.json`.
- Internal auth plugins still load, so credentials and skills are unaffected.

## Why

Without `--pure`, target repos that load oh-my-openagent get its `delegate-task` tool, which dispatches sub-agents to an async `BackgroundManager`. The main agent's turn ends as soon as it emits an "I dispatched it, stand by" text — session goes idle → `opencode run` exits (`packages/opencode/src/cli/cmd/run.ts:532-538`). The real `===TRIAGE_RESULT===` never reaches worker stdout, and the parser ends up with the intermediate narration instead.

Core opencode's built-in `task` tool (`packages/opencode/src/tool/task.ts:130-145`) is synchronous, so sub-agent work still happens — just inside the main turn, blocking until the marker is emitted.

## Local verification

- `opencode run --pure --print-logs --log-level INFO -m opencode/nemotron-3-super-free "Reply just ok"` → `count=2 skipping external plugins in pure mode`, model responds `ok`, auth intact.
- Repeated with a project-level `opencode.json` that adds a plugin → same skip behaviour (merged plugin origins regardless of source).
- `opencode debug skill` output unchanged between `--pure` / non-`--pure` → skills are not plugin-based.
- `go test ./...` green across root, worker, app (226 tests).

## Test plan

- [ ] Deploy to a worker replica and re-run against a target repo that ships oh-my-openagent / oh-my-opencode under `.opencode/`, confirm `===TRIAGE_RESULT===` lands in stdout.
- [ ] Re-run a control job on a repo without project-level opencode plugins, confirm behaviour unchanged.
- [ ] Verify opencode providers/credentials load fine inside the deployed worker (`opencode providers list` in-container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)