### PR TITLE
docs(worker): add --pure to opencode example in configuration-worker

### DIFF
--- a/docs/configuration-worker.en.md
+++ b/docs/configuration-worker.en.md
@@ -34,7 +34,7 @@ agents:
     skill_dir: .agents/skills         # Codex discovers skills in .agents/skills, not .codex/skills
   opencode:
     command: opencode
-    args: ["run", "{prompt}"]
+    args: ["run", "--pure", "{prompt}"]  # --pure skips external plugins (e.g. oh-my-openagent) that spawn async background agents
     timeout: 15m
     skill_dir: .opencode/skills
 

--- a/docs/configuration-worker.md
+++ b/docs/configuration-worker.md
@@ -34,7 +34,7 @@ agents:
     skill_dir: .agents/skills         # Codex 讀 .agents/skills，不是 .codex/skills
   opencode:
     command: opencode
-    args: ["run", "{prompt}"]
+    args: ["run", "--pure", "{prompt}"]  # --pure 跳過 external plugins（例如 oh-my-openagent）避免 async 背景 agent
     timeout: 15m
     skill_dir: .opencode/skills
 


### PR DESCRIPTION
## Summary

- Update `docs/configuration-worker.md` and `docs/configuration-worker.en.md` opencode agent example to match the new `BuiltinAgents` default (`["run", "--pure", "{prompt}"]`).
- Annotate why `--pure` exists, so anyone copying the example out of docs can understand what the flag buys them.

## Why

PR #108 / commit 64d12af added `--pure` to the built-in opencode args to sidestep oh-my-openagent's async background-agent pattern (main agent emits "I dispatched it" text, session idles, `opencode run` exits before the real marker lands). The docs still showed the old `["run", "{prompt}"]` form, which would leave readers stepping on the same rake.

No behaviour change — docs-only.

## Test plan

- [ ] Visually inspect the rendered docs snippets in GitHub to confirm the comment line renders sensibly.
- [ ] `grep -rn '"run", "{prompt}"' docs/` returns no matches (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)