### PR TITLE
fix(bot/parser): handle doubled ===TRIAGE_RESULT=== fence markers

### DIFF
--- a/app/bot/parser.go
+++ b/app/bot/parser.go
@@ -52,16 +52,19 @@ type TriageResult struct {
 	Questions  int    `json:"open_questions,omitempty"`
 }
 
-// ParseAgentOutput extracts the triage result from agent stdout.
-// Looks for ===TRIAGE_RESULT=== followed by CREATED:/REJECTED:/ERROR:
+// ParseAgentOutput extracts the triage result from agent stdout. Looks for
+// ===TRIAGE_RESULT=== followed by a JSON object or a CREATED:/REJECTED:/ERROR:
+// prefix. When the marker appears multiple times (e.g. opencode wraps the
+// JSON between an opening and a closing marker as a fence), the parser walks
+// them from last to first and returns the first segment that parses.
 func ParseAgentOutput(output string) (TriageResult, error) {
 	output = strings.TrimSpace(output)
 	if len(output) < minOutputLength {
 		return TriageResult{}, fmt.Errorf("agent output too short (%d chars)", len(output))
 	}
 
-	idx := strings.LastIndex(output, resultSeparator)
-	if idx == -1 {
+	positions := markerPositions(output, resultSeparator)
+	if len(positions) == 0 {
 		// No result marker — try to find a GitHub issue URL anywhere in the output
 		if url := extractIssueURL(output); url != "" {
 			return TriageResult{Status: "CREATED", IssueURL: url}, nil
@@ -69,44 +72,99 @@ func ParseAgentOutput(output string) (TriageResult, error) {
 		return TriageResult{}, fmt.Errorf("no triage result found in agent output")
 	}
 
-	result := strings.TrimSpace(output[idx+len(resultSeparator):])
-
-	// Try JSON format first.
-	if strings.HasPrefix(result, "{") {
-		jsonStr := extractJSON(result)
-		var tr TriageResult
-		if err := json.Unmarshal([]byte(jsonStr), &tr); err == nil && tr.Status != "" {
-			// CREATED payloads are fed directly into CreateIssue — an empty
-			// title causes GitHub to 422 mid-flight with "title can't be
-			// blank", burning retries and confusing the user. Catch it here
-			// so the failure surfaces as a clear parse error instead.
-			if tr.Status == "CREATED" && strings.TrimSpace(tr.Title) == "" {
-				return TriageResult{}, fmt.Errorf("CREATED result missing required title")
-			}
+	// Walk markers from last to first. Preferring the final marker keeps the
+	// "agent echoed the marker in a preamble example, then wrote the real
+	// answer later" case working. Falling back to earlier markers handles the
+	// fence case (opening + closing) where the last marker's segment is empty.
+	for i := len(positions) - 1; i >= 0; i-- {
+		start := positions[i] + len(resultSeparator)
+		end := len(output)
+		if i+1 < len(positions) {
+			end = positions[i+1]
+		}
+		segment := strings.TrimSpace(output[start:end])
+		if segment == "" {
+			continue
+		}
+		tr, titleErr, matched := parseResultSegment(segment, output)
+		if titleErr != nil {
+			// CREATED with missing title — definitive error, don't silently
+			// fall back to an earlier marker and risk a bogus match.
+			return TriageResult{}, titleErr
+		}
+		if matched {
 			return tr, nil
 		}
 	}
 
-	// Legacy format.
-	if strings.HasPrefix(result, "CREATED:") {
-		url := strings.TrimSpace(strings.TrimPrefix(result, "CREATED:"))
-		if url == "" {
-			url = extractIssueURL(output)
+	// Final error message uses the last non-empty segment for context.
+	lastSegment := ""
+	for i := len(positions) - 1; i >= 0; i-- {
+		start := positions[i] + len(resultSeparator)
+		end := len(output)
+		if i+1 < len(positions) {
+			end = positions[i+1]
 		}
-		return TriageResult{Status: "CREATED", IssueURL: url}, nil
+		if s := strings.TrimSpace(output[start:end]); s != "" {
+			lastSegment = s
+			break
+		}
+	}
+	return TriageResult{}, fmt.Errorf("unknown triage result: %s", lastSegment)
+}
+
+// markerPositions returns the byte offsets of every occurrence of marker in s.
+func markerPositions(s, marker string) []int {
+	var out []int
+	offset := 0
+	for {
+		idx := strings.Index(s[offset:], marker)
+		if idx == -1 {
+			return out
+		}
+		out = append(out, offset+idx)
+		offset += idx + len(marker)
+	}
+}
+
+// parseResultSegment tries JSON first, then the legacy CREATED:/REJECTED:/ERROR:
+// prefixes. Returns (result, titleErr, matched):
+//   - matched=true, titleErr=nil → caller returns (result, nil).
+//   - titleErr!=nil → CREATED JSON without a title; caller returns (zero, err)
+//     immediately (do not fall back to earlier markers).
+//   - matched=false, titleErr=nil → segment did not match; caller keeps
+//     searching earlier markers.
+func parseResultSegment(segment, fullOutput string) (TriageResult, error, bool) {
+	if strings.HasPrefix(segment, "{") {
+		jsonStr := extractJSON(segment)
+		var tr TriageResult
+		if err := json.Unmarshal([]byte(jsonStr), &tr); err == nil && tr.Status != "" {
+			if tr.Status == "CREATED" && strings.TrimSpace(tr.Title) == "" {
+				return TriageResult{}, fmt.Errorf("CREATED result missing required title"), false
+			}
+			return tr, nil, true
+		}
 	}
 
-	if strings.HasPrefix(result, "REJECTED:") {
-		msg := strings.TrimSpace(strings.TrimPrefix(result, "REJECTED:"))
-		return TriageResult{Status: "REJECTED", Message: msg}, nil
+	if strings.HasPrefix(segment, "CREATED:") {
+		url := strings.TrimSpace(strings.TrimPrefix(segment, "CREATED:"))
+		if url == "" {
+			url = extractIssueURL(fullOutput)
+		}
+		return TriageResult{Status: "CREATED", IssueURL: url}, nil, true
 	}
 
-	if strings.HasPrefix(result, "ERROR:") {
-		msg := strings.TrimSpace(strings.TrimPrefix(result, "ERROR:"))
-		return TriageResult{Status: "ERROR", Message: msg}, nil
+	if strings.HasPrefix(segment, "REJECTED:") {
+		msg := strings.TrimSpace(strings.TrimPrefix(segment, "REJECTED:"))
+		return TriageResult{Status: "REJECTED", Message: msg}, nil, true
 	}
 
-	return TriageResult{}, fmt.Errorf("unknown triage result: %s", result)
+	if strings.HasPrefix(segment, "ERROR:") {
+		msg := strings.TrimSpace(strings.TrimPrefix(segment, "ERROR:"))
+		return TriageResult{Status: "ERROR", Message: msg}, nil, true
+	}
+
+	return TriageResult{}, nil, false
 }
 
 // extractJSON finds the first top-level JSON object in text by matching braces.

--- a/app/bot/parser_test.go
+++ b/app/bot/parser_test.go
@@ -222,6 +222,61 @@ func TestParseAgentOutput_NoResult(t *testing.T) {
 	}
 }
 
+func TestParseAgentOutput_DoubleMarkerFence(t *testing.T) {
+	// Opencode (observed with minimax-m2.5-free) wraps the JSON between an
+	// opening AND a closing ===TRIAGE_RESULT=== marker, treating it as a
+	// fenced block. LastIndex would land on the closing marker with empty
+	// content — parser must fall back to an earlier marker and pull the
+	// JSON from between.
+	output := "Based on my investigation of Mantis #36321...\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "CREATED",
+  "title": "[已解決] 報價單列印顯示正本副本文字",
+  "body": "## Problem\n報價單列印時錯誤顯示正副本文字",
+  "labels": ["bug"],
+  "confidence": "high",
+  "files_found": 12,
+  "open_questions": 0
+}
+===TRIAGE_RESULT===`
+
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if result.Status != "CREATED" {
+		t.Errorf("status = %q, want CREATED", result.Status)
+	}
+	if result.Title != "[已解決] 報價單列印顯示正本副本文字" {
+		t.Errorf("title lost: %q", result.Title)
+	}
+	if result.Confidence != "high" {
+		t.Errorf("confidence = %q, want high", result.Confidence)
+	}
+	if result.FilesFound != 12 {
+		t.Errorf("files_found = %d, want 12", result.FilesFound)
+	}
+}
+
+func TestParseAgentOutput_PreambleEchoThenRealResult(t *testing.T) {
+	// Guard the existing LastIndex-preferred behavior: if an agent echoes
+	// the marker in a preamble example and THEN writes the real answer after
+	// a second marker, the final answer wins. Regression test for anyone
+	// trying to naively swap LastIndex → FirstIndex.
+	output := "Example: ===TRIAGE_RESULT===\nCREATED: https://example.com\n\n" +
+		"Now doing the real work.\n\n===TRIAGE_RESULT===\n" + `{
+  "status": "REJECTED",
+  "message": "Problem unrelated to this repo"
+}`
+
+	result, err := ParseAgentOutput(output)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if result.Status != "REJECTED" {
+		t.Errorf("status = %q, want REJECTED (from the LAST marker, not the echoed one)", result.Status)
+	}
+}
+
 func TestParseAgentOutput_JSONWithTrailingContent(t *testing.T) {
 	output := "Investigation complete.\n\n===TRIAGE_RESULT===\n" + `{
   "status": "CREATED",


### PR DESCRIPTION
## Problem

When an agent wraps its triage JSON between an opening **and a closing** `===TRIAGE_RESULT===` marker (treating it as a fence block), the parser fails and the job surfaces as \`:x: 分析失敗（解析失敗，輸出原始內容）\` to the user — with a perfectly valid JSON payload right there in the agent output.

Observed with \`opencode run --pure\` + \`opencode/minimax-m2.5-free\` model. Codex doesn't hit this (writes the marker only once).

## Root Cause

\`app/bot/parser.go:63\`:

\`\`\`go
idx := strings.LastIndex(output, resultSeparator)
result := strings.TrimSpace(output[idx+len(resultSeparator):])
\`\`\`

With two markers (opening + closing fence), \`LastIndex\` points at the **closing** marker, and the slice after it is empty / just trailing whitespace. The parser then runs through \`HasPrefix(\"{\")\` / \`HasPrefix(\"CREATED:\")\` / etc. — none match — and returns \`unknown triage result: \`.

The real-world fence output from opencode looks like:

\`\`\`
Based on my investigation of Mantis #36321...

===TRIAGE_RESULT===
{
  \"status\": \"CREATED\",
  \"title\": \"...\",
  ...
}
===TRIAGE_RESULT===
\`\`\`

Raw Redis payload inspected locally confirmed: 1712-byte \`raw_output\`, structurally valid JSON, parser just couldn't see it past the closing fence.

## Fix

Walk marker occurrences from **last to first**. For each, take the segment between \`marker[i]\` and \`marker[i+1]\` (or EOF). Try to parse — return the first segment that matches a known format.

- **Preserves existing behavior** for agents that echo the marker in a preamble example before writing the real answer later: the last marker still wins when its segment is valid.
- **Fixes the fence case**: when the last segment is empty, falls back to the previous marker's segment, which contains the real JSON.
- Extracts the legacy \`CREATED:/REJECTED:/ERROR:\` branches into \`parseResultSegment\` so the fallback loop doesn't duplicate them.
- CREATED-without-title is still a **definitive error** — the loop does not silently fall back past it to an earlier marker. Adding a regression test around this would be cheap but isn't new behavior.

## Tests

Two new tests in \`app/bot/parser_test.go\`, both added before the fix landed (TDD):

- \`TestParseAgentOutput_DoubleMarkerFence\` — the actual failing case. Asserts title / confidence / files_found are all extracted correctly from the fenced JSON.
- \`TestParseAgentOutput_PreambleEchoThenRealResult\` — regression guard. If someone naively swaps \`LastIndex\` → \`FirstIndex\` to \"fix\" the fence case, this test catches the regression for the echo case (agent describes the marker in preamble, then writes the real result after a second marker, REJECTED wins).

All 19 \`TestParseAgentOutput_*\` tests pass. All 78 tests in \`app/bot/\` pass. \`go build ./...\` clean.

## Test plan

- [ ] CI green across all modules
- [ ] Manual smoke: trigger opencode-backed triage with Mantis URL, confirm GitHub issue created (no more \`:x: 分析失敗\`)
- [ ] Manual smoke: trigger codex-backed triage (single marker), confirm still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)