### PR TITLE
Worker liveness precheck: trigger warn + submit reject

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -356,14 +356,21 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 		}
 
 		// Update the status message to show queue position.
+		//
+		// BusyHint is only set when CheckHard saw all worker slots occupied, so
+		// saying "正在處理" in that case contradicts the wait-estimate tail. When
+		// busy, the head is queued regardless of its position in the pending
+		// list (the occupant worker holds a non-pending job).
 		pos, _ := coordinator.QueuePosition(job.ID)
 		var queueMsg string
-		if pos <= 1 {
-			queueMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
-		} else {
+		switch {
+		case pos > 1:
 			queueMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
+		case p.BusyHint != "":
+			queueMsg = ":hourglass_flowing_sand: 已加入排隊，將盡快處理"
+		default:
+			queueMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
 		}
-		// Re-apply the busy hint so the post-submit update doesn't clobber it.
 		if p.BusyHint != "" {
 			queueMsg += " " + p.BusyHint
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -167,7 +167,7 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 	reg.Register(prReviewWorkflow)
 	dispatcher := workflow.NewDispatcher(reg, slackPort, appLogger)
 
-	wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger)
+	wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, nil)
 
 	handler := slackclient.NewHandler(slackclient.HandlerConfig{
 		DedupTTL:        5 * time.Minute,

--- a/app/app.go
+++ b/app/app.go
@@ -363,6 +363,10 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 		} else {
 			queueMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
 		}
+		// Re-apply the busy hint so the post-submit update doesn't clobber it.
+		if p.BusyHint != "" {
+			queueMsg += " " + p.BusyHint
+		}
 
 		if statusMsgTS != "" {
 			if upErr := slackPort.UpdateMessageWithButton(p.ChannelID, statusMsgTS,

--- a/app/app.go
+++ b/app/app.go
@@ -167,7 +167,19 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 	reg.Register(prReviewWorkflow)
 	dispatcher := workflow.NewDispatcher(reg, slackPort, appLogger)
 
-	wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, nil)
+	availability := queue.NewWorkerAvailability(coordinator, jobStore, queue.AvailabilityConfig{
+		AvgJobDuration: cfg.Availability.AvgJobDuration,
+	},
+		queue.WithVerdictHook(func(kind, stage string, d time.Duration) {
+			metrics.WorkerAvailabilityVerdictTotal.WithLabelValues(kind, stage).Inc()
+			metrics.WorkerAvailabilityCheckDuration.Observe(d.Seconds())
+		}),
+		queue.WithDepErrorHook(func(dep string) {
+			metrics.WorkerAvailabilityCheckErrors.WithLabelValues(dep).Inc()
+		}),
+	)
+
+	wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, availability)
 
 	handler := slackclient.NewHandler(slackclient.HandlerConfig{
 		DedupTTL:        5 * time.Minute,
@@ -201,6 +213,11 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 				handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
 			}
 			return
+		}
+
+		// Append worker-availability busy hint if the pre-submit check set one.
+		if p.BusyHint != "" {
+			statusText += " " + p.BusyHint
 		}
 
 		// Post lifecycle status message.

--- a/app/bot/verdict_message.go
+++ b/app/bot/verdict_message.go
@@ -25,6 +25,14 @@ func RenderSoftWarn(v queue.Verdict) string {
 			return ""
 		}
 		mins := int(v.EstimatedWait.Round(time.Minute).Minutes())
+		// ActiveJobs is capacity-occupying count at check time; subtracting
+		// TotalSlots yields jobs queued beyond capacity (i.e. ahead of a
+		// hypothetical submit). When == 0, no one is queued yet — the caller
+		// will be first into the wait line.
+		ahead := v.ActiveJobs - v.TotalSlots
+		if ahead > 0 {
+			return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，前面還有 %d 個請求在等，送出後預估等候 ~%dm。你仍可繼續選擇。", ahead, mins)
+		}
 		return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，送出後預估等候 ~%dm。你仍可繼續選擇。", mins)
 	default:
 		return ""

--- a/app/bot/verdict_message.go
+++ b/app/bot/verdict_message.go
@@ -28,12 +28,14 @@ func RenderSoftWarn(v queue.Verdict) string {
 		// ActiveJobs is capacity-occupying count at check time; subtracting
 		// TotalSlots yields jobs queued beyond capacity (i.e. ahead of a
 		// hypothetical submit). When == 0, no one is queued yet — the caller
-		// will be first into the wait line.
+		// will be first into the wait line, so say so explicitly rather than
+		// leaving them to stare at a bare ETA (which reads as worse than it
+		// is when they're actually next up).
 		ahead := v.ActiveJobs - v.TotalSlots
 		if ahead > 0 {
 			return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，前面還有 %d 個請求在等，送出後預估等候 ~%dm。你仍可繼續選擇。", ahead, mins)
 		}
-		return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，送出後預估等候 ~%dm。你仍可繼續選擇。", mins)
+		return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，但你會是下一個，預估等候 ~%dm。你仍可繼續選擇。", mins)
 	default:
 		return ""
 	}

--- a/app/bot/verdict_message.go
+++ b/app/bot/verdict_message.go
@@ -1,0 +1,36 @@
+package bot
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// RenderSoftWarn produces the trigger-time soft warning. Currently only the
+// NoWorkers verdict is rendered; other verdicts return "" (caller should not
+// post empty messages).
+func RenderSoftWarn(v queue.Verdict) string {
+	if v.Kind != queue.VerdictNoWorkers {
+		return ""
+	}
+	return ":warning: 目前沒有 worker 在線，你仍可繼續選擇，送出時會再確認一次。"
+}
+
+// RenderHardReject produces the submit-time rejection message.
+func RenderHardReject(v queue.Verdict) string {
+	if v.Kind != queue.VerdictNoWorkers {
+		return ""
+	}
+	return ":x: 目前沒有 worker 在線，無法處理。請稍後再試。"
+}
+
+// RenderBusyHint produces the suffix appended to the lifecycle queue
+// message when the verdict is BusyEnqueueOK with a non-zero ETA.
+func RenderBusyHint(v queue.Verdict) string {
+	if v.EstimatedWait <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("(預估等候 ~%dm)",
+		int(v.EstimatedWait.Round(time.Minute).Minutes()))
+}

--- a/app/bot/verdict_message.go
+++ b/app/bot/verdict_message.go
@@ -7,14 +7,28 @@ import (
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
-// RenderSoftWarn produces the trigger-time soft warning. Currently only the
-// NoWorkers verdict is rendered; other verdicts return "" (caller should not
-// post empty messages).
+// RenderSoftWarn produces the trigger-time soft warning. Returns "" when the
+// verdict doesn't warrant user-facing notice (OK, or BusyEnqueueOK with no
+// ETA).
+//
+// Two cases are rendered:
+//   - NoWorkers: no worker online, submit may fail
+//   - BusyEnqueueOK with ETA: all workers are busy — warn early so the user
+//     knows clicking through the selectors will end in a queued submit, not
+//     an immediate handoff
 func RenderSoftWarn(v queue.Verdict) string {
-	if v.Kind != queue.VerdictNoWorkers {
+	switch v.Kind {
+	case queue.VerdictNoWorkers:
+		return ":warning: 目前沒有 worker 在線，你仍可繼續選擇，送出時會再確認一次。"
+	case queue.VerdictBusyEnqueueOK:
+		if v.EstimatedWait <= 0 {
+			return ""
+		}
+		mins := int(v.EstimatedWait.Round(time.Minute).Minutes())
+		return fmt.Sprintf(":hourglass_flowing_sand: 目前所有 worker 都在忙，送出後預估等候 ~%dm。你仍可繼續選擇。", mins)
+	default:
 		return ""
 	}
-	return ":warning: 目前沒有 worker 在線，你仍可繼續選擇，送出時會再確認一次。"
 }
 
 // RenderHardReject produces the submit-time rejection message.

--- a/app/bot/verdict_message_test.go
+++ b/app/bot/verdict_message_test.go
@@ -18,10 +18,12 @@ func TestRenderSoftWarn_NoWorkers(t *testing.T) {
 	}
 }
 
-func TestRenderSoftWarn_BusyWithETA(t *testing.T) {
+func TestRenderSoftWarn_BusyWithETA_NoQueue(t *testing.T) {
 	v := queue.Verdict{
 		Kind:          queue.VerdictBusyEnqueueOK,
 		EstimatedWait: 6 * time.Minute,
+		ActiveJobs:    1,
+		TotalSlots:    1,
 	}
 	got := RenderSoftWarn(v)
 	if got == "" {
@@ -32,6 +34,25 @@ func TestRenderSoftWarn_BusyWithETA(t *testing.T) {
 	}
 	if !strings.Contains(got, "6m") {
 		t.Errorf("missing ETA '6m'; got %q", got)
+	}
+	if strings.Contains(got, "前面還有") {
+		t.Errorf("no-queue branch should not mention '前面還有'; got %q", got)
+	}
+}
+
+func TestRenderSoftWarn_BusyWithETA_WithQueue(t *testing.T) {
+	v := queue.Verdict{
+		Kind:          queue.VerdictBusyEnqueueOK,
+		EstimatedWait: 9 * time.Minute,
+		ActiveJobs:    3,
+		TotalSlots:    1,
+	}
+	got := RenderSoftWarn(v)
+	if !strings.Contains(got, "前面還有 2 個請求") {
+		t.Errorf("missing '前面還有 2 個請求'; got %q", got)
+	}
+	if !strings.Contains(got, "9m") {
+		t.Errorf("missing ETA '9m'; got %q", got)
 	}
 }
 

--- a/app/bot/verdict_message_test.go
+++ b/app/bot/verdict_message_test.go
@@ -38,6 +38,9 @@ func TestRenderSoftWarn_BusyWithETA_NoQueue(t *testing.T) {
 	if strings.Contains(got, "前面還有") {
 		t.Errorf("no-queue branch should not mention '前面還有'; got %q", got)
 	}
+	if !strings.Contains(got, "下一個") {
+		t.Errorf("no-queue branch should reassure '下一個'; got %q", got)
+	}
 }
 
 func TestRenderSoftWarn_BusyWithETA_WithQueue(t *testing.T) {

--- a/app/bot/verdict_message_test.go
+++ b/app/bot/verdict_message_test.go
@@ -1,0 +1,50 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+func TestRenderSoftWarn_NoWorkers(t *testing.T) {
+	got := RenderSoftWarn(queue.Verdict{Kind: queue.VerdictNoWorkers})
+	if !strings.Contains(got, ":warning:") {
+		t.Errorf("missing :warning: prefix; got %q", got)
+	}
+	if !strings.Contains(got, "沒有 worker") {
+		t.Errorf("missing key phrase '沒有 worker'; got %q", got)
+	}
+}
+
+func TestRenderHardReject_NoWorkers(t *testing.T) {
+	got := RenderHardReject(queue.Verdict{Kind: queue.VerdictNoWorkers})
+	if !strings.Contains(got, ":x:") {
+		t.Errorf("missing :x: prefix; got %q", got)
+	}
+	if !strings.Contains(got, "無法處理") {
+		t.Errorf("missing '無法處理'; got %q", got)
+	}
+}
+
+func TestRenderBusyHint_WithETA(t *testing.T) {
+	v := queue.Verdict{
+		Kind:          queue.VerdictBusyEnqueueOK,
+		EstimatedWait: 9 * time.Minute,
+	}
+	got := RenderBusyHint(v)
+	if !strings.Contains(got, "預估等候") {
+		t.Errorf("missing '預估等候'; got %q", got)
+	}
+	if !strings.Contains(got, "9m") {
+		t.Errorf("expected '9m' in output; got %q", got)
+	}
+}
+
+func TestRenderBusyHint_ZeroETA_ReturnsEmpty(t *testing.T) {
+	v := queue.Verdict{Kind: queue.VerdictBusyEnqueueOK, EstimatedWait: 0}
+	if got := RenderBusyHint(v); got != "" {
+		t.Errorf("expected empty string for zero ETA; got %q", got)
+	}
+}

--- a/app/bot/verdict_message_test.go
+++ b/app/bot/verdict_message_test.go
@@ -18,6 +18,36 @@ func TestRenderSoftWarn_NoWorkers(t *testing.T) {
 	}
 }
 
+func TestRenderSoftWarn_BusyWithETA(t *testing.T) {
+	v := queue.Verdict{
+		Kind:          queue.VerdictBusyEnqueueOK,
+		EstimatedWait: 6 * time.Minute,
+	}
+	got := RenderSoftWarn(v)
+	if got == "" {
+		t.Fatal("expected non-empty warning for BusyEnqueueOK with ETA")
+	}
+	if !strings.Contains(got, "都在忙") {
+		t.Errorf("missing key phrase '都在忙'; got %q", got)
+	}
+	if !strings.Contains(got, "6m") {
+		t.Errorf("missing ETA '6m'; got %q", got)
+	}
+}
+
+func TestRenderSoftWarn_BusyZeroETA_ReturnsEmpty(t *testing.T) {
+	v := queue.Verdict{Kind: queue.VerdictBusyEnqueueOK, EstimatedWait: 0}
+	if got := RenderSoftWarn(v); got != "" {
+		t.Errorf("expected empty for zero-ETA busy; got %q", got)
+	}
+}
+
+func TestRenderSoftWarn_OK_ReturnsEmpty(t *testing.T) {
+	if got := RenderSoftWarn(queue.Verdict{Kind: queue.VerdictOK}); got != "" {
+		t.Errorf("expected empty for OK verdict; got %q", got)
+	}
+}
+
 func TestRenderHardReject_NoWorkers(t *testing.T) {
 	got := RenderHardReject(queue.Verdict{Kind: queue.VerdictNoWorkers})
 	if !strings.Contains(got, ":x:") {

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -10,6 +10,7 @@ import (
 	slackclient "github.com/Ivantseng123/agentdock/app/slack"
 	"github.com/Ivantseng123/agentdock/app/workflow"
 	ghclient "github.com/Ivantseng123/agentdock/shared/github"
+	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
 const pendingTimeout = 1 * time.Minute
@@ -23,6 +24,7 @@ type Workflow struct {
 	handler       *slackclient.Handler
 	repoDiscovery *ghclient.RepoDiscovery
 	logger        *slog.Logger
+	availability  queue.WorkerAvailability
 
 	mu        sync.Mutex
 	pending   map[string]*workflow.Pending
@@ -41,6 +43,7 @@ func NewWorkflow(
 	slack workflow.SlackPort,
 	repoDiscovery *ghclient.RepoDiscovery,
 	logger *slog.Logger,
+	availability queue.WorkerAvailability,
 ) *Workflow {
 	return &Workflow{
 		cfg:           cfg,
@@ -48,6 +51,7 @@ func NewWorkflow(
 		slack:         slack,
 		repoDiscovery: repoDiscovery,
 		logger:        logger,
+		availability:  availability,
 		pending:       make(map[string]*workflow.Pending),
 		autoBound:     make(map[string]bool),
 	}

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -354,9 +354,7 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 		if tid == "" {
 			// No trigger ID available — fall through to submit without description.
 			w.logger.Warn("OpenModal requested but no triggerID", "phase", "失敗")
-			if w.onSubmit != nil {
-				w.onSubmit(ctx, pending)
-			}
+			w.submit(ctx, pending)
 			return
 		}
 		// Modal-first flows (PR Review D-path when thread has no URL) reach
@@ -385,9 +383,7 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 				delete(w.pending, selectorTS)
 				w.mu.Unlock()
 			}
-			if w.onSubmit != nil {
-				w.onSubmit(ctx, pending)
-			}
+			w.submit(ctx, pending)
 		}
 		// Pending is now in the map under meta (either SelectorTS from a
 		// prior selector, or the synthesised "modal-<reqID>" key above); the
@@ -398,11 +394,7 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 		if p == nil {
 			p = pending
 		}
-		if w.onSubmit != nil {
-			w.onSubmit(ctx, p)
-		} else {
-			w.logger.Warn("NextStepSubmit but no onSubmit hook set", "phase", "失敗")
-		}
+		w.submit(ctx, p)
 
 	case workflow.NextStepError:
 		_ = w.slack.PostMessage(pending.ChannelID, ":x: "+step.ErrorText, pending.ThreadTS)
@@ -423,6 +415,34 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 
 	default:
 		w.logger.Warn("executeStep: unknown NextStepKind", "phase", "失敗", "kind", step.Kind)
+	}
+}
+
+// submit is the single chokepoint for sending a Pending to the queue-submission
+// closure. Consolidates the three former `if w.onSubmit != nil { w.onSubmit(...) }`
+// call sites in executeStep so pre-submit checks (like the worker-availability
+// hard check below) only need to land in one place.
+func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
+	if w.availability != nil {
+		verdict := w.availability.CheckHard(ctx)
+		switch verdict.Kind {
+		case queue.VerdictNoWorkers:
+			_ = w.slack.PostMessage(p.ChannelID,
+				RenderHardReject(verdict), p.ThreadTS)
+			if w.handler != nil {
+				w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+			}
+			return
+		case queue.VerdictBusyEnqueueOK:
+			// Task 11 adds p.BusyHint = RenderBusyHint(verdict) here.
+		case queue.VerdictOK:
+			// continue
+		}
+	}
+	if w.onSubmit != nil {
+		w.onSubmit(ctx, p)
+	} else {
+		w.logger.Warn("submit but no onSubmit hook set", "phase", "失敗")
 	}
 }
 

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -434,7 +434,7 @@ func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
 			}
 			return
 		case queue.VerdictBusyEnqueueOK:
-			// Task 11 adds p.BusyHint = RenderBusyHint(verdict) here.
+			p.BusyHint = RenderBusyHint(verdict)
 		case queue.VerdictOK:
 			// continue
 		}

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -100,6 +100,16 @@ func (w *Workflow) HandleTrigger(event slackclient.TriggerEvent) {
 		}
 	}
 
+	// Soft availability check — informational only; do NOT block dispatch.
+	// The hard check inside submit() gates actual queue submission.
+	if w.availability != nil {
+		verdict := w.availability.CheckSoft(context.Background())
+		if verdict.Kind == queue.VerdictNoWorkers {
+			_ = w.slack.PostMessage(event.ChannelID,
+				RenderSoftWarn(verdict), event.ThreadTS)
+		}
+	}
+
 	ctx := context.Background()
 	ev := workflow.TriggerEvent{
 		ChannelID: event.ChannelID,

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -104,9 +104,8 @@ func (w *Workflow) HandleTrigger(event slackclient.TriggerEvent) {
 	// The hard check inside submit() gates actual queue submission.
 	if w.availability != nil {
 		verdict := w.availability.CheckSoft(context.Background())
-		if verdict.Kind == queue.VerdictNoWorkers {
-			_ = w.slack.PostMessage(event.ChannelID,
-				RenderSoftWarn(verdict), event.ThreadTS)
+		if msg := RenderSoftWarn(verdict); msg != "" {
+			_ = w.slack.PostMessage(event.ChannelID, msg, event.ThreadTS)
 		}
 	}
 

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -437,8 +437,10 @@ func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
 		verdict := w.availability.CheckHard(ctx)
 		switch verdict.Kind {
 		case queue.VerdictNoWorkers:
-			_ = w.slack.PostMessage(p.ChannelID,
-				RenderHardReject(verdict), p.ThreadTS)
+			if err := w.slack.PostMessage(p.ChannelID,
+				RenderHardReject(verdict), p.ThreadTS); err != nil {
+				w.logger.Error("可用性檢查: 硬性拒絕訊息發送失敗", "phase", "失敗", "error", err)
+			}
 			if w.handler != nil {
 				w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
 			}

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/Ivantseng123/agentdock/app/config"
-	"github.com/Ivantseng123/agentdock/app/workflow"
 	slackclient "github.com/Ivantseng123/agentdock/app/slack"
+	"github.com/Ivantseng123/agentdock/app/workflow"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
@@ -26,7 +26,7 @@ func (s *shimSlack) PostMessageWithTS(ch, text, ts string) (string, error) { ret
 func (s *shimSlack) PostMessageWithButton(ch, text, ts, aid, bt, val string) (string, error) {
 	return "ts", nil
 }
-func (s *shimSlack) UpdateMessage(ch, mts, text string) error                  { return nil }
+func (s *shimSlack) UpdateMessage(ch, mts, text string) error                         { return nil }
 func (s *shimSlack) UpdateMessageWithButton(ch, mts, text, aid, bt, val string) error { return nil }
 func (s *shimSlack) PostSelector(ch, prompt, prefix string, labels, values []string, ts string) (string, error) {
 	return "sel-ts", nil
@@ -64,7 +64,7 @@ func TestHandleTrigger_NoThread_PostsWarning(t *testing.T) {
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, slack, nil)
 
-	wf := NewWorkflow(cfg, disp, slack, nil, nil)
+	wf := NewWorkflow(cfg, disp, slack, nil, nil, nil)
 
 	wf.HandleTrigger(slackclient.TriggerEvent{
 		ChannelID: "C1",
@@ -99,7 +99,7 @@ func TestHandleTrigger_UnboundChannel_Silent(t *testing.T) {
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, slack, nil)
 
-	wf := NewWorkflow(cfg, disp, slack, nil, nil)
+	wf := NewWorkflow(cfg, disp, slack, nil, nil, nil)
 
 	wf.HandleTrigger(slackclient.TriggerEvent{
 		ChannelID: "C_UNBOUND",
@@ -120,7 +120,7 @@ func TestExecuteStep_Submit_CallsHook(t *testing.T) {
 	reg := workflow.NewRegistry()
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, slack, nil)
-	wf := NewWorkflow(cfg, disp, slack, nil, nil)
+	wf := NewWorkflow(cfg, disp, slack, nil, nil, nil)
 
 	called := false
 	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
@@ -143,7 +143,7 @@ func TestExecuteStep_Error_PostsMessage(t *testing.T) {
 	reg := workflow.NewRegistry()
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, slack, nil)
-	wf := NewWorkflow(cfg, disp, slack, nil, nil)
+	wf := NewWorkflow(cfg, disp, slack, nil, nil, nil)
 
 	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1"}
 	step := workflow.NextStep{Kind: workflow.NextStepError, ErrorText: "boom"}
@@ -173,7 +173,7 @@ func TestHandleSelection_DSelector_DispatchesWorkflow(t *testing.T) {
 	reg := workflow.NewRegistry()
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, sl, nil)
-	wf := NewWorkflow(cfg, disp, sl, nil, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, nil, nil)
 
 	submitted := false
 	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
@@ -219,7 +219,7 @@ func TestExecuteStep_OpenModal_FirstStepStoresPending(t *testing.T) {
 	reg := workflow.NewRegistry()
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, sl, nil)
-	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default())
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
 
 	p := &workflow.Pending{
 		ChannelID: "C1", ThreadTS: "T1",
@@ -260,7 +260,7 @@ func TestHandleDescriptionAction_ModalFail_ConsumesPending(t *testing.T) {
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, sl, nil)
 	logger := slog.Default()
-	wf := NewWorkflow(cfg, disp, sl, nil, logger)
+	wf := NewWorkflow(cfg, disp, sl, nil, logger, nil)
 
 	submitted := false
 	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Ivantseng123/agentdock/app/config"
@@ -327,4 +329,62 @@ func (f *fakeIssueWorkflow) BuildJob(ctx context.Context, p *workflow.Pending) (
 }
 func (f *fakeIssueWorkflow) HandleResult(ctx context.Context, state *queue.JobState, result *queue.JobResult) error {
 	return nil
+}
+
+// stubAvailability lets tests pre-program verdicts.
+type stubAvailability struct {
+	mu          sync.Mutex
+	SoftVerdict queue.Verdict
+	HardVerdict queue.Verdict
+	SoftCalls   int
+	HardCalls   int
+}
+
+func (s *stubAvailability) CheckSoft(ctx context.Context) queue.Verdict {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SoftCalls++
+	return s.SoftVerdict
+}
+func (s *stubAvailability) CheckHard(ctx context.Context) queue.Verdict {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.HardCalls++
+	return s.HardVerdict
+}
+
+func TestSubmit_NoWorkers_HardRejects(t *testing.T) {
+	sl := &shimSlack{}
+	avail := &stubAvailability{HardVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers}}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
+
+	onSubmitCalled := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		onSubmitCalled = true
+	})
+
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	step := workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+	wf.executeStep(context.Background(), p, step, "")
+
+	if avail.HardCalls != 1 {
+		t.Errorf("HardCalls = %d, want 1", avail.HardCalls)
+	}
+	if onSubmitCalled {
+		t.Error("onSubmit must NOT be called when verdict is NoWorkers")
+	}
+
+	foundReject := false
+	for _, m := range sl.posted {
+		if strings.Contains(m, ":x:") && strings.Contains(m, "沒有 worker") {
+			foundReject = true
+		}
+	}
+	if !foundReject {
+		t.Errorf("expected :x: hard reject message; got posts: %+v", sl.posted)
+	}
 }

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Ivantseng123/agentdock/app/config"
 	slackclient "github.com/Ivantseng123/agentdock/app/slack"
@@ -386,5 +387,39 @@ func TestSubmit_NoWorkers_HardRejects(t *testing.T) {
 	}
 	if !foundReject {
 		t.Errorf("expected :x: hard reject message; got posts: %+v", sl.posted)
+	}
+}
+
+func TestSubmit_BusyEnqueueOK_SetsBusyHint(t *testing.T) {
+	sl := &shimSlack{}
+	avail := &stubAvailability{
+		HardVerdict: queue.Verdict{
+			Kind:          queue.VerdictBusyEnqueueOK,
+			EstimatedWait: 6 * time.Minute,
+		},
+	}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
+
+	var gotPending *workflow.Pending
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		gotPending = p
+	})
+
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	step := workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+	wf.executeStep(context.Background(), p, step, "")
+
+	if gotPending == nil {
+		t.Fatal("onSubmit was not called; expected BusyEnqueueOK to pass through")
+	}
+	if gotPending.BusyHint == "" {
+		t.Errorf("BusyHint should be set; got empty")
+	}
+	if !strings.Contains(gotPending.BusyHint, "預估等候") {
+		t.Errorf("BusyHint should contain 預估等候; got %q", gotPending.BusyHint)
 	}
 }

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -423,3 +423,74 @@ func TestSubmit_BusyEnqueueOK_SetsBusyHint(t *testing.T) {
 		t.Errorf("BusyHint should contain 預估等候; got %q", gotPending.BusyHint)
 	}
 }
+
+func TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues(t *testing.T) {
+	sl := &shimSlack{}
+	avail := &stubAvailability{SoftVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers}}
+	cfg := &config.Config{
+		Channels: map[string]config.ChannelConfig{"C1": {}},
+	}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
+
+	onSubmitCalled := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		onSubmitCalled = true
+	})
+
+	wf.HandleTrigger(slackclient.TriggerEvent{
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		TriggerTS: "T1",
+		UserID:    "U1",
+		Text:      "issue foo/bar",
+	})
+
+	if avail.SoftCalls != 1 {
+		t.Errorf("SoftCalls = %d, want 1", avail.SoftCalls)
+	}
+
+	foundWarn := false
+	for _, m := range sl.posted {
+		if strings.Contains(m, ":warning:") && strings.Contains(m, "沒有 worker") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected :warning: soft warn; got posts: %+v", sl.posted)
+	}
+
+	// fakeIssueWorkflow.Trigger returns NextStepSubmit → submit() runs. The stub's
+	// hard verdict is zero-valued (VerdictKind("")) which matches none of the switch
+	// cases, so submit() falls through to onSubmit. That's the assertion that soft
+	// warn doesn't short-circuit dispatch.
+	if !onSubmitCalled {
+		t.Error("soft warn must not block dispatch; expected onSubmit to still be called")
+	}
+}
+
+func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
+	sl := &shimSlack{}
+	avail := &stubAvailability{SoftVerdict: queue.Verdict{Kind: queue.VerdictOK}}
+	cfg := &config.Config{
+		Channels: map[string]config.ChannelConfig{"C1": {}},
+	}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
+
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {})
+
+	wf.HandleTrigger(slackclient.TriggerEvent{
+		ChannelID: "C1", ThreadTS: "T1", TriggerTS: "T1", UserID: "U1", Text: "issue foo/bar",
+	})
+
+	for _, m := range sl.posted {
+		if strings.Contains(m, "沒有 worker") {
+			t.Errorf("OK verdict should not post soft warn; got %q", m)
+		}
+	}
+}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Attachments       AttachmentsConfig        `yaml:"attachments"`
 	RepoCache         RepoCacheConfig          `yaml:"repo_cache"`
 	Queue             QueueConfig              `yaml:"queue"`
+	Availability      AvailabilityConfig       `yaml:"availability"`
 	Logging           LoggingConfig            `yaml:"logging"`
 	Redis             RedisConfig              `yaml:"redis"`
 	SecretKey         string                   `yaml:"secret_key"`
@@ -156,3 +157,6 @@ type QueueConfig struct {
 	StatusInterval   time.Duration `yaml:"status_interval"`
 }
 
+type AvailabilityConfig struct {
+	AvgJobDuration time.Duration `yaml:"avg_job_duration"`
+}

--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -59,6 +59,9 @@ func ApplyDefaults(cfg *Config) {
 	if cfg.Queue.StatusInterval <= 0 {
 		cfg.Queue.StatusInterval = 5 * time.Second
 	}
+	if cfg.Availability.AvgJobDuration <= 0 {
+		cfg.Availability.AvgJobDuration = 3 * time.Minute
+	}
 	if cfg.RepoCache.Dir == "" {
 		if cacheDir, err := os.UserCacheDir(); err == nil {
 			cfg.RepoCache.Dir = filepath.Join(cacheDir, "agentdock", "repos")

--- a/app/slack/client.go
+++ b/app/slack/client.go
@@ -224,6 +224,7 @@ func (c *Client) UploadFile(channelID, threadTS, filename, title, content, initi
 		Filename:        filename,
 		Title:           title,
 		Content:         content,
+		FileSize:        len(content),
 		InitialComment:  initialComment,
 	})
 	metrics.ExternalDuration.WithLabelValues("slack", "upload_file").Observe(time.Since(start).Seconds())

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -353,6 +353,11 @@ func (w *AskWorkflow) HandleResult(ctx context.Context, state *queue.JobState, r
 // an answer.md file with a short preview comment, because long bodies
 // render awkwardly in Slack's message column and agent output is
 // mrkdwn-styled (which collapses its own structure at length).
+//
+// When file upload fails (e.g. workspace missing the files:write scope
+// for files.upload v2), the answer is posted inline as a fallback so the
+// user still sees the content — truncated messages are preferable to a
+// dangling "已附為檔案：" preview with no file.
 func (w *AskWorkflow) post(job *queue.Job, text string) error {
 	if len(text) <= askInlineThreshold {
 		if job.StatusMsgTS != "" {
@@ -362,11 +367,23 @@ func (w *AskWorkflow) post(job *queue.Job, text string) error {
 	}
 
 	preview := fmt.Sprintf(":memo: 答案較長（約 %d 字），已附為檔案：", len(text))
+	var uploadErr error
 	if job.StatusMsgTS != "" {
 		// Flip the earlier "思考中..." status into the preview so the
 		// thread has one lifecycle marker + the file, not two notices.
 		_ = w.slack.UpdateMessage(job.ChannelID, job.StatusMsgTS, preview)
-		return w.slack.UploadFile(job.ChannelID, job.ThreadTS, "answer.md", "Answer", text, "")
+		uploadErr = w.slack.UploadFile(job.ChannelID, job.ThreadTS, "answer.md", "Answer", text, "")
+	} else {
+		uploadErr = w.slack.UploadFile(job.ChannelID, job.ThreadTS, "answer.md", "Answer", text, preview)
 	}
-	return w.slack.UploadFile(job.ChannelID, job.ThreadTS, "answer.md", "Answer", text, preview)
+	if uploadErr == nil {
+		return nil
+	}
+
+	w.logger.Warn("Slack 檔案上傳失敗，改用內嵌訊息",
+		"phase", "失敗", "error", uploadErr, "length", len(text))
+	if job.StatusMsgTS != "" {
+		_ = w.slack.UpdateMessage(job.ChannelID, job.StatusMsgTS, ":memo: 答案如下：")
+	}
+	return w.slack.PostMessage(job.ChannelID, text, job.ThreadTS)
 }

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -39,6 +39,7 @@ type Pending struct {
 	Phase       string // workflow-defined phase label
 	TaskType    string // workflow identity, equal to Workflow.Type()
 	State       any    // per-workflow state struct
+	BusyHint    string // populated by bot.Workflow.submit() when verdict is BusyEnqueueOK; app.submitJob appends to statusText
 }
 
 // NextStepKind enumerates the actions a workflow's Trigger/Selection can
@@ -51,7 +52,7 @@ const (
 	NextStepOpenModal
 	NextStepSubmit
 	NextStepError
-	NextStepNoop                // used when the workflow handled everything in-place (rare)
+	NextStepNoop                 // used when the workflow handled everything in-place (rare)
 	NextStepPostExternalSelector // external searchable selector (no configured repos)
 	NextStepCancel               // user aborted mid-flow; dispatcher clears dedup and stops
 )

--- a/docs/superpowers/plans/2026-04-22-worker-liveness-precheck.md
+++ b/docs/superpowers/plans/2026-04-22-worker-liveness-precheck.md
@@ -1,0 +1,1772 @@
+# Worker Liveness Precheck Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md`
+
+**Goal:** Wire a two-stage worker availability precheck into the Slack triage flow so that the user is told (a) at trigger time when no workers are online, and (b) at submit time gets a hard reject (no workers) or an ETA (busy) — replacing today's silent wait that ends in a watchdog timeout.
+
+**Architecture:** New `shared/queue.WorkerAvailability` service produces a typed `Verdict` from `JobQueue.ListWorkers`, `JobQueue.QueueDepth`, and `JobStore.ListAll`. The Slack adapter (`app/bot/workflow.go`) calls `CheckSoft` in `HandleTrigger` (non-blocking warn) and `CheckHard` at the top of `runTriage` (can reject). A small `app/bot/verdict_message.go` translates `Verdict` into Slack-flavored text — the seam where future mediums plug in their own renderers.
+
+**Tech Stack:** Go 1.22+ / `slog` / `prometheus/client_golang` / existing `shared/queue` Redis transport / `queuetest` in-memory bundle for unit tests.
+
+**Phases (one commit per task):**
+1. Data model — `WorkerInfo.Slots`
+2. Availability service — TDD growth
+3. Metrics
+4. Verdict rendering
+5. Workflow integration (4 sub-tasks)
+6. Worker side
+7. App wiring + config
+8. Final verification
+
+---
+
+## Phase 1 — Data Model
+
+### Task 1: Add `Slots` field to `WorkerInfo`
+
+**Files:**
+- Modify: `shared/queue/job.go:116-123`
+
+- [ ] **Step 1: Add the field**
+
+In `shared/queue/job.go`, replace the existing `WorkerInfo` struct (lines 116–123) with:
+
+```go
+type WorkerInfo struct {
+	WorkerID    string   `json:"worker_id"`
+	Name        string   `json:"name"`
+	Nickname    string   `json:"nickname,omitempty"`
+	Agents      []string `json:"agents"`
+	Tags        []string `json:"tags"`
+	Slots       int      `json:"slots,omitempty"` // concurrent jobs this worker handles; 0 normalised to 1 by consumers
+	ConnectedAt time.Time
+}
+```
+
+- [ ] **Step 2: Verify the change compiles**
+
+Run: `cd shared && go build ./...`
+Expected: no output (success). Any callers building `WorkerInfo` literals continue to compile because `Slots` is positional-after-existing-fields and unset → `0`.
+
+- [ ] **Step 3: Run existing queue tests (regression check)**
+
+Run: `cd shared && go test ./queue/...`
+Expected: all existing tests pass; `redis_jobqueue_test.go` JSON round-trip continues to work because `omitempty` on a zero int omits the field.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/queue/job.go
+git commit -m "$(cat <<'EOF'
+feat(queue): add Slots field to WorkerInfo
+
+Per-worker concurrency declaration; zero value normalised to 1 by
+consumers so existing single-job workers continue to work.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 — Availability Service (TDD)
+
+### Task 2: Skeleton + healthy-path verdict
+
+**Files:**
+- Create: `shared/queue/availability.go`
+- Create: `shared/queue/availability_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `shared/queue/availability_test.go`:
+
+```go
+package queue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+	"github.com/Ivantseng123/agentdock/shared/queue/queuetest"
+)
+
+func newAvail(t *testing.T) (*queuetest.JobQueue, queue.JobStore, queue.WorkerAvailability) {
+	t.Helper()
+	store := queue.NewMemJobStore()
+	q := queuetest.NewJobQueue(50, store)
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+	return q, store, a
+}
+
+func TestAvailability_HealthyOK(t *testing.T) {
+	q, _, a := newAvail(t)
+
+	q.Register(context.Background(), queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+	q.Register(context.Background(), queue.WorkerInfo{WorkerID: "w2", Slots: 1})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictOK)
+	}
+	if v.WorkerCount != 2 {
+		t.Errorf("WorkerCount = %d, want 2", v.WorkerCount)
+	}
+	if v.TotalSlots != 2 {
+		t.Errorf("TotalSlots = %d, want 2", v.TotalSlots)
+	}
+}
+```
+
+- [ ] **Step 2: Run test — should fail (no symbols defined yet)**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability_HealthyOK -v`
+Expected: FAIL — `undefined: queue.WorkerAvailability`, `undefined: queue.NewWorkerAvailability`, etc.
+
+- [ ] **Step 3: Implement minimal availability service**
+
+Create `shared/queue/availability.go`:
+
+```go
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type VerdictKind string
+
+const (
+	VerdictOK            VerdictKind = "ok"
+	VerdictBusyEnqueueOK VerdictKind = "busy_enqueue"
+	VerdictNoWorkers     VerdictKind = "no_workers"
+)
+
+type Verdict struct {
+	Kind          VerdictKind
+	WorkerCount   int
+	ActiveJobs    int
+	TotalSlots    int
+	EstimatedWait time.Duration
+}
+
+type WorkerAvailability interface {
+	CheckSoft(ctx context.Context) Verdict
+	CheckHard(ctx context.Context) Verdict
+}
+
+type AvailabilityConfig struct {
+	AvgJobDuration time.Duration
+}
+
+type availability struct {
+	queue   JobQueue
+	store   JobStore
+	avgJob  time.Duration
+	logger  *slog.Logger
+}
+
+func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig) WorkerAvailability {
+	avg := cfg.AvgJobDuration
+	if avg <= 0 {
+		avg = 3 * time.Minute
+	}
+	return &availability{
+		queue:  q,
+		store:  store,
+		avgJob: avg,
+		logger: slog.Default(),
+	}
+}
+
+func (a *availability) CheckSoft(ctx context.Context) Verdict { return a.compute(ctx) }
+func (a *availability) CheckHard(ctx context.Context) Verdict { return a.compute(ctx) }
+
+func (a *availability) compute(ctx context.Context) Verdict {
+	workers, err := a.queue.ListWorkers(ctx)
+	if err != nil {
+		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		return Verdict{Kind: VerdictOK}
+	}
+	totalSlots := 0
+	for _, w := range workers {
+		totalSlots += normaliseSlots(w.Slots)
+	}
+	return Verdict{
+		Kind:        VerdictOK,
+		WorkerCount: len(workers),
+		TotalSlots:  totalSlots,
+	}
+}
+
+func normaliseSlots(s int) int {
+	if s <= 0 {
+		return 1
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Run test — should pass**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability_HealthyOK -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/queue/availability.go shared/queue/availability_test.go
+git commit -m "$(cat <<'EOF'
+feat(queue): introduce WorkerAvailability service skeleton
+
+Verdict types and OK-path computation. Subsequent commits add
+NoWorkers, BusyEnqueueOK, slots normalisation, and fail-open paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3: NoWorkers verdict
+
+**Files:**
+- Modify: `shared/queue/availability.go`
+- Modify: `shared/queue/availability_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `shared/queue/availability_test.go`:
+
+```go
+func TestAvailability_NoWorkers(t *testing.T) {
+	_, _, a := newAvail(t)
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictNoWorkers {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictNoWorkers)
+	}
+	if v.WorkerCount != 0 {
+		t.Errorf("WorkerCount = %d, want 0", v.WorkerCount)
+	}
+}
+```
+
+- [ ] **Step 2: Run — should fail (still returns OK)**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability_NoWorkers -v`
+Expected: FAIL — `Kind = "ok", want "no_workers"`.
+
+- [ ] **Step 3: Add the NoWorkers branch in `compute`**
+
+In `shared/queue/availability.go`, replace the body of `compute` with:
+
+```go
+func (a *availability) compute(ctx context.Context) Verdict {
+	workers, err := a.queue.ListWorkers(ctx)
+	if err != nil {
+		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		return Verdict{Kind: VerdictOK}
+	}
+	totalSlots := 0
+	for _, w := range workers {
+		totalSlots += normaliseSlots(w.Slots)
+	}
+	if len(workers) == 0 {
+		return Verdict{Kind: VerdictNoWorkers}
+	}
+	return Verdict{
+		Kind:        VerdictOK,
+		WorkerCount: len(workers),
+		TotalSlots:  totalSlots,
+	}
+}
+```
+
+- [ ] **Step 4: Run both tests**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability -v`
+Expected: PASS for `TestAvailability_HealthyOK` and `TestAvailability_NoWorkers`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/queue/availability.go shared/queue/availability_test.go
+git commit -m "$(cat <<'EOF'
+feat(queue): availability returns NoWorkers when no workers registered
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4: BusyEnqueueOK verdict + ETA
+
+**Files:**
+- Modify: `shared/queue/availability.go`
+- Modify: `shared/queue/availability_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestAvailability_BusyEnqueueOK_FullySaturated(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w2", Slots: 1})
+
+	// Two jobs in JobRunning consume both slots; queue depth = 0.
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	store.Put(&queue.Job{ID: "j2"})
+	store.UpdateStatus("j2", queue.JobRunning)
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictBusyEnqueueOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictBusyEnqueueOK)
+	}
+	if v.ActiveJobs != 2 {
+		t.Errorf("ActiveJobs = %d, want 2", v.ActiveJobs)
+	}
+	wantETA := 1 * 3 * time.Minute // overflow=1
+	if v.EstimatedWait != wantETA {
+		t.Errorf("EstimatedWait = %v, want %v", v.EstimatedWait, wantETA)
+	}
+}
+
+func TestAvailability_BusyEnqueueOK_WithQueueDepth(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+
+	// 1 running + 4 queued = 5 active, slots = 1, overflow = 5
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	for i := 0; i < 4; i++ {
+		q.Submit(ctx, &queue.Job{ID: "p" + string(rune('a'+i))})
+	}
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictBusyEnqueueOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictBusyEnqueueOK)
+	}
+	wantETA := time.Duration(5) * 3 * time.Minute
+	if v.EstimatedWait != wantETA {
+		t.Errorf("EstimatedWait = %v, want %v", v.EstimatedWait, wantETA)
+	}
+}
+```
+
+- [ ] **Step 2: Run — should fail (active count not yet computed)**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability_BusyEnqueueOK -v`
+Expected: FAIL — verdict still returns `OK` because the busy branch is missing.
+
+- [ ] **Step 3: Add active-jobs computation + busy branch**
+
+Replace `compute` body:
+
+```go
+func (a *availability) compute(ctx context.Context) Verdict {
+	workers, err := a.queue.ListWorkers(ctx)
+	if err != nil {
+		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		return Verdict{Kind: VerdictOK}
+	}
+	totalSlots := 0
+	for _, w := range workers {
+		totalSlots += normaliseSlots(w.Slots)
+	}
+	if len(workers) == 0 {
+		return Verdict{Kind: VerdictNoWorkers}
+	}
+
+	depth := a.queue.QueueDepth()
+	states, err := a.store.ListAll()
+	if err != nil {
+		a.logger.Warn("availability: ListAll failed", "error", err)
+		return Verdict{Kind: VerdictOK, WorkerCount: len(workers), TotalSlots: totalSlots}
+	}
+	running := 0
+	for _, s := range states {
+		if s.Status == JobPreparing || s.Status == JobRunning {
+			running++
+		}
+	}
+	active := depth + running
+
+	if active >= totalSlots {
+		overflow := active - totalSlots + 1
+		return Verdict{
+			Kind:          VerdictBusyEnqueueOK,
+			WorkerCount:   len(workers),
+			TotalSlots:    totalSlots,
+			ActiveJobs:    active,
+			EstimatedWait: time.Duration(overflow) * a.avgJob,
+		}
+	}
+	return Verdict{
+		Kind:        VerdictOK,
+		WorkerCount: len(workers),
+		TotalSlots:  totalSlots,
+		ActiveJobs:  active,
+	}
+}
+```
+
+- [ ] **Step 4: Run all availability tests**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/queue/availability.go shared/queue/availability_test.go
+git commit -m "$(cat <<'EOF'
+feat(queue): availability returns BusyEnqueueOK with ETA when saturated
+
+ETA = (active - slots + 1) * AvgJobDuration. Coarse intentional —
+spec is signal "you'll wait", not minute-accurate prediction.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 5: Multi-slot + zero-slot normalisation
+
+**Files:**
+- Modify: `shared/queue/availability_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```go
+func TestAvailability_MultiSlotWorker(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	// One worker with 3 slots, two running jobs → 1 spare slot → OK.
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 3})
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	store.Put(&queue.Job{ID: "j2"})
+	store.UpdateStatus("j2", queue.JobRunning)
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (3 slots, 2 active)", v.Kind, queue.VerdictOK)
+	}
+	if v.TotalSlots != 3 {
+		t.Errorf("TotalSlots = %d, want 3", v.TotalSlots)
+	}
+}
+
+func TestAvailability_ZeroSlotsNormalisedToOne(t *testing.T) {
+	q, _, a := newAvail(t)
+	ctx := context.Background()
+
+	// Slots=0 (e.g. older worker that didn't set the field) → treated as 1.
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "old", Slots: 0})
+
+	v := a.CheckHard(ctx)
+	if v.TotalSlots != 1 {
+		t.Errorf("TotalSlots = %d, want 1 (normalised)", v.TotalSlots)
+	}
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictOK)
+	}
+}
+```
+
+- [ ] **Step 2: Run — these should already pass**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability -v`
+Expected: PASS for both new tests. (`normaliseSlots` is already in place from Task 2; this task locks that behavior with explicit tests.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/queue/availability_test.go
+git commit -m "$(cat <<'EOF'
+test(queue): lock multi-slot and zero-slot normalisation behaviour
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 6: Fail-open on dependency errors
+
+**Files:**
+- Create: `shared/queue/availability_failopen_test.go` (separate file because we need a stub `JobQueue` that returns errors, distinct from `queuetest.JobQueue`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `shared/queue/availability_failopen_test.go`:
+
+```go
+package queue_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// erroringQueue satisfies queue.JobQueue but returns errors on the methods
+// availability depends on. Other methods panic — they should never be called
+// by the availability service.
+type erroringQueue struct {
+	listWorkersErr error
+}
+
+func (e *erroringQueue) Submit(context.Context, *queue.Job) error  { panic("unused") }
+func (e *erroringQueue) QueuePosition(string) (int, error)          { panic("unused") }
+func (e *erroringQueue) QueueDepth() int                            { return 0 }
+func (e *erroringQueue) Receive(context.Context) (<-chan *queue.Job, error) {
+	panic("unused")
+}
+func (e *erroringQueue) Ack(context.Context, string) error            { panic("unused") }
+func (e *erroringQueue) Register(context.Context, queue.WorkerInfo) error {
+	panic("unused")
+}
+func (e *erroringQueue) Unregister(context.Context, string) error { panic("unused") }
+func (e *erroringQueue) ListWorkers(context.Context) ([]queue.WorkerInfo, error) {
+	if e.listWorkersErr != nil {
+		return nil, e.listWorkersErr
+	}
+	return nil, nil
+}
+func (e *erroringQueue) Close() error { return nil }
+
+// erroringStore satisfies queue.JobStore but errors on ListAll.
+type erroringStore struct {
+	listAllErr error
+}
+
+func (s *erroringStore) Put(*queue.Job) error                    { panic("unused") }
+func (s *erroringStore) Get(string) (*queue.JobState, error)      { panic("unused") }
+func (s *erroringStore) GetByThread(string, string) (*queue.JobState, error) {
+	panic("unused")
+}
+func (s *erroringStore) ListPending() ([]*queue.JobState, error) { panic("unused") }
+func (s *erroringStore) UpdateStatus(string, queue.JobStatus) error {
+	panic("unused")
+}
+func (s *erroringStore) SetWorker(string, string) error { panic("unused") }
+func (s *erroringStore) SetAgentStatus(string, queue.StatusReport) error {
+	panic("unused")
+}
+func (s *erroringStore) Delete(string) error { panic("unused") }
+func (s *erroringStore) ListAll() ([]*queue.JobState, error) {
+	if s.listAllErr != nil {
+		return nil, s.listAllErr
+	}
+	return nil, nil
+}
+
+func TestAvailability_FailOpen_ListWorkersError(t *testing.T) {
+	q := &erroringQueue{listWorkersErr: errors.New("redis down")}
+	store := queue.NewMemJobStore()
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (fail-open)", v.Kind, queue.VerdictOK)
+	}
+}
+
+func TestAvailability_FailOpen_ListAllError(t *testing.T) {
+	// Need a queue that returns at least one worker (so we pass the NoWorkers gate)
+	// AND a store that errors on ListAll.
+	q := &workerListingQueue{erroringQueue: erroringQueue{}, workers: []queue.WorkerInfo{{WorkerID: "w1"}}}
+	store := &erroringStore{listAllErr: errors.New("store down")}
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (fail-open on store error)", v.Kind, queue.VerdictOK)
+	}
+}
+
+// workerListingQueue is erroringQueue but with a configurable workers list.
+type workerListingQueue struct {
+	erroringQueue
+	workers []queue.WorkerInfo
+}
+
+func (w *workerListingQueue) ListWorkers(context.Context) ([]queue.WorkerInfo, error) {
+	return w.workers, nil
+}
+```
+
+- [ ] **Step 2: Run — `TestAvailability_FailOpen_ListWorkersError` already passes, `TestAvailability_FailOpen_ListAllError` should pass too**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability_FailOpen -v`
+Expected: PASS for both. The `compute` function written in Task 4 already returns `OK` on `ListAll` error before the busy branch is evaluated.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/queue/availability_failopen_test.go
+git commit -m "$(cat <<'EOF'
+test(queue): lock availability fail-open behaviour for dep errors
+
+Treat ListWorkers / ListAll errors as transient blindness; return OK
+rather than mis-classify the system as broken. The watchdog backstops.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Metrics
+
+### Task 7: Add availability metrics + register + wire
+
+**Files:**
+- Modify: `shared/metrics/metrics.go:139-194`
+- Modify: `shared/queue/availability.go`
+
+- [ ] **Step 1: Add the three new metrics in `shared/metrics/metrics.go`**
+
+After the existing `WatchdogKillsTotal` declaration (around line 145), insert:
+
+```go
+// ---- Availability ----
+
+var WorkerAvailabilityVerdictTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_verdict_total",
+	Help:      "Counts of availability verdicts by kind and stage.",
+}, []string{"kind", "stage"})
+
+var WorkerAvailabilityCheckDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_check_duration_seconds",
+	Help:      "Latency of WorkerAvailability.compute.",
+	Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
+})
+
+var WorkerAvailabilityCheckErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_check_errors_total",
+	Help:      "Errors from availability dependencies.",
+}, []string{"dependency"})
+```
+
+Then in the `reg.MustRegister(...)` block in `Register` (around line 173–194), add the three new metrics:
+
+```go
+reg.MustRegister(
+	RequestTotal,
+	// ... existing ...
+	ExternalErrorsTotal,
+	WorkerAvailabilityVerdictTotal,    // NEW
+	WorkerAvailabilityCheckDuration,    // NEW
+	WorkerAvailabilityCheckErrors,      // NEW
+)
+```
+
+- [ ] **Step 2: Verify metrics package compiles & tests still pass**
+
+Run: `cd shared && go test ./metrics/ -v`
+Expected: PASS.
+
+- [ ] **Step 3: Wire metrics into availability via a hook (avoid import cycle)**
+
+`shared/queue` cannot import `shared/metrics` (would create a cycle: metrics imports queue for the GaugeFunc). Use the same pattern as `WithWatchdogKillHook`.
+
+In `shared/queue/availability.go`, replace the file with:
+
+```go
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type VerdictKind string
+
+const (
+	VerdictOK            VerdictKind = "ok"
+	VerdictBusyEnqueueOK VerdictKind = "busy_enqueue"
+	VerdictNoWorkers     VerdictKind = "no_workers"
+)
+
+type Verdict struct {
+	Kind          VerdictKind
+	WorkerCount   int
+	ActiveJobs    int
+	TotalSlots    int
+	EstimatedWait time.Duration
+}
+
+type WorkerAvailability interface {
+	CheckSoft(ctx context.Context) Verdict
+	CheckHard(ctx context.Context) Verdict
+}
+
+type AvailabilityConfig struct {
+	AvgJobDuration time.Duration
+}
+
+// AvailabilityOption configures observability hooks without creating an
+// import cycle with shared/metrics.
+type AvailabilityOption func(*availability)
+
+// WithVerdictHook is invoked on every compute() call with kind, stage, and duration.
+func WithVerdictHook(fn func(kind, stage string, d time.Duration)) AvailabilityOption {
+	return func(a *availability) { a.verdictHook = fn }
+}
+
+// WithDepErrorHook is invoked when a dependency call fails, with the
+// dependency name (e.g. "list_workers", "list_all").
+func WithDepErrorHook(fn func(dep string)) AvailabilityOption {
+	return func(a *availability) { a.depErrorHook = fn }
+}
+
+type availability struct {
+	queue        JobQueue
+	store        JobStore
+	avgJob       time.Duration
+	logger       *slog.Logger
+	verdictHook  func(kind, stage string, d time.Duration)
+	depErrorHook func(dep string)
+}
+
+func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig, opts ...AvailabilityOption) WorkerAvailability {
+	avg := cfg.AvgJobDuration
+	if avg <= 0 {
+		avg = 3 * time.Minute
+	}
+	a := &availability{
+		queue:  q,
+		store:  store,
+		avgJob: avg,
+		logger: slog.Default(),
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+func (a *availability) CheckSoft(ctx context.Context) Verdict {
+	return a.observe(ctx, "soft")
+}
+
+func (a *availability) CheckHard(ctx context.Context) Verdict {
+	return a.observe(ctx, "hard")
+}
+
+func (a *availability) observe(ctx context.Context, stage string) Verdict {
+	start := time.Now()
+	v := a.compute(ctx)
+	if a.verdictHook != nil {
+		a.verdictHook(string(v.Kind), stage, time.Since(start))
+	}
+	return v
+}
+
+func (a *availability) compute(ctx context.Context) Verdict {
+	workers, err := a.queue.ListWorkers(ctx)
+	if err != nil {
+		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		if a.depErrorHook != nil {
+			a.depErrorHook("list_workers")
+		}
+		return Verdict{Kind: VerdictOK}
+	}
+	totalSlots := 0
+	for _, w := range workers {
+		totalSlots += normaliseSlots(w.Slots)
+	}
+	if len(workers) == 0 {
+		return Verdict{Kind: VerdictNoWorkers}
+	}
+
+	depth := a.queue.QueueDepth()
+	states, err := a.store.ListAll()
+	if err != nil {
+		a.logger.Warn("availability: ListAll failed", "error", err)
+		if a.depErrorHook != nil {
+			a.depErrorHook("list_all")
+		}
+		return Verdict{Kind: VerdictOK, WorkerCount: len(workers), TotalSlots: totalSlots}
+	}
+	running := 0
+	for _, s := range states {
+		if s.Status == JobPreparing || s.Status == JobRunning {
+			running++
+		}
+	}
+	active := depth + running
+
+	if active >= totalSlots {
+		overflow := active - totalSlots + 1
+		return Verdict{
+			Kind:          VerdictBusyEnqueueOK,
+			WorkerCount:   len(workers),
+			TotalSlots:    totalSlots,
+			ActiveJobs:    active,
+			EstimatedWait: time.Duration(overflow) * a.avgJob,
+		}
+	}
+	return Verdict{
+		Kind:        VerdictOK,
+		WorkerCount: len(workers),
+		TotalSlots:  totalSlots,
+		ActiveJobs:  active,
+	}
+}
+
+func normaliseSlots(s int) int {
+	if s <= 0 {
+		return 1
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Run availability tests**
+
+Run: `cd shared && go test ./queue/ -run TestAvailability -v`
+Expected: all PASS (no test depends on the hook being set; default nil).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/queue/availability.go shared/metrics/metrics.go
+git commit -m "$(cat <<'EOF'
+feat(metrics): WorkerAvailability verdict + duration + dep errors
+
+Wired via functional options (verdict hook + dep-error hook) to avoid
+introducing a shared/queue → shared/metrics import cycle.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Verdict Rendering
+
+### Task 8: `verdict_message.go` + tests
+
+**Files:**
+- Create: `app/bot/verdict_message.go`
+- Create: `app/bot/verdict_message_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/bot/verdict_message_test.go`:
+
+```go
+package bot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+func TestRenderSoftWarn_NoWorkers(t *testing.T) {
+	got := RenderSoftWarn(queue.Verdict{Kind: queue.VerdictNoWorkers})
+	if !strings.Contains(got, ":warning:") {
+		t.Errorf("missing :warning: prefix; got %q", got)
+	}
+	if !strings.Contains(got, "沒有 worker") {
+		t.Errorf("missing key phrase '沒有 worker'; got %q", got)
+	}
+}
+
+func TestRenderHardReject_NoWorkers(t *testing.T) {
+	got := RenderHardReject(queue.Verdict{Kind: queue.VerdictNoWorkers})
+	if !strings.Contains(got, ":x:") {
+		t.Errorf("missing :x: prefix; got %q", got)
+	}
+	if !strings.Contains(got, "無法處理") {
+		t.Errorf("missing '無法處理'; got %q", got)
+	}
+}
+
+func TestRenderBusyHint_WithETA(t *testing.T) {
+	v := queue.Verdict{
+		Kind:          queue.VerdictBusyEnqueueOK,
+		EstimatedWait: 9 * time.Minute,
+	}
+	got := RenderBusyHint(v)
+	if !strings.Contains(got, "預估等候") {
+		t.Errorf("missing '預估等候'; got %q", got)
+	}
+	if !strings.Contains(got, "9m") {
+		t.Errorf("expected '9m' in output; got %q", got)
+	}
+}
+
+func TestRenderBusyHint_ZeroETA_ReturnsEmpty(t *testing.T) {
+	v := queue.Verdict{Kind: queue.VerdictBusyEnqueueOK, EstimatedWait: 0}
+	if got := RenderBusyHint(v); got != "" {
+		t.Errorf("expected empty string for zero ETA; got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — should fail**
+
+Run: `cd app && go test ./bot/ -run "TestRender" -v`
+Expected: FAIL — `undefined: RenderSoftWarn`, etc.
+
+- [ ] **Step 3: Implement renderers**
+
+Create `app/bot/verdict_message.go`:
+
+```go
+package bot
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// RenderSoftWarn produces the trigger-time soft warning. Currently only the
+// NoWorkers verdict is rendered; other verdicts return "" (caller should not
+// post empty messages).
+func RenderSoftWarn(v queue.Verdict) string {
+	if v.Kind != queue.VerdictNoWorkers {
+		return ""
+	}
+	return ":warning: 目前沒有 worker 在線，你仍可繼續選擇，送出時會再確認一次。"
+}
+
+// RenderHardReject produces the submit-time rejection message.
+func RenderHardReject(v queue.Verdict) string {
+	if v.Kind != queue.VerdictNoWorkers {
+		return ""
+	}
+	return ":x: 目前沒有 worker 在線，無法處理。請稍後再試。"
+}
+
+// RenderBusyHint produces the suffix appended to the lifecycle queue
+// message when the verdict is BusyEnqueueOK with a non-zero ETA.
+func RenderBusyHint(v queue.Verdict) string {
+	if v.EstimatedWait <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("(預估等候 ~%dm)",
+		int(v.EstimatedWait.Round(time.Minute).Minutes()))
+}
+```
+
+- [ ] **Step 4: Run renderer tests — should pass**
+
+Run: `cd app && go test ./bot/ -run "TestRender" -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bot/verdict_message.go app/bot/verdict_message_test.go
+git commit -m "$(cat <<'EOF'
+feat(bot): verdict_message renders Slack text from queue.Verdict
+
+Single seam where future mediums (X, Discord) plug in their own
+renderers. Today's text is intentionally minimal — oncall handles
+or richer guidance can be added without touching the verdict service.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5 — Workflow Integration
+
+### Task 9: Inject availability + add busyHint field (no behaviour change yet)
+
+**Files:**
+- Modify: `app/bot/workflow.go:60-115` (Workflow struct + NewWorkflow)
+- Modify: `app/bot/workflow.go:41-58` (pendingTriage struct)
+
+- [ ] **Step 1: Add the field, constructor param, and pendingTriage field**
+
+In `app/bot/workflow.go`:
+
+(a) Inside `pendingTriage` (around line 41–58), append:
+
+```go
+type pendingTriage struct {
+	// ... existing fields ...
+	RepoWasPicked  bool
+	busyHint       string // populated by hard check when verdict is BusyEnqueueOK
+}
+```
+
+(b) Inside `Workflow` (around line 60–77), add an `availability` field:
+
+```go
+type Workflow struct {
+	// ... existing fields ...
+	skillProvider SkillProvider
+	secretKey     []byte
+	identity      Identity
+	availability  queue.WorkerAvailability // NEW
+
+	mu        sync.Mutex
+	pending   map[string]*pendingTriage
+	autoBound map[string]bool
+}
+```
+
+(c) Update the `NewWorkflow` signature (around line 79–115). Add `availability queue.WorkerAvailability` as the LAST parameter (after `identity Identity`):
+
+```go
+func NewWorkflow(
+	cfg *config.Config,
+	slack slackAPI,
+	repoCache *ghclient.RepoCache,
+	repoDiscovery *ghclient.RepoDiscovery,
+	jobQueue queue.JobQueue,
+	jobStore queue.JobStore,
+	attachStore queue.AttachmentStore,
+	resultBus queue.ResultBus,
+	skillProvider SkillProvider,
+	identity Identity,
+	availability queue.WorkerAvailability, // NEW
+) *Workflow {
+```
+
+And inside the function body, add `availability: availability,` to the struct literal.
+
+- [ ] **Step 2: Update the only existing caller (`app/app.go:142`)**
+
+In `app/app.go` line 142, the current call is:
+
+```go
+wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity)
+```
+
+Update to pass `nil` for now (Task 15 will replace this with a real instance):
+
+```go
+wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity, nil)
+```
+
+- [ ] **Step 3: Verify the whole tree compiles**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 4: Run all existing tests (regression)**
+
+Run: `go test ./...`
+Expected: all PASS. (No existing test calls `HandleTrigger` or `runTriage`, so the nil `availability` is not yet dereferenced. The new tests in Tasks 10–12 will set a stub.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bot/workflow.go app/app.go
+git commit -m "$(cat <<'EOF'
+refactor(bot): inject WorkerAvailability + busyHint field
+
+Wiring only — no behaviour change. The hard/soft check call sites
+land in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 10: Submit-time hard check — NoWorkers reject path
+
+**Files:**
+- Modify: `app/bot/workflow.go:386-396` (top of `runTriage`)
+- Modify: `app/bot/workflow_test.go` (add `stubAvailability` + new test)
+
+- [ ] **Step 1: Add the `stubAvailability` helper to `workflow_test.go`**
+
+Append to `app/bot/workflow_test.go` (right above `func newTestWorkflow`):
+
+```go
+// stubAvailability lets tests pre-program verdicts.
+type stubAvailability struct {
+	mu          sync.Mutex
+	SoftVerdict queue.Verdict
+	HardVerdict queue.Verdict
+	SoftCalls   int
+	HardCalls   int
+}
+
+func (s *stubAvailability) CheckSoft(ctx context.Context) queue.Verdict {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.SoftCalls++
+	return s.SoftVerdict
+}
+func (s *stubAvailability) CheckHard(ctx context.Context) queue.Verdict {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.HardCalls++
+	return s.HardVerdict
+}
+```
+
+You will also need to add `"context"` to the existing imports if not already present.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `app/bot/workflow_test.go`:
+
+```go
+func TestRunTriage_NoWorkers_HardRejects(t *testing.T) {
+	slack := &stubSlack{}
+	avail := &stubAvailability{
+		HardVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers},
+	}
+	cfg := &config.Config{
+		Channels:        map[string]config.ChannelConfig{"C1": {Repo: "o/r"}},
+		ChannelDefaults: config.ChannelConfig{},
+	}
+	w := newTestWorkflow(t, slack, cfg)
+	w.availability = avail
+
+	pt := testPending("C1", "T1", true, "")
+	pt.SelectedRepo = "o/r"
+	pt.SelectedBranch = "main"
+
+	w.runTriage(pt)
+
+	if avail.HardCalls != 1 {
+		t.Errorf("HardCalls = %d, want 1", avail.HardCalls)
+	}
+
+	foundReject := false
+	for _, m := range slack.PostMessageCalls {
+		if containsStr(m.Text, ":x:") && containsStr(m.Text, "沒有 worker") {
+			foundReject = true
+		}
+	}
+	if !foundReject {
+		t.Errorf("expected hard reject :x: message; got posts: %+v", slack.PostMessageCalls)
+	}
+
+	// Verify the lifecycle ":mag:" message was NOT posted (hard reject runs first).
+	for _, m := range slack.PostMessageCalls {
+		if containsStr(m.Text, ":mag:") {
+			t.Errorf("lifecycle :mag: message should NOT appear after hard reject; got %q", m.Text)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run — should fail**
+
+Run: `cd app && go test ./bot/ -run TestRunTriage_NoWorkers_HardRejects -v`
+Expected: FAIL — the hard check is not yet wired; the test will see the `:mag:` lifecycle message and no `:x:` reject. (Note: it will likely panic on nil queue at `w.queue.Submit` — the failure is expected one way or another. The point is the green-light test will pass after Step 4.)
+
+- [ ] **Step 4: Implement the hard check**
+
+In `app/bot/workflow.go`, locate `runTriage` (line 386). Right after `ctx := context.Background()` (line 387) and BEFORE the `statusMsgTS, err := w.slack.PostMessageWithTS(...)` line (line 392), insert:
+
+```go
+	// Hard availability check — must run before any lifecycle Slack post so
+	// rejections don't leave orphan ":mag:" messages.
+	if w.availability != nil {
+		verdict := w.availability.CheckHard(ctx)
+		switch verdict.Kind {
+		case queue.VerdictNoWorkers:
+			w.slack.PostMessage(pt.ChannelID,
+				RenderHardReject(verdict), pt.ThreadTS)
+			w.clearDedup(pt)
+			return
+		case queue.VerdictBusyEnqueueOK:
+			pt.busyHint = RenderBusyHint(verdict)
+		case queue.VerdictOK:
+			// continue
+		}
+	}
+```
+
+The `if w.availability != nil` guard exists only because Task 15 hasn't replaced the `nil` in `app.go` yet — once that's done, the field is always populated.
+
+- [ ] **Step 5: Run — should pass**
+
+Run: `cd app && go test ./bot/ -run TestRunTriage_NoWorkers_HardRejects -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run full bot test package (regression)**
+
+Run: `cd app && go test ./bot/`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/bot/workflow.go app/bot/workflow_test.go
+git commit -m "$(cat <<'EOF'
+feat(bot): runTriage hard-rejects when no workers are online
+
+Posts the reject message, clears thread dedup so the user can retry,
+and returns before the lifecycle ':mag:' message is sent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 11: Submit-time hard check — BusyEnqueueOK appends ETA hint
+
+**Files:**
+- Modify: `app/bot/workflow.go:537-544` (the statusMsg block)
+- Modify: `app/bot/workflow_test.go` (new test)
+
+- [ ] **Step 1: Append busyHint to statusMsg in `workflow.go`**
+
+In `app/bot/workflow.go`, locate the block (around lines 537–544):
+
+```go
+	pos, _ := w.queue.QueuePosition(job.ID)
+	var statusMsg string
+	if pos <= 1 {
+		statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
+	} else {
+		statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
+	}
+```
+
+Replace with:
+
+```go
+	pos, _ := w.queue.QueuePosition(job.ID)
+	var statusMsg string
+	if pos <= 1 {
+		statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
+	} else {
+		statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
+	}
+	if pt.busyHint != "" {
+		statusMsg += " " + pt.busyHint
+	}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `app/bot/workflow_test.go`:
+
+```go
+func TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA(t *testing.T) {
+	slack := &stubSlack{}
+	avail := &stubAvailability{
+		HardVerdict: queue.Verdict{
+			Kind:          queue.VerdictBusyEnqueueOK,
+			EstimatedWait: 6 * time.Minute,
+		},
+	}
+	cfg := &config.Config{
+		Channels:        map[string]config.ChannelConfig{"C1": {Repo: "o/r"}},
+		ChannelDefaults: config.ChannelConfig{},
+	}
+	w := newTestWorkflow(t, slack, cfg)
+	w.availability = avail
+
+	// runTriage requires a working queue + store + attachments + results.
+	store := queue.NewMemJobStore()
+	bundle := queuetest.NewBundle(50, 1, store)
+	w.queue = bundle.Queue
+	w.store = store
+	w.attachments = bundle.Attachments
+	w.results = bundle.Results
+
+	pt := testPending("C1", "T1", true, "")
+	pt.SelectedRepo = "o/r"
+	pt.SelectedBranch = "main"
+
+	// FetchThreadContext stub returns nil messages — runTriage handles this by
+	// notifying error and returning. To exercise the ETA path we need at least
+	// one message. Inject one via a custom stub return.
+	slack.FetchThreadResult = []slackclient.ThreadRawMessage{
+		{User: "U1", Timestamp: "T1", Text: "help me"},
+	}
+
+	w.runTriage(pt)
+
+	// Find the lifecycle status message (post-submit). It should contain the ETA hint.
+	foundETA := false
+	for _, u := range slack.UpdateMessageCalls {
+		if containsStr(u.Text, ":hourglass") && containsStr(u.Text, "預估等候") {
+			foundETA = true
+		}
+	}
+	for _, m := range slack.PostMessageCalls {
+		if containsStr(m.Text, ":hourglass") && containsStr(m.Text, "預估等候") {
+			foundETA = true
+		}
+	}
+	for _, b := range slack.PostMessageWithButtonCalls {
+		if containsStr(b.Text, ":hourglass") && containsStr(b.Text, "預估等候") {
+			foundETA = true
+		}
+	}
+	if !foundETA {
+		t.Errorf("expected lifecycle message containing 預估等候; got updates=%+v posts=%+v buttons=%+v",
+			slack.UpdateMessageCalls, slack.PostMessageCalls, slack.PostMessageWithButtonCalls)
+	}
+}
+```
+
+You will also need to:
+- Add `"time"` import to `workflow_test.go` if not present.
+- Add `"github.com/Ivantseng123/agentdock/shared/queue/queuetest"` import.
+- Extend `stubSlack` with a `FetchThreadResult []slackclient.ThreadRawMessage` field (and update `FetchThreadContext` to return it):
+
+```go
+type stubSlack struct {
+	mu sync.Mutex
+	// ... existing fields ...
+	FetchThreadResult []slackclient.ThreadRawMessage
+}
+
+func (s *stubSlack) FetchThreadContext(channelID, threadTS, triggerTS, botUserID, botID string, limit int) ([]slackclient.ThreadRawMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.FetchThreadResult, nil
+}
+```
+
+(Replace the existing `FetchThreadContext` method that always returns `nil, nil`.)
+
+- [ ] **Step 3: Run — should pass**
+
+Run: `cd app && go test ./bot/ -run TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run full bot tests (regression)**
+
+Run: `cd app && go test ./bot/`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bot/workflow.go app/bot/workflow_test.go
+git commit -m "$(cat <<'EOF'
+feat(bot): runTriage appends ETA hint when verdict is BusyEnqueueOK
+
+Lifecycle message becomes ':hourglass: 已加入排隊，前面有 N 個請求 (預估等候 ~Xm)'.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 12: Trigger-time soft warn
+
+**Files:**
+- Modify: `app/bot/workflow.go:141-208` (`HandleTrigger`)
+- Modify: `app/bot/workflow_test.go` (new test)
+
+- [ ] **Step 1: Insert the soft check in `HandleTrigger`**
+
+In `app/bot/workflow.go`, locate `HandleTrigger`. After the channel-guard block (around line 156, right after `channelCfg = w.cfg.ChannelDefaults` for the auto-bind branch — i.e., after the `if !ok { ... }` block ends) and BEFORE `reqID := logging.NewRequestID()`, insert:
+
+```go
+	// Soft availability check — informational only; do NOT block the flow.
+	// Hard check at submit time decides whether to proceed.
+	if w.availability != nil {
+		verdict := w.availability.CheckSoft(context.Background())
+		if verdict.Kind == queue.VerdictNoWorkers {
+			w.slack.PostMessage(event.ChannelID,
+				RenderSoftWarn(verdict), event.ThreadTS)
+		}
+	}
+```
+
+You will need to import `"context"` if not already imported (it is, per existing `runTriage` body).
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `app/bot/workflow_test.go`:
+
+```go
+func TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues(t *testing.T) {
+	slack := &stubSlack{}
+	avail := &stubAvailability{
+		SoftVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers},
+	}
+	cfg := &config.Config{
+		Channels: map[string]config.ChannelConfig{
+			"C1": {Repos: []string{"o/a", "o/b"}},
+		},
+	}
+	w := newTestWorkflow(t, slack, cfg)
+	w.availability = avail
+
+	w.HandleTrigger(slackclient.TriggerEvent{
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		TriggerTS: "T1",
+		UserID:    "U1",
+		Text:      "<@bot>",
+	})
+
+	if avail.SoftCalls != 1 {
+		t.Errorf("SoftCalls = %d, want 1", avail.SoftCalls)
+	}
+
+	foundWarn := false
+	for _, m := range slack.PostMessageCalls {
+		if containsStr(m.Text, ":warning:") && containsStr(m.Text, "沒有 worker") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected :warning: soft warn; got posts: %+v", slack.PostMessageCalls)
+	}
+
+	// Selector must still be posted — soft warn does NOT short-circuit.
+	if len(slack.PostSelectorCalls) != 1 {
+		t.Errorf("expected 1 PostSelector call (flow continues); got %d", len(slack.PostSelectorCalls))
+	}
+}
+
+func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
+	slack := &stubSlack{}
+	avail := &stubAvailability{
+		SoftVerdict: queue.Verdict{Kind: queue.VerdictOK},
+	}
+	cfg := &config.Config{
+		Channels: map[string]config.ChannelConfig{
+			"C1": {Repos: []string{"o/a", "o/b"}},
+		},
+	}
+	w := newTestWorkflow(t, slack, cfg)
+	w.availability = avail
+
+	w.HandleTrigger(slackclient.TriggerEvent{
+		ChannelID: "C1", ThreadTS: "T1", TriggerTS: "T1", UserID: "U1", Text: "<@bot>",
+	})
+
+	for _, m := range slack.PostMessageCalls {
+		if containsStr(m.Text, "沒有 worker") {
+			t.Errorf("OK verdict should not post soft warn; got %q", m.Text)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run — should pass**
+
+Run: `cd app && go test ./bot/ -run TestHandleTrigger -v`
+Expected: PASS for both new tests, plus the existing `HandleTrigger` tests if any. (The existing tests don't call `HandleTrigger` directly — verify no regressions.)
+
+- [ ] **Step 4: Run full bot tests (regression)**
+
+Run: `cd app && go test ./bot/`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bot/workflow.go app/bot/workflow_test.go
+git commit -m "$(cat <<'EOF'
+feat(bot): HandleTrigger posts soft warn when no workers (non-blocking)
+
+Selection still proceeds; the hard check at submit is the gate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6 — Worker Side
+
+### Task 13: Worker registers with `Slots: 1`
+
+**Files:**
+- Modify: `worker/pool/pool.go:242-248`
+- Modify: `worker/pool/pool.go:260-266`
+
+- [ ] **Step 1: Update both call sites in `workerHeartbeat`**
+
+In `worker/pool/pool.go`, the function `workerHeartbeat` (around line 239) builds `WorkerInfo` in two places. Add `Slots: 1,` to both:
+
+(a) Initial registration (around line 242–247):
+
+```go
+	for i := 0; i < p.cfg.WorkerCount; i++ {
+		info := queue.WorkerInfo{
+			WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
+			Name:        p.cfg.Hostname,
+			Nickname:    p.nicknameForIndex(i),
+			Slots:       1, // hardcoded; future work: read from worker.yaml when concurrent execution lands
+			ConnectedAt: now,
+		}
+		// ...
+	}
+```
+
+(b) Ticker re-registration (around line 260–265):
+
+```go
+			for i := 0; i < p.cfg.WorkerCount; i++ {
+				info := queue.WorkerInfo{
+					WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
+					Name:        p.cfg.Hostname,
+					Nickname:    p.nicknameForIndex(i),
+					Slots:       1, // see initial-registration comment above
+					ConnectedAt: now,
+				}
+				p.cfg.Queue.Register(ctx, info)
+			}
+```
+
+- [ ] **Step 2: Verify worker compiles & tests pass**
+
+Run: `cd worker && go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add worker/pool/pool.go
+git commit -m "$(cat <<'EOF'
+feat(worker): declare Slots: 1 in heartbeat WorkerInfo
+
+Hardcoded — matches today's single-job-per-worker pool. When the pool
+gains concurrent execution, this lifts to worker.yaml config.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 7 — App Wiring + Config
+
+### Task 14: Add `AvailabilityConfig` to `app/config`
+
+**Files:**
+- Modify: `app/config/config.go`
+- Modify: `app/config/defaults.go`
+
+- [ ] **Step 1: Add `AvailabilityConfig` type + `Availability` field on `Config`**
+
+In `app/config/config.go`:
+
+(a) Append the new type after the `QueueConfig` declaration (around line 132):
+
+```go
+type AvailabilityConfig struct {
+	AvgJobDuration time.Duration `yaml:"avg_job_duration"`
+}
+```
+
+(b) Add the field to the top-level `Config` struct (after `Queue QueueConfig`, around line 27):
+
+```go
+type Config struct {
+	// ... existing fields ...
+	Queue        QueueConfig        `yaml:"queue"`
+	Availability AvailabilityConfig `yaml:"availability"` // NEW
+	Logging      LoggingConfig      `yaml:"logging"`
+	// ... rest ...
+}
+```
+
+- [ ] **Step 2: Apply default in `defaults.go`**
+
+In `app/config/defaults.go`, add inside `ApplyDefaults` (e.g. after the queue defaults block, around line 61):
+
+```go
+	if cfg.Availability.AvgJobDuration <= 0 {
+		cfg.Availability.AvgJobDuration = 3 * time.Minute
+	}
+```
+
+- [ ] **Step 3: Verify config tests pass**
+
+Run: `cd app && go test ./config/ -v`
+Expected: all PASS. `DefaultsMap` round-trips the new field.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/config/config.go app/config/defaults.go
+git commit -m "$(cat <<'EOF'
+feat(app/config): add availability.avg_job_duration (default 3m)
+
+Optional field; powers ETA calculation in the worker availability
+service. Absent → 3m default applied via ApplyDefaults.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 15: Wire availability into `app/app.go`
+
+**Files:**
+- Modify: `app/app.go:135-184` (around coordinator construction and `metrics.Register`)
+
+- [ ] **Step 1: Construct availability and pass to `NewWorkflow`**
+
+In `app/app.go`, immediately after the `coordinator` is constructed and `RegisterQueue` is called (around line 140), but before the `wf := bot.NewWorkflow(...)` call (line 142), insert:
+
+```go
+	availability := queue.NewWorkerAvailability(coordinator, jobStore, queue.AvailabilityConfig{
+		AvgJobDuration: cfg.Availability.AvgJobDuration,
+	},
+		queue.WithVerdictHook(func(kind, stage string, d time.Duration) {
+			metrics.WorkerAvailabilityVerdictTotal.WithLabelValues(kind, stage).Inc()
+			metrics.WorkerAvailabilityCheckDuration.Observe(d.Seconds())
+		}),
+		queue.WithDepErrorHook(func(dep string) {
+			metrics.WorkerAvailabilityCheckErrors.WithLabelValues(dep).Inc()
+		}),
+	)
+```
+
+Then update the `NewWorkflow` call (line 142) — replace the trailing `nil` (added in Task 9) with `availability`:
+
+```go
+	wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity, availability)
+```
+
+- [ ] **Step 2: Verify the whole tree compiles**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Run all tests (regression)**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/app.go
+git commit -m "$(cat <<'EOF'
+feat(app): construct WorkerAvailability and inject into Workflow
+
+Wires the verdict + dep-error hooks into Prometheus. Behaviour is
+now end-to-end: trigger soft warn + submit hard check both active.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 8 — Final Verification
+
+### Task 16: Full build + import direction + test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build everything**
+
+Run: `go build ./...`
+Expected: success across all three modules (app, worker, shared, root).
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `go test ./...`
+Expected: all PASS, including:
+- `shared/queue/...` (new availability tests)
+- `app/bot/...` (new workflow integration tests)
+- `app/config/...` (config defaults round-trip)
+- `worker/pool/...` (existing; Slots field is additive)
+- `test/import_direction_test.go` (no new cross-module imports introduced)
+
+- [ ] **Step 3: Verify import direction explicitly**
+
+Run: `go test ./test/ -run TestImportDirection -v`
+Expected: PASS. The new code respects boundaries:
+- `shared/queue` does NOT import `shared/metrics` (uses functional-option hooks).
+- `app/bot/verdict_message.go` imports `shared/queue` (allowed).
+- `app/app.go` imports `shared/metrics` and `shared/queue` (allowed).
+
+- [ ] **Step 4: Confirm no committed `nil` placeholder remains**
+
+Run: `grep -n "NewWorkflow.*nil" app/app.go`
+Expected: no matches (Task 15 replaced the `nil` from Task 9).
+
+- [ ] **Step 5: Manually exercise (optional, off-CI)**
+
+Optionally bring up Redis + start an `agentdock app` with no workers and confirm:
+- `@bot` in a thread → soft warn appears, repo selector still appears.
+- After completing selection → hard reject appears, `:mag:` lifecycle message does NOT.
+- `agentdock worker` started → next `@bot` works normally with no warn.
+
+This is documentation of the manual smoke; the integration tests are the gate.
+
+- [ ] **Step 6: No commit needed**
+
+If all of the above pass, the implementation is complete. The plan was committed-as-you-go; no final commit step.
+
+---
+
+## Spec Coverage Self-Review
+
+Cross-referenced against `docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md`:
+
+| Spec Section | Implementing Task(s) |
+|---|---|
+| §1 Data Model — `WorkerInfo.Slots` | Task 1 |
+| §2 Availability Service — types, interface, compute | Tasks 2–4 |
+| §2 Slots normalisation | Task 5 (locked by test) |
+| §2 Fail-open | Task 6 |
+| §3.1 NewWorkflow constructor change | Task 9 |
+| §3.2 Trigger-time soft warn | Task 12 |
+| §3.3 Submit-time hard check (NoWorkers) | Task 10 |
+| §3.3 Submit-time hard check (BusyEnqueueOK + ETA in lifecycle) | Task 11 |
+| §3 `pendingTriage.busyHint` field | Task 9 |
+| §4 Verdict rendering | Task 8 |
+| §5 Wiring + config | Tasks 14, 15 |
+| §6 Worker Slots: 1 | Task 13 |
+| §7 Metrics (verdict, duration, dep errors) | Tasks 7, 15 |
+| §8 Error Handling Summary | Tasks 6 (deps), 10 (Slack reject), 12 (Slack warn) |
+| §9 Ordering Constraints — soft AFTER channel-guard | Task 12 (insertion location specified) |
+| §9 Ordering — hard BEFORE first lifecycle post | Task 10 (insertion at line 387–392 boundary) |
+| §9 Ordering — hard reject calls clearDedup | Task 10 (assertion implicit; impl explicit) |
+| Testing — unit matrix (9 cases) | Tasks 2–6 cover all 9 rows |
+| Testing — 3 integration cases | Tasks 10, 11, 12 |
+| Migration / Rollout | Additive changes in Tasks 1, 14 (omitempty + optional config) |

--- a/docs/superpowers/plans/2026-04-22-worker-liveness-precheck.md
+++ b/docs/superpowers/plans/2026-04-22-worker-liveness-precheck.md
@@ -6,18 +6,18 @@
 
 **Goal:** Wire a two-stage worker availability precheck into the Slack triage flow so that the user is told (a) at trigger time when no workers are online, and (b) at submit time gets a hard reject (no workers) or an ETA (busy) — replacing today's silent wait that ends in a watchdog timeout.
 
-**Architecture:** New `shared/queue.WorkerAvailability` service produces a typed `Verdict` from `JobQueue.ListWorkers`, `JobQueue.QueueDepth`, and `JobStore.ListAll`. The Slack adapter (`app/bot/workflow.go`) calls `CheckSoft` in `HandleTrigger` (non-blocking warn) and `CheckHard` at the top of `runTriage` (can reject). A small `app/bot/verdict_message.go` translates `Verdict` into Slack-flavored text — the seam where future mediums plug in their own renderers.
+**Architecture:** New `shared/queue.WorkerAvailability` service produces a typed `Verdict` from `JobQueue.ListWorkers`, `JobQueue.QueueDepth`, and `JobStore.ListAll`. The Slack adapter (`app/bot/workflow.go`, post-dispatcher refactor) calls `CheckSoft` in `HandleTrigger` (non-blocking warn) and `CheckHard` inside a new `submit()` helper that consolidates the three current `executeStep` → `onSubmit` call sites. A small `app/bot/verdict_message.go` translates `Verdict` into Slack-flavored text — the seam where future mediums plug in their own renderers. `workflow.Pending` gains an exported `BusyHint` field so the `submitJob` closure in `app/app.go` can append the ETA hint to the lifecycle status text returned by `BuildJob`.
 
 **Tech Stack:** Go 1.22+ / `slog` / `prometheus/client_golang` / existing `shared/queue` Redis transport / `queuetest` in-memory bundle for unit tests.
 
 **Phases (one commit per task):**
 1. Data model — `WorkerInfo.Slots`
-2. Availability service — TDD growth
+2. Availability service — TDD growth (5 tasks)
 3. Metrics
 4. Verdict rendering
-5. Workflow integration (4 sub-tasks)
+5. Workflow integration (4 tasks: wiring → submit() helper + NoWorkers → BusyHint on busy → soft warn)
 6. Worker side
-7. App wiring + config
+7. App wiring + config (config struct → app.go construction + BusyHint append)
 8. Final verification
 
 ---
@@ -27,11 +27,11 @@
 ### Task 1: Add `Slots` field to `WorkerInfo`
 
 **Files:**
-- Modify: `shared/queue/job.go:116-123`
+- Modify: `shared/queue/job.go` (`WorkerInfo` struct, around line 111)
 
 - [ ] **Step 1: Add the field**
 
-In `shared/queue/job.go`, replace the existing `WorkerInfo` struct (lines 116–123) with:
+In `shared/queue/job.go`, replace the existing `WorkerInfo` struct (the block beginning `type WorkerInfo struct {`) with:
 
 ```go
 type WorkerInfo struct {
@@ -649,12 +649,12 @@ EOF
 ### Task 7: Add availability metrics + register + wire
 
 **Files:**
-- Modify: `shared/metrics/metrics.go:139-194`
+- Modify: `shared/metrics/metrics.go` (`WatchdogKillsTotal` ~line 135, `Register` ~line 165)
 - Modify: `shared/queue/availability.go`
 
 - [ ] **Step 1: Add the three new metrics in `shared/metrics/metrics.go`**
 
-After the existing `WatchdogKillsTotal` declaration (around line 145), insert:
+After the existing `WatchdogKillsTotal` declaration (around line 141), insert:
 
 ```go
 // ---- Availability ----
@@ -1015,110 +1015,142 @@ EOF
 
 ## Phase 5 — Workflow Integration
 
-### Task 9: Inject availability + add busyHint field (no behaviour change yet)
+### Task 9: Add availability wiring + `Pending.BusyHint` (no behaviour yet)
 
 **Files:**
-- Modify: `app/bot/workflow.go:60-115` (Workflow struct + NewWorkflow)
-- Modify: `app/bot/workflow.go:41-58` (pendingTriage struct)
+- Modify: `app/workflow/workflow.go` (`Pending` struct, ~line 30)
+- Modify: `app/bot/workflow.go` (`Workflow` struct ~line 19, `NewWorkflow` ~line 38)
+- Modify: `app/bot/workflow_test.go` (5 existing `NewWorkflow` call sites need a trailing `nil`)
+- Modify: `app/app.go` (`bot.NewWorkflow(...)` call ~line 170 — append `nil` placeholder until Task 15)
 
-- [ ] **Step 1: Add the field, constructor param, and pendingTriage field**
+- [ ] **Step 1: Add `BusyHint` to `workflow.Pending`**
 
-In `app/bot/workflow.go`:
-
-(a) Inside `pendingTriage` (around line 41–58), append:
+In `app/workflow/workflow.go`, append a `BusyHint` field to the `Pending` struct:
 
 ```go
-type pendingTriage struct {
-	// ... existing fields ...
-	RepoWasPicked  bool
-	busyHint       string // populated by hard check when verdict is BusyEnqueueOK
+type Pending struct {
+	ChannelID   string
+	ThreadTS    string
+	TriggerTS   string
+	UserID      string
+	Reporter    string
+	ChannelName string
+	RequestID   string
+	SelectorTS  string // TS of the latest selector/modal message; used as pending-map key
+	Phase       string // workflow-defined phase label
+	TaskType    string // workflow identity, equal to Workflow.Type()
+	State       any    // per-workflow state struct
+	BusyHint    string // populated by bot.Workflow.submit() when verdict is BusyEnqueueOK; app.submitJob appends to statusText
 }
 ```
 
-(b) Inside `Workflow` (around line 60–77), add an `availability` field:
+- [ ] **Step 2: Add `availability` field + extend `NewWorkflow` signature in `app/bot/workflow.go`**
+
+(a) Add the field to the `Workflow` struct (around line 19):
 
 ```go
 type Workflow struct {
-	// ... existing fields ...
-	skillProvider SkillProvider
-	secretKey     []byte
-	identity      Identity
+	cfg           *config.Config
+	dispatcher    *workflow.Dispatcher
+	slack         workflow.SlackPort
+	handler       *slackclient.Handler
+	repoDiscovery *ghclient.RepoDiscovery
+	logger        *slog.Logger
 	availability  queue.WorkerAvailability // NEW
 
 	mu        sync.Mutex
-	pending   map[string]*pendingTriage
+	pending   map[string]*workflow.Pending
 	autoBound map[string]bool
+
+	onSubmit func(ctx context.Context, p *workflow.Pending)
 }
 ```
 
-(c) Update the `NewWorkflow` signature (around line 79–115). Add `availability queue.WorkerAvailability` as the LAST parameter (after `identity Identity`):
+(b) Add `"github.com/Ivantseng123/agentdock/shared/queue"` to the imports if not already present.
+
+(c) Update `NewWorkflow` to accept availability as the LAST parameter:
 
 ```go
 func NewWorkflow(
 	cfg *config.Config,
-	slack slackAPI,
-	repoCache *ghclient.RepoCache,
+	dispatcher *workflow.Dispatcher,
+	slack workflow.SlackPort,
 	repoDiscovery *ghclient.RepoDiscovery,
-	jobQueue queue.JobQueue,
-	jobStore queue.JobStore,
-	attachStore queue.AttachmentStore,
-	resultBus queue.ResultBus,
-	skillProvider SkillProvider,
-	identity Identity,
+	logger *slog.Logger,
 	availability queue.WorkerAvailability, // NEW
 ) *Workflow {
+	return &Workflow{
+		cfg:           cfg,
+		dispatcher:    dispatcher,
+		slack:         slack,
+		repoDiscovery: repoDiscovery,
+		logger:        logger,
+		availability:  availability, // NEW
+		pending:       make(map[string]*workflow.Pending),
+		autoBound:     make(map[string]bool),
+	}
+}
 ```
 
-And inside the function body, add `availability: availability,` to the struct literal.
+- [ ] **Step 3: Update existing `NewWorkflow` call sites in tests**
 
-- [ ] **Step 2: Update the only existing caller (`app/app.go:142`)**
-
-In `app/app.go` line 142, the current call is:
+`app/bot/workflow_test.go` has 5 calls of the form `NewWorkflow(cfg, disp, slack, nil, nil)` (search for `:= NewWorkflow(`). Append a trailing `nil` argument to each so they pass `nil` for the new `availability` parameter:
 
 ```go
-wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity)
+wf := NewWorkflow(cfg, disp, slack, nil, nil, nil)
 ```
 
-Update to pass `nil` for now (Task 15 will replace this with a real instance):
+Also in `app/bot/workflow_test.go:222` the call is `NewWorkflow(cfg, disp, sl, nil, slog.Default())` — becomes `NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)`.
+
+- [ ] **Step 4: Update the production caller in `app/app.go`**
+
+In `app/app.go` around line 170, the current call is:
 
 ```go
-wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity, nil)
+wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger)
 ```
 
-- [ ] **Step 3: Verify the whole tree compiles**
+Append a `nil` (Task 15 replaces this with a real instance):
+
+```go
+wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, nil)
+```
+
+- [ ] **Step 5: Verify the whole tree compiles**
 
 Run: `go build ./...`
 Expected: success.
 
-- [ ] **Step 4: Run all existing tests (regression)**
+- [ ] **Step 6: Run all tests (regression)**
 
 Run: `go test ./...`
-Expected: all PASS. (No existing test calls `HandleTrigger` or `runTriage`, so the nil `availability` is not yet dereferenced. The new tests in Tasks 10–12 will set a stub.)
+Expected: all PASS. The new `availability` field is nil; no existing test touches availability. New tests in Tasks 10–12 will set a stub.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add app/bot/workflow.go app/app.go
+git add app/workflow/workflow.go app/bot/workflow.go app/bot/workflow_test.go app/app.go
 git commit -m "$(cat <<'EOF'
-refactor(bot): inject WorkerAvailability + busyHint field
+refactor(bot+workflow): add availability wiring + Pending.BusyHint
 
-Wiring only — no behaviour change. The hard/soft check call sites
-land in subsequent commits.
+No behaviour change. Workflow constructor gains a nil-allowed
+availability parameter and Pending gains a BusyHint field; the
+hard/soft check call sites land in subsequent commits.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
 
-### Task 10: Submit-time hard check — NoWorkers reject path
+### Task 10: `Workflow.submit()` helper + NoWorkers hard reject
 
 **Files:**
-- Modify: `app/bot/workflow.go:386-396` (top of `runTriage`)
+- Modify: `app/bot/workflow.go` (`executeStep` ~line 277, add new `submit` method)
 - Modify: `app/bot/workflow_test.go` (add `stubAvailability` + new test)
 
 - [ ] **Step 1: Add the `stubAvailability` helper to `workflow_test.go`**
 
-Append to `app/bot/workflow_test.go` (right above `func newTestWorkflow`):
+Append to `app/bot/workflow_test.go` (the end of the existing helper block, e.g. right after `fakeIssueWorkflow`):
 
 ```go
 // stubAvailability lets tests pre-program verdicts.
@@ -1144,302 +1176,262 @@ func (s *stubAvailability) CheckHard(ctx context.Context) queue.Verdict {
 }
 ```
 
-You will also need to add `"context"` to the existing imports if not already present.
+Also add `"sync"` to imports if not already present.
 
 - [ ] **Step 2: Write the failing test**
 
 Append to `app/bot/workflow_test.go`:
 
 ```go
-func TestRunTriage_NoWorkers_HardRejects(t *testing.T) {
-	slack := &stubSlack{}
-	avail := &stubAvailability{
-		HardVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers},
-	}
-	cfg := &config.Config{
-		Channels:        map[string]config.ChannelConfig{"C1": {Repo: "o/r"}},
-		ChannelDefaults: config.ChannelConfig{},
-	}
-	w := newTestWorkflow(t, slack, cfg)
-	w.availability = avail
+func TestSubmit_NoWorkers_HardRejects(t *testing.T) {
+	sl := &shimSlack{}
+	avail := &stubAvailability{HardVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers}}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
 
-	pt := testPending("C1", "T1", true, "")
-	pt.SelectedRepo = "o/r"
-	pt.SelectedBranch = "main"
+	onSubmitCalled := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		onSubmitCalled = true
+	})
 
-	w.runTriage(pt)
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	step := workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+	wf.executeStep(context.Background(), p, step, "")
 
 	if avail.HardCalls != 1 {
 		t.Errorf("HardCalls = %d, want 1", avail.HardCalls)
 	}
+	if onSubmitCalled {
+		t.Error("onSubmit must NOT be called when verdict is NoWorkers")
+	}
 
 	foundReject := false
-	for _, m := range slack.PostMessageCalls {
-		if containsStr(m.Text, ":x:") && containsStr(m.Text, "沒有 worker") {
+	for _, m := range sl.posted {
+		if strings.Contains(m, ":x:") && strings.Contains(m, "沒有 worker") {
 			foundReject = true
 		}
 	}
 	if !foundReject {
-		t.Errorf("expected hard reject :x: message; got posts: %+v", slack.PostMessageCalls)
-	}
-
-	// Verify the lifecycle ":mag:" message was NOT posted (hard reject runs first).
-	for _, m := range slack.PostMessageCalls {
-		if containsStr(m.Text, ":mag:") {
-			t.Errorf("lifecycle :mag: message should NOT appear after hard reject; got %q", m.Text)
-		}
+		t.Errorf("expected :x: hard reject message; got posts: %+v", sl.posted)
 	}
 }
 ```
 
-- [ ] **Step 3: Run — should fail**
+Also add `"strings"` to imports if not already present (and `slog` / `context` / `queue` which are already imported).
 
-Run: `cd app && go test ./bot/ -run TestRunTriage_NoWorkers_HardRejects -v`
-Expected: FAIL — the hard check is not yet wired; the test will see the `:mag:` lifecycle message and no `:x:` reject. (Note: it will likely panic on nil queue at `w.queue.Submit` — the failure is expected one way or another. The point is the green-light test will pass after Step 4.)
+- [ ] **Step 3: Run — should fail (submit helper + reject not implemented)**
 
-- [ ] **Step 4: Implement the hard check**
+Run: `cd app && go test ./bot/ -run TestSubmit_NoWorkers_HardRejects -v`
+Expected: FAIL — either `onSubmit` fires (no gate exists), or compilation fails because `w.submit` is undefined. Either failure mode is acceptable; Step 4 makes it pass.
 
-In `app/bot/workflow.go`, locate `runTriage` (line 386). Right after `ctx := context.Background()` (line 387) and BEFORE the `statusMsgTS, err := w.slack.PostMessageWithTS(...)` line (line 392), insert:
+- [ ] **Step 4: Add `submit()` helper and refactor `executeStep` to use it**
+
+In `app/bot/workflow.go`, add a new method (place it right after `executeStep`):
 
 ```go
-	// Hard availability check — must run before any lifecycle Slack post so
-	// rejections don't leave orphan ":mag:" messages.
+// submit is the single chokepoint for sending a Pending to the queue-submission
+// closure. Consolidates the three former `if w.onSubmit != nil { w.onSubmit(...) }`
+// call sites in executeStep so pre-submit checks (like the worker-availability
+// hard check below) only need to land in one place.
+func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
 	if w.availability != nil {
 		verdict := w.availability.CheckHard(ctx)
 		switch verdict.Kind {
 		case queue.VerdictNoWorkers:
-			w.slack.PostMessage(pt.ChannelID,
-				RenderHardReject(verdict), pt.ThreadTS)
-			w.clearDedup(pt)
+			_ = w.slack.PostMessage(p.ChannelID,
+				RenderHardReject(verdict), p.ThreadTS)
+			if w.handler != nil {
+				w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+			}
 			return
 		case queue.VerdictBusyEnqueueOK:
-			pt.busyHint = RenderBusyHint(verdict)
+			// Task 11 adds p.BusyHint = RenderBusyHint(verdict) here.
 		case queue.VerdictOK:
 			// continue
 		}
 	}
+	if w.onSubmit != nil {
+		w.onSubmit(ctx, p)
+	} else {
+		w.logger.Warn("submit but no onSubmit hook set", "phase", "失敗")
+	}
+}
 ```
 
-The `if w.availability != nil` guard exists only because Task 15 hasn't replaced the `nil` in `app.go` yet — once that's done, the field is always populated.
+Then refactor the three `executeStep` call sites (they are inside the `NextStepOpenModal` case and the `NextStepSubmit` case; search for `w.onSubmit`). Replace each of the three `if w.onSubmit != nil { w.onSubmit(ctx, …) }` blocks with a single call:
+
+Old (three occurrences, varying only in the variable name — `pending` or `p`):
+```go
+if w.onSubmit != nil {
+    w.onSubmit(ctx, pending)
+}
+```
+
+New:
+```go
+w.submit(ctx, pending)
+```
+
+For the `NextStepSubmit` case specifically, also remove the `else { w.logger.Warn("NextStepSubmit but no onSubmit hook set", ...) }` branch — the equivalent warn now lives inside `submit()`. The final case shape becomes:
+
+```go
+case workflow.NextStepSubmit:
+	p := step.Pending
+	if p == nil {
+		p = pending
+	}
+	w.submit(ctx, p)
+```
 
 - [ ] **Step 5: Run — should pass**
 
-Run: `cd app && go test ./bot/ -run TestRunTriage_NoWorkers_HardRejects -v`
+Run: `cd app && go test ./bot/ -run TestSubmit_NoWorkers_HardRejects -v`
 Expected: PASS.
 
-- [ ] **Step 6: Run full bot test package (regression)**
+- [ ] **Step 6: Run full bot tests (regression)**
 
 Run: `cd app && go test ./bot/`
-Expected: all PASS.
+Expected: all PASS. In particular, the existing `TestExecuteStep_Submit_CallsHook` and `TestHandleSelection_DSelector_DispatchesWorkflow` must still pass — they do not set availability, so `submit()` passes straight through to `onSubmit` (the `if w.availability != nil` guard).
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add app/bot/workflow.go app/bot/workflow_test.go
 git commit -m "$(cat <<'EOF'
-feat(bot): runTriage hard-rejects when no workers are online
+feat(bot): add submit() helper, reject when no workers online
 
-Posts the reject message, clears thread dedup so the user can retry,
-and returns before the lifecycle ':mag:' message is sent.
+Collapses three executeStep→onSubmit call sites into a single submit()
+chokepoint, and runs a hard availability check before dispatching.
+NoWorkers verdict posts a reject message and clears thread dedup.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
 
-### Task 11: Submit-time hard check — BusyEnqueueOK appends ETA hint
+### Task 11: `submit()` sets `Pending.BusyHint` on BusyEnqueueOK
 
 **Files:**
-- Modify: `app/bot/workflow.go:537-544` (the statusMsg block)
+- Modify: `app/bot/workflow.go` (the `submit()` method added in Task 10)
 - Modify: `app/bot/workflow_test.go` (new test)
 
-- [ ] **Step 1: Append busyHint to statusMsg in `workflow.go`**
-
-In `app/bot/workflow.go`, locate the block (around lines 537–544):
-
-```go
-	pos, _ := w.queue.QueuePosition(job.ID)
-	var statusMsg string
-	if pos <= 1 {
-		statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
-	} else {
-		statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
-	}
-```
-
-Replace with:
-
-```go
-	pos, _ := w.queue.QueuePosition(job.ID)
-	var statusMsg string
-	if pos <= 1 {
-		statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
-	} else {
-		statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
-	}
-	if pt.busyHint != "" {
-		statusMsg += " " + pt.busyHint
-	}
-```
-
-- [ ] **Step 2: Write the failing test**
+- [ ] **Step 1: Write the failing test**
 
 Append to `app/bot/workflow_test.go`:
 
 ```go
-func TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA(t *testing.T) {
-	slack := &stubSlack{}
+func TestSubmit_BusyEnqueueOK_SetsBusyHint(t *testing.T) {
+	sl := &shimSlack{}
 	avail := &stubAvailability{
 		HardVerdict: queue.Verdict{
 			Kind:          queue.VerdictBusyEnqueueOK,
 			EstimatedWait: 6 * time.Minute,
 		},
 	}
-	cfg := &config.Config{
-		Channels:        map[string]config.ChannelConfig{"C1": {Repo: "o/r"}},
-		ChannelDefaults: config.ChannelConfig{},
-	}
-	w := newTestWorkflow(t, slack, cfg)
-	w.availability = avail
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
 
-	// runTriage requires a working queue + store + attachments + results.
-	store := queue.NewMemJobStore()
-	bundle := queuetest.NewBundle(50, 1, store)
-	w.queue = bundle.Queue
-	w.store = store
-	w.attachments = bundle.Attachments
-	w.results = bundle.Results
+	var gotPending *workflow.Pending
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		gotPending = p
+	})
 
-	pt := testPending("C1", "T1", true, "")
-	pt.SelectedRepo = "o/r"
-	pt.SelectedBranch = "main"
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	step := workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+	wf.executeStep(context.Background(), p, step, "")
 
-	// FetchThreadContext stub returns nil messages — runTriage handles this by
-	// notifying error and returning. To exercise the ETA path we need at least
-	// one message. Inject one via a custom stub return.
-	slack.FetchThreadResult = []slackclient.ThreadRawMessage{
-		{User: "U1", Timestamp: "T1", Text: "help me"},
+	if gotPending == nil {
+		t.Fatal("onSubmit was not called; expected BusyEnqueueOK to pass through")
 	}
-
-	w.runTriage(pt)
-
-	// Find the lifecycle status message (post-submit). It should contain the ETA hint.
-	foundETA := false
-	for _, u := range slack.UpdateMessageCalls {
-		if containsStr(u.Text, ":hourglass") && containsStr(u.Text, "預估等候") {
-			foundETA = true
-		}
+	if gotPending.BusyHint == "" {
+		t.Errorf("BusyHint should be set; got empty")
 	}
-	for _, m := range slack.PostMessageCalls {
-		if containsStr(m.Text, ":hourglass") && containsStr(m.Text, "預估等候") {
-			foundETA = true
-		}
-	}
-	for _, b := range slack.PostMessageWithButtonCalls {
-		if containsStr(b.Text, ":hourglass") && containsStr(b.Text, "預估等候") {
-			foundETA = true
-		}
-	}
-	if !foundETA {
-		t.Errorf("expected lifecycle message containing 預估等候; got updates=%+v posts=%+v buttons=%+v",
-			slack.UpdateMessageCalls, slack.PostMessageCalls, slack.PostMessageWithButtonCalls)
+	if !strings.Contains(gotPending.BusyHint, "預估等候") {
+		t.Errorf("BusyHint should contain 預估等候; got %q", gotPending.BusyHint)
 	}
 }
 ```
 
-You will also need to:
-- Add `"time"` import to `workflow_test.go` if not present.
-- Add `"github.com/Ivantseng123/agentdock/shared/queue/queuetest"` import.
-- Extend `stubSlack` with a `FetchThreadResult []slackclient.ThreadRawMessage` field (and update `FetchThreadContext` to return it):
+Add `"time"` import to workflow_test.go if not already present.
+
+- [ ] **Step 2: Run — should fail**
+
+Run: `cd app && go test ./bot/ -run TestSubmit_BusyEnqueueOK_SetsBusyHint -v`
+Expected: FAIL — BusyHint is never set (Task 10 stubbed the branch with a TODO comment).
+
+- [ ] **Step 3: Implement BusyHint assignment**
+
+In `app/bot/workflow.go`, locate the `submit()` method added in Task 10. Replace the `case queue.VerdictBusyEnqueueOK` body (currently just a comment) with:
 
 ```go
-type stubSlack struct {
-	mu sync.Mutex
-	// ... existing fields ...
-	FetchThreadResult []slackclient.ThreadRawMessage
-}
-
-func (s *stubSlack) FetchThreadContext(channelID, threadTS, triggerTS, botUserID, botID string, limit int) ([]slackclient.ThreadRawMessage, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.FetchThreadResult, nil
-}
+		case queue.VerdictBusyEnqueueOK:
+			p.BusyHint = RenderBusyHint(verdict)
 ```
 
-(Replace the existing `FetchThreadContext` method that always returns `nil, nil`.)
+- [ ] **Step 4: Run — should pass**
 
-- [ ] **Step 3: Run — should pass**
-
-Run: `cd app && go test ./bot/ -run TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA -v`
+Run: `cd app && go test ./bot/ -run TestSubmit_BusyEnqueueOK -v`
 Expected: PASS.
 
-- [ ] **Step 4: Run full bot tests (regression)**
+- [ ] **Step 5: Run full bot tests (regression)**
 
 Run: `cd app && go test ./bot/`
 Expected: all PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add app/bot/workflow.go app/bot/workflow_test.go
 git commit -m "$(cat <<'EOF'
-feat(bot): runTriage appends ETA hint when verdict is BusyEnqueueOK
+feat(bot): submit() sets Pending.BusyHint on BusyEnqueueOK
 
-Lifecycle message becomes ':hourglass: 已加入排隊，前面有 N 個請求 (預估等候 ~Xm)'.
+app.submitJob reads the hint and appends it to the lifecycle status
+text (wired in Task 15).
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
 
-### Task 12: Trigger-time soft warn
+### Task 12: Trigger-time soft warn in `HandleTrigger`
 
 **Files:**
-- Modify: `app/bot/workflow.go:141-208` (`HandleTrigger`)
+- Modify: `app/bot/workflow.go` (`HandleTrigger` ~line 83)
 - Modify: `app/bot/workflow_test.go` (new test)
 
-- [ ] **Step 1: Insert the soft check in `HandleTrigger`**
-
-In `app/bot/workflow.go`, locate `HandleTrigger`. After the channel-guard block (around line 156, right after `channelCfg = w.cfg.ChannelDefaults` for the auto-bind branch — i.e., after the `if !ok { ... }` block ends) and BEFORE `reqID := logging.NewRequestID()`, insert:
-
-```go
-	// Soft availability check — informational only; do NOT block the flow.
-	// Hard check at submit time decides whether to proceed.
-	if w.availability != nil {
-		verdict := w.availability.CheckSoft(context.Background())
-		if verdict.Kind == queue.VerdictNoWorkers {
-			w.slack.PostMessage(event.ChannelID,
-				RenderSoftWarn(verdict), event.ThreadTS)
-		}
-	}
-```
-
-You will need to import `"context"` if not already imported (it is, per existing `runTriage` body).
-
-- [ ] **Step 2: Write the failing test**
+- [ ] **Step 1: Write the failing test**
 
 Append to `app/bot/workflow_test.go`:
 
 ```go
 func TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues(t *testing.T) {
-	slack := &stubSlack{}
-	avail := &stubAvailability{
-		SoftVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers},
-	}
+	sl := &shimSlack{}
+	avail := &stubAvailability{SoftVerdict: queue.Verdict{Kind: queue.VerdictNoWorkers}}
 	cfg := &config.Config{
-		Channels: map[string]config.ChannelConfig{
-			"C1": {Repos: []string{"o/a", "o/b"}},
-		},
+		Channels: map[string]config.ChannelConfig{"C1": {}},
 	}
-	w := newTestWorkflow(t, slack, cfg)
-	w.availability = avail
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
 
-	w.HandleTrigger(slackclient.TriggerEvent{
+	onSubmitCalled := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		onSubmitCalled = true
+	})
+
+	wf.HandleTrigger(slackclient.TriggerEvent{
 		ChannelID: "C1",
 		ThreadTS:  "T1",
 		TriggerTS: "T1",
 		UserID:    "U1",
-		Text:      "<@bot>",
+		Text:      "issue foo/bar",
 	})
 
 	if avail.SoftCalls != 1 {
@@ -1447,64 +1439,91 @@ func TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues(t *testing.T) {
 	}
 
 	foundWarn := false
-	for _, m := range slack.PostMessageCalls {
-		if containsStr(m.Text, ":warning:") && containsStr(m.Text, "沒有 worker") {
+	for _, m := range sl.posted {
+		if strings.Contains(m, ":warning:") && strings.Contains(m, "沒有 worker") {
 			foundWarn = true
 		}
 	}
 	if !foundWarn {
-		t.Errorf("expected :warning: soft warn; got posts: %+v", slack.PostMessageCalls)
+		t.Errorf("expected :warning: soft warn; got posts: %+v", sl.posted)
 	}
 
-	// Selector must still be posted — soft warn does NOT short-circuit.
-	if len(slack.PostSelectorCalls) != 1 {
-		t.Errorf("expected 1 PostSelector call (flow continues); got %d", len(slack.PostSelectorCalls))
+	// fakeIssueWorkflow.Trigger returns NextStepSubmit → hard check runs.
+	// With nil hard verdict (zero value), submit() treats it as OK branch? No —
+	// zero-value Kind "" is none of the switch cases, so submit falls through
+	// to onSubmit. Thus soft warn must NOT short-circuit dispatch.
+	if !onSubmitCalled {
+		t.Error("soft warn must not block dispatch; expected onSubmit to still be called")
 	}
 }
 
 func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
-	slack := &stubSlack{}
-	avail := &stubAvailability{
-		SoftVerdict: queue.Verdict{Kind: queue.VerdictOK},
-	}
+	sl := &shimSlack{}
+	avail := &stubAvailability{SoftVerdict: queue.Verdict{Kind: queue.VerdictOK}}
 	cfg := &config.Config{
-		Channels: map[string]config.ChannelConfig{
-			"C1": {Repos: []string{"o/a", "o/b"}},
-		},
+		Channels: map[string]config.ChannelConfig{"C1": {}},
 	}
-	w := newTestWorkflow(t, slack, cfg)
-	w.availability = avail
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), avail)
 
-	w.HandleTrigger(slackclient.TriggerEvent{
-		ChannelID: "C1", ThreadTS: "T1", TriggerTS: "T1", UserID: "U1", Text: "<@bot>",
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {})
+
+	wf.HandleTrigger(slackclient.TriggerEvent{
+		ChannelID: "C1", ThreadTS: "T1", TriggerTS: "T1", UserID: "U1", Text: "issue foo/bar",
 	})
 
-	for _, m := range slack.PostMessageCalls {
-		if containsStr(m.Text, "沒有 worker") {
-			t.Errorf("OK verdict should not post soft warn; got %q", m.Text)
+	for _, m := range sl.posted {
+		if strings.Contains(m, "沒有 worker") {
+			t.Errorf("OK verdict should not post soft warn; got %q", m)
 		}
 	}
 }
 ```
 
-- [ ] **Step 3: Run — should pass**
+Note about the `TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues` test: the fake issue workflow returns `NextStepSubmit` directly, so the flow reaches `submit()`. With the stub's **hard** verdict zero-valued (default `VerdictKind("")`), the `switch` falls through to `onSubmit`. That's the assertion that soft warn doesn't short-circuit. If future refactoring makes zero-value verdicts reject, this test's hard verdict needs to be explicitly set to `VerdictOK`.
+
+- [ ] **Step 2: Run — should fail**
+
+Run: `cd app && go test ./bot/ -run TestHandleTrigger_NoWorkers_PostsSoftWarn -v`
+Expected: FAIL — `avail.SoftCalls` stays at 0 because `HandleTrigger` doesn't call `CheckSoft` yet.
+
+- [ ] **Step 3: Insert the soft check in `HandleTrigger`**
+
+In `app/bot/workflow.go`, locate `HandleTrigger` (~line 83). After the channel-binding check (the `if _, ok := w.cfg.Channels[...]` block ending with the `}`), and BEFORE `ctx := context.Background()` that precedes `dispatcher.Dispatch`, insert:
+
+```go
+	// Soft availability check — informational only; do NOT block dispatch.
+	// The hard check inside submit() gates actual queue submission.
+	if w.availability != nil {
+		verdict := w.availability.CheckSoft(context.Background())
+		if verdict.Kind == queue.VerdictNoWorkers {
+			_ = w.slack.PostMessage(event.ChannelID,
+				RenderSoftWarn(verdict), event.ThreadTS)
+		}
+	}
+```
+
+- [ ] **Step 4: Run — should pass**
 
 Run: `cd app && go test ./bot/ -run TestHandleTrigger -v`
-Expected: PASS for both new tests, plus the existing `HandleTrigger` tests if any. (The existing tests don't call `HandleTrigger` directly — verify no regressions.)
+Expected: PASS for the new tests AND the existing `TestHandleTrigger_NoThread_PostsWarning` / `TestHandleTrigger_UnboundChannel_Silent`.
 
-- [ ] **Step 4: Run full bot tests (regression)**
+- [ ] **Step 5: Run full bot tests (regression)**
 
 Run: `cd app && go test ./bot/`
 Expected: all PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add app/bot/workflow.go app/bot/workflow_test.go
 git commit -m "$(cat <<'EOF'
 feat(bot): HandleTrigger posts soft warn when no workers (non-blocking)
 
-Selection still proceeds; the hard check at submit is the gate.
+Dispatch still proceeds; the hard check inside submit() gates the
+actual queue submission.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -1518,14 +1537,13 @@ EOF
 ### Task 13: Worker registers with `Slots: 1`
 
 **Files:**
-- Modify: `worker/pool/pool.go:242-248`
-- Modify: `worker/pool/pool.go:260-266`
+- Modify: `worker/pool/pool.go` (`workerHeartbeat`, around line 241)
 
 - [ ] **Step 1: Update both call sites in `workerHeartbeat`**
 
-In `worker/pool/pool.go`, the function `workerHeartbeat` (around line 239) builds `WorkerInfo` in two places. Add `Slots: 1,` to both:
+In `worker/pool/pool.go`, the function `workerHeartbeat` (around line 241) builds `WorkerInfo` in two places. Add `Slots: 1,` to both:
 
-(a) Initial registration (around line 242–247):
+(a) Initial registration (around line 244):
 
 ```go
 	for i := 0; i < p.cfg.WorkerCount; i++ {
@@ -1540,7 +1558,7 @@ In `worker/pool/pool.go`, the function `workerHeartbeat` (around line 239) build
 	}
 ```
 
-(b) Ticker re-registration (around line 260–265):
+(b) Ticker re-registration (around line 262):
 
 ```go
 			for i := 0; i < p.cfg.WorkerCount; i++ {
@@ -1639,14 +1657,14 @@ EOF
 )"
 ```
 
-### Task 15: Wire availability into `app/app.go`
+### Task 15: Wire availability into `app/app.go` + append BusyHint in `submitJob`
 
 **Files:**
-- Modify: `app/app.go:135-184` (around coordinator construction and `metrics.Register`)
+- Modify: `app/app.go` (construct availability before `bot.NewWorkflow` ~line 170; append `BusyHint` in `submitJob` closure after `BuildJob` ~line 196)
 
 - [ ] **Step 1: Construct availability and pass to `NewWorkflow`**
 
-In `app/app.go`, immediately after the `coordinator` is constructed and `RegisterQueue` is called (around line 140), but before the `wf := bot.NewWorkflow(...)` call (line 142), insert:
+In `app/app.go`, immediately after `dispatcher := workflow.NewDispatcher(reg, slackPort, appLogger)` (around line 168) and BEFORE `wf := bot.NewWorkflow(...)` (around line 170), insert:
 
 ```go
 	availability := queue.NewWorkerAvailability(coordinator, jobStore, queue.AvailabilityConfig{
@@ -1662,31 +1680,74 @@ In `app/app.go`, immediately after the `coordinator` is constructed and `Registe
 	)
 ```
 
-Then update the `NewWorkflow` call (line 142) — replace the trailing `nil` (added in Task 9) with `availability`:
+Then update the `NewWorkflow` call (around line 170) — replace the trailing `nil` (added in Task 9) with `availability`:
 
 ```go
-	wf := bot.NewWorkflow(cfg, slackClient, repoCache, repoDiscovery, coordinator, jobStore, bundle.Attachments, bundle.Results, skillLoader, identity, availability)
+	wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, availability)
 ```
 
-- [ ] **Step 2: Verify the whole tree compiles**
+- [ ] **Step 2: Append `BusyHint` to `statusText` in `submitJob`**
+
+In `app/app.go`, locate the `submitJob` closure. Find the block (around line 196):
+
+```go
+		job, statusText, err := wfImpl.BuildJob(ctx, p)
+		if err != nil {
+			appLogger.Error("BuildJob failed", "phase", "失敗", "error", err)
+			_ = slackPort.PostMessage(p.ChannelID, fmt.Sprintf(":x: %v", err), p.ThreadTS)
+			if handler != nil {
+				handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+			}
+			return
+		}
+
+		// Post lifecycle status message.
+		statusMsgTS, postErr := slackPort.PostMessageWithTS(p.ChannelID, statusText, p.ThreadTS)
+```
+
+Insert the append right after the error-return block and before `statusMsgTS` is posted:
+
+```go
+		job, statusText, err := wfImpl.BuildJob(ctx, p)
+		if err != nil {
+			appLogger.Error("BuildJob failed", "phase", "失敗", "error", err)
+			_ = slackPort.PostMessage(p.ChannelID, fmt.Sprintf(":x: %v", err), p.ThreadTS)
+			if handler != nil {
+				handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+			}
+			return
+		}
+
+		// Append worker-availability busy hint if the pre-submit check set one.
+		if p.BusyHint != "" {
+			statusText += " " + p.BusyHint
+		}
+
+		// Post lifecycle status message.
+		statusMsgTS, postErr := slackPort.PostMessageWithTS(p.ChannelID, statusText, p.ThreadTS)
+```
+
+- [ ] **Step 3: Verify the whole tree compiles**
 
 Run: `go build ./...`
 Expected: success.
 
-- [ ] **Step 3: Run all tests (regression)**
+- [ ] **Step 4: Run all tests (regression)**
 
 Run: `go test ./...`
 Expected: all PASS.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add app/app.go
 git commit -m "$(cat <<'EOF'
-feat(app): construct WorkerAvailability and inject into Workflow
+feat(app): construct WorkerAvailability + append BusyHint in submitJob
 
-Wires the verdict + dep-error hooks into Prometheus. Behaviour is
-now end-to-end: trigger soft warn + submit hard check both active.
+Wires verdict/dep-error hooks into Prometheus and injects availability
+into bot.Workflow. In submitJob, reads Pending.BusyHint (set by the
+shim's submit() helper) and appends it to the lifecycle status text
+before posting. Two-stage precheck is now end-to-end active.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -1754,19 +1815,21 @@ Cross-referenced against `docs/superpowers/specs/2026-04-22-worker-liveness-prec
 | §2 Availability Service — types, interface, compute | Tasks 2–4 |
 | §2 Slots normalisation | Task 5 (locked by test) |
 | §2 Fail-open | Task 6 |
-| §3.1 NewWorkflow constructor change | Task 9 |
-| §3.2 Trigger-time soft warn | Task 12 |
-| §3.3 Submit-time hard check (NoWorkers) | Task 10 |
-| §3.3 Submit-time hard check (BusyEnqueueOK + ETA in lifecycle) | Task 11 |
-| §3 `pendingTriage.busyHint` field | Task 9 |
+| §3.1 Workflow struct + NewWorkflow constructor change | Task 9 |
+| §3.1 `workflow.Pending.BusyHint` field | Task 9 |
+| §3.2 Trigger-time soft warn in HandleTrigger | Task 12 |
+| §3.3 `submit()` helper + NoWorkers hard reject | Task 10 |
+| §3.3 BusyEnqueueOK sets `Pending.BusyHint` | Task 11 |
+| §3.3 `submitJob` appends BusyHint to statusText | Task 15 |
 | §4 Verdict rendering | Task 8 |
 | §5 Wiring + config | Tasks 14, 15 |
 | §6 Worker Slots: 1 | Task 13 |
 | §7 Metrics (verdict, duration, dep errors) | Tasks 7, 15 |
 | §8 Error Handling Summary | Tasks 6 (deps), 10 (Slack reject), 12 (Slack warn) |
-| §9 Ordering Constraints — soft AFTER channel-guard | Task 12 (insertion location specified) |
-| §9 Ordering — hard BEFORE first lifecycle post | Task 10 (insertion at line 387–392 boundary) |
-| §9 Ordering — hard reject calls clearDedup | Task 10 (assertion implicit; impl explicit) |
+| §9 Ordering — soft AFTER channel-guard | Task 12 (insertion location specified) |
+| §9 Ordering — hard check BEFORE onSubmit | Task 10 (enforced by `submit()` helper) |
+| §9 Ordering — hard reject calls ClearThreadDedup | Task 10 (impl explicit; test asserts onSubmit not called) |
+| §9 Ordering — BusyHint append after BuildJob, before PostMessageWithTS | Task 15 |
 | Testing — unit matrix (9 cases) | Tasks 2–6 cover all 9 rows |
 | Testing — 3 integration cases | Tasks 10, 11, 12 |
 | Migration / Rollout | Additive changes in Tasks 1, 14 (omitempty + optional config) |

--- a/docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md
+++ b/docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md
@@ -1,0 +1,321 @@
+# Worker Liveness Precheck (Trigger-time Warn + Submit-time Reject)
+
+**Date:** 2026-04-22
+**Status:** Draft
+
+## Problem
+
+When a Slack user `@bot`-triggers a triage, `app/bot/workflow.go` immediately posts `:mag: 正在排入處理佇列...` and proceeds through repo/branch/description selection, then enqueues the job. The bot **never checks whether any worker is online**.
+
+Failure mode: with zero registered workers (or worker pool fully busy with a saturated queue), the job sits in the Redis stream until `shared/queue/watchdog.go` kills it after `JobTimeout`. The user sees only `:hourglass_flowing_sand: 正在處理你的請求...` and waits — with no signal that nothing will happen and no clue what to do next.
+
+The `shared/queue` package already has the primitives needed:
+
+- `JobQueue.ListWorkers(ctx)` returns 30s-TTL worker registrations (`shared/queue/redis_jobqueue.go:202`).
+- `JobQueue.QueueDepth()` returns Redis stream length.
+- `JobStore.ListAll()` enumerates job states.
+
+No code calls these to gate the trigger flow. This spec wires them in.
+
+This spec also addresses a forward-compatibility constraint: the bot is expected to grow new mediums beyond Slack (X, Discord, etc.). The precheck logic must be reusable across mediums without each medium re-implementing the rule.
+
+## Goals
+
+1. When a user triggers triage and **no workers** are online:
+   - Post a soft warning in the thread at trigger time (do not block selection).
+   - Hard-reject at submit time before any queue interaction; clear thread dedup so the user can retry.
+2. When workers exist but **capacity is saturated** (queued + running ≥ total slots):
+   - Allow enqueue; surface an estimated wait alongside the existing `:hourglass:` lifecycle message.
+3. Precheck rule lives in `shared/queue/`, agnostic of medium. Each medium translates the verdict into its own user-visible message.
+4. Precheck failure of dependencies (Redis SCAN/XLEN) is fail-open: log and treat as `OK` — never let availability checks themselves break triage.
+5. Worker capacity is modelled with a per-worker `Slots` field (default 1) so that future concurrent workers do not require a schema change.
+
+## Non-Goals
+
+- Auto-notifying oncall when workers are absent (deferred; messaging extension point preserved).
+- Historical sliding-window ETA averaging — a static `AvgJobDuration` constant is used.
+- Caching verdicts (deferred; soft check is currently uncached).
+- Implementing a second medium adapter. Only the abstraction shape is laid down.
+- Changing how workers register or how their TTL is renewed.
+- Distinguishing per-agent capability (e.g. "no `claude` worker"). Treats all workers as fungible.
+
+## Design
+
+### 1. Data Model
+
+**`shared/queue/job.go`** — extend `WorkerInfo` with a `Slots` field:
+
+```go
+type WorkerInfo struct {
+    WorkerID    string   `json:"worker_id"`
+    Name        string   `json:"name"`
+    Nickname    string   `json:"nickname,omitempty"`
+    Agents      []string `json:"agents"`
+    Tags        []string `json:"tags"`
+    Slots       int      `json:"slots,omitempty"` // NEW — concurrent jobs this worker can handle; 0 normalised to 1
+    ConnectedAt time.Time
+}
+```
+
+Backward compatible: existing workers omitting the field deserialise to `Slots: 0`, normalised to `1` at consumption time. Worker code populates `Slots` from its config (initially always `1` for today's single-job-per-worker pool).
+
+### 2. Availability Service
+
+New file **`shared/queue/availability.go`**:
+
+```go
+type VerdictKind string
+
+const (
+    VerdictOK            VerdictKind = "ok"            // healthy
+    VerdictBusyEnqueueOK VerdictKind = "busy_enqueue"  // workers exist but saturated
+    VerdictNoWorkers     VerdictKind = "no_workers"    // no online workers
+)
+
+type Verdict struct {
+    Kind          VerdictKind
+    WorkerCount   int
+    ActiveJobs    int           // QueueDepth + count of preparing/running JobStates
+    TotalSlots    int           // Σ max(WorkerInfo.Slots, 1)
+    EstimatedWait time.Duration // populated only for VerdictBusyEnqueueOK
+}
+
+type WorkerAvailability interface {
+    CheckSoft(ctx context.Context) Verdict
+    CheckHard(ctx context.Context) Verdict
+}
+
+type AvailabilityConfig struct {
+    AvgJobDuration time.Duration // used for ETA; default 3m if zero
+}
+```
+
+`CheckSoft` and `CheckHard` currently delegate to a private `compute(ctx)` returning the same `Verdict`. They are intentionally separate methods so that future tweaks (e.g. caching `CheckSoft`) need not touch `CheckHard`.
+
+**Computation:**
+
+```
+depErr := false
+
+workers, err := ListWorkers()
+if err != nil { log.Warn(...); depErr = true; workers = nil }
+
+states, err := ListAll()
+if err != nil { log.Warn(...); depErr = true; states = nil }
+
+depth, err := QueueDepth()
+if err != nil { log.Warn(...); depErr = true; depth = 0 }
+
+// Fail-open: any dependency error → return OK rather than mis-classify.
+// Treat partial blindness as healthy; the existing watchdog still backstops.
+if depErr {
+    return {Kind: OK, ...}
+}
+
+totalSlots := Σ normaliseSlots(w.Slots) for w in workers   // 0 → 1
+activeJobs := depth + |{s : s.Status ∈ {preparing, running}}|
+
+if len(workers) == 0:
+    return {Kind: NoWorkers, ...}
+if activeJobs >= totalSlots:
+    overflow := activeJobs - totalSlots + 1
+    return {Kind: BusyEnqueueOK, EstimatedWait: overflow * AvgJobDuration, ...}
+return {Kind: OK, ...}
+```
+
+The fail-open early-return is the single source of truth for dependency-error behaviour. `WorkerAvailabilityCheckErrors` is incremented per failing dependency before returning.
+
+### 3. Slack Adapter Integration
+
+**`app/bot/workflow.go`** changes:
+
+1. Inject availability via constructor:
+
+```go
+func NewWorkflow(
+    cfg *config.Config,
+    slack slackAPI,
+    repoCache *ghclient.RepoCache,
+    repoDiscovery *ghclient.RepoDiscovery,
+    jobQueue queue.JobQueue,
+    jobStore queue.JobStore,
+    attachStore queue.AttachmentStore,
+    resultBus queue.ResultBus,
+    skillProvider SkillProvider,
+    identity Identity,
+    availability queue.WorkerAvailability, // NEW
+) *Workflow
+```
+
+2. **Trigger-time soft warn** in `HandleTrigger`, after the channel-guard block but before `repo` selection. `HandleTrigger` does not currently take a `context.Context`; use `context.Background()` to keep this spec's scope tight:
+
+```go
+verdict := w.availability.CheckSoft(context.Background())
+if verdict.Kind == queue.VerdictNoWorkers {
+    w.slack.PostMessage(event.ChannelID,
+        RenderSoftWarn(verdict), event.ThreadTS)
+    // Do NOT return — selection still proceeds; hard check will gate submit.
+}
+```
+
+3. **Submit-time hard check** in `runTriage`, immediately after the existing `ctx := context.Background()` (line 387) and **before** the `:mag: 正在排入處理佇列...` post (line 392):
+
+```go
+verdict := w.availability.CheckHard(ctx)
+switch verdict.Kind {
+case queue.VerdictNoWorkers:
+    w.slack.PostMessage(pt.ChannelID,
+        RenderHardReject(verdict), pt.ThreadTS)
+    w.clearDedup(pt)
+    return
+case queue.VerdictBusyEnqueueOK:
+    pt.busyHint = RenderBusyHint(verdict) // attached to lifecycle message
+case queue.VerdictOK:
+    // continue
+}
+```
+
+`pendingTriage` gains an unexported `busyHint string` field. The existing block that builds the post-submit `statusMsg` (`workflow.go:537–544`) is amended:
+
+```go
+if pos <= 1 {
+    statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
+} else {
+    statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
+}
+if pt.busyHint != "" {
+    statusMsg += " " + pt.busyHint
+}
+```
+
+### 4. Verdict Rendering
+
+New file **`app/bot/verdict_message.go`**:
+
+```go
+func RenderSoftWarn(v queue.Verdict) string {
+    return ":warning: 目前沒有 worker 在線，你仍可繼續選擇，送出時會再確認一次。"
+}
+
+func RenderHardReject(v queue.Verdict) string {
+    return ":x: 目前沒有 worker 在線，無法處理。請稍後再試。"
+}
+
+func RenderBusyHint(v queue.Verdict) string {
+    if v.EstimatedWait <= 0 {
+        return ""
+    }
+    return fmt.Sprintf("(預估等候 ~%dm)",
+        int(v.EstimatedWait.Round(time.Minute).Minutes()))
+}
+```
+
+This file is the single point of change when (a) oncall handles need to be appended to reject messages or (b) verdict text needs to be localised. The `Verdict` struct is the contract; future medium adapters write their own renderers without touching `shared/queue/availability.go`.
+
+### 5. Wiring
+
+**`app/app.go`** — construct availability after `coordinator` and `jobStore` exist (currently around `metrics.Register` at line 184), then pass into `NewWorkflow`:
+
+```go
+availability := queue.NewWorkerAvailability(coordinator, jobStore, queue.AvailabilityConfig{
+    AvgJobDuration: cfg.Availability.AvgJobDuration,
+})
+workflow := bot.NewWorkflow(..., availability)
+```
+
+**`app/config/`** — add an `Availability` block to `app.yaml` schema:
+
+```yaml
+availability:
+  avg_job_duration: 3m
+```
+
+Field is optional; absent → service default of `3 * time.Minute`.
+
+### 6. Worker-side Change
+
+**`worker/worker.go`** — when calling `JobQueue.Register`, populate `Slots`:
+
+```go
+info := queue.WorkerInfo{
+    WorkerID: ...,
+    Slots:    1, // hardcoded today; future: read from worker.yaml
+    ...
+}
+```
+
+No `worker.yaml` schema change in this spec — the field is hardcoded to keep scope tight. A follow-up can introduce `worker.slots` config when concurrent execution is implemented.
+
+### 7. Metrics
+
+Add to **`shared/metrics/`**:
+
+```go
+WorkerAvailabilityVerdictTotal *prometheus.CounterVec  // labels: kind, stage
+WorkerAvailabilityCheckDuration prometheus.Histogram
+WorkerAvailabilityCheckErrors *prometheus.CounterVec   // labels: dependency
+```
+
+Increment at the end of every `compute()` call. Sufficient to answer: how often does each verdict fire, how long does the check take, how often does each dependency fail.
+
+### 8. Error Handling Summary
+
+| Failure | Behaviour |
+|---|---|
+| `coordinator.ListWorkers` errors | Logged warn; verdict forced to `OK` (fail-open) |
+| `jobStore.ListAll` errors | Logged warn; verdict forced to `OK` |
+| `jobQueue.QueueDepth` errors | Logged warn; verdict forced to `OK` |
+| Slack `PostMessage` (soft warn) fails | Logged warn; flow continues; hard check still runs |
+| Slack `PostMessage` (hard reject) fails | Logged error; **flow still terminates** (do not enqueue) |
+| Panic inside `compute()` | `recover` returns zero-value verdict (`OK`); logged error |
+
+Explicitly **not** doing: retry, circuit breaker, verdict caching. All YAGNI for current load.
+
+### 9. Ordering Constraints
+
+- Soft check runs **after** `channel-guard` (`autoBound` / `AutoBind`) — never broadcast worker status to channels the bot is not bound to.
+- Soft check runs **after** `event.ThreadTS == ""` guard — outside-thread triggers get the existing usage hint, not a worker status.
+- Hard check runs **before** the first lifecycle `PostMessage` in `runTriage` — never leave a `":mag:"` orphan when rejecting.
+- Hard reject **must** call `clearDedup(pt)` — otherwise the user's retry within `DedupTTL` (5m default) is silently swallowed.
+
+## Testing
+
+### Unit — `shared/queue/availability_test.go`
+
+Drive `WorkerAvailability` against the in-memory `queuetest` bundle:
+
+| # | Workers (slots) | Active jobs | Expected verdict |
+|---|---|---|---|
+| 1 | 2 (1, 1) | 1 | `OK` |
+| 2 | 2 (1, 1) | 2 | `BusyEnqueueOK`, ETA = 1 × AvgJobDuration |
+| 3 | 2 (1, 1) | 5 | `BusyEnqueueOK`, ETA = 4 × AvgJobDuration |
+| 4 | 0 | 0 | `NoWorkers` |
+| 5 | 1 (3) | 2 | `OK` (sums to 3 slots) |
+| 6 | 1 (0) | 0 | `OK` (normalised to 1) |
+| 7 | `ListWorkers` errors | n/a | `OK` (fail-open) |
+| 8 | `ListAll` errors | n/a | `OK` (fail-open) |
+| 9 | `QueueDepth` errors | n/a | `OK` (fail-open) |
+
+### Integration — `app/bot/workflow_test.go`
+
+Add three cases using the existing `slackAPI` stub and a stub `WorkerAvailability`:
+
+- `TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues` — assert: soft warn message posted; repo selector still appears.
+- `TestRunTriage_NoWorkers_HardRejects` — assert: hard reject message posted; no `queue.Submit`; no lifecycle message; `clearDedup` invoked.
+- `TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA` — assert: `queue.Submit` called; lifecycle message contains `預估等候`.
+
+### Out of Scope
+
+- End-to-end Slack live tests (mocked stubs cover the surface).
+- Multi-app race tests for verdict consistency (Redis is the central source of truth — covered by existing `redis_jobqueue_test.go`).
+- Worker register/expire timing tests (already covered by `redis_jobqueue_test.go`).
+
+## Migration / Rollout
+
+1. Code change is additive: `WorkerInfo.Slots` is omit-empty JSON; old workers continue to register without it.
+2. Existing workflows run unchanged when verdict is `OK` (the only path observable today on a healthy deployment).
+3. No config migration required — `availability.avg_job_duration` is optional.
+
+## Open Questions
+
+None. All design decisions confirmed during brainstorming on 2026-04-22.

--- a/docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md
+++ b/docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md
@@ -125,68 +125,110 @@ return {Kind: OK, ...}
 
 The fail-open early-return is the single source of truth for dependency-error behaviour. `WorkerAvailabilityCheckErrors` is incremented per failing dependency before returning.
 
-### 3. Slack Adapter Integration
+### 3. Slack Adapter Integration (dispatcher architecture)
+
+The bot has a thin Slack-side shim (`app/bot/workflow.go`) that delegates real logic to a `workflow.Dispatcher` and one of three workflows (`issue`, `ask`, `pr_review`) via the `app/workflow` package. Each workflow returns a `NextStep` of various kinds; `executeStep` (in the shim) calls a closure `onSubmit` (set by `app/app.go` via `SetSubmitHook`) when the workflow returns `NextStepSubmit` (or fallback paths in `NextStepOpenModal`). Today three call sites in `executeStep` reach `onSubmit`.
 
 **`app/bot/workflow.go`** changes:
 
-1. Inject availability via constructor:
+1. Add `availability` field + extend constructor:
 
 ```go
+type Workflow struct {
+    cfg           *config.Config
+    dispatcher    *workflow.Dispatcher
+    slack         workflow.SlackPort
+    handler       *slackclient.Handler
+    repoDiscovery *ghclient.RepoDiscovery
+    logger        *slog.Logger
+    availability  queue.WorkerAvailability // NEW
+    // ...
+}
+
 func NewWorkflow(
     cfg *config.Config,
-    slack slackAPI,
-    repoCache *ghclient.RepoCache,
+    dispatcher *workflow.Dispatcher,
+    slack workflow.SlackPort,
     repoDiscovery *ghclient.RepoDiscovery,
-    jobQueue queue.JobQueue,
-    jobStore queue.JobStore,
-    attachStore queue.AttachmentStore,
-    resultBus queue.ResultBus,
-    skillProvider SkillProvider,
-    identity Identity,
+    logger *slog.Logger,
     availability queue.WorkerAvailability, // NEW
 ) *Workflow
 ```
 
-2. **Trigger-time soft warn** in `HandleTrigger`, after the channel-guard block but before `repo` selection. `HandleTrigger` does not currently take a `context.Context`; use `context.Background()` to keep this spec's scope tight:
+2. **Trigger-time soft warn** in `HandleTrigger`, after the channel-binding check (`if _, ok := w.cfg.Channels[event.ChannelID]; !ok { ... }`) and BEFORE `ctx := context.Background()` / `dispatcher.Dispatch`:
 
 ```go
-verdict := w.availability.CheckSoft(context.Background())
-if verdict.Kind == queue.VerdictNoWorkers {
-    w.slack.PostMessage(event.ChannelID,
-        RenderSoftWarn(verdict), event.ThreadTS)
-    // Do NOT return — selection still proceeds; hard check will gate submit.
+if w.availability != nil {
+    verdict := w.availability.CheckSoft(context.Background())
+    if verdict.Kind == queue.VerdictNoWorkers {
+        _ = w.slack.PostMessage(event.ChannelID,
+            RenderSoftWarn(verdict), event.ThreadTS)
+        // Do NOT return — selection still proceeds; hard check at submit gates the submission.
+    }
 }
 ```
 
-3. **Submit-time hard check** in `runTriage`, immediately after the existing `ctx := context.Background()` (line 387) and **before** the `:mag: 正在排入處理佇列...` post (line 392):
+3. **Submit-time hard check** in a new `submit()` helper that consolidates the three current `onSubmit` call sites in `executeStep`:
 
 ```go
-verdict := w.availability.CheckHard(ctx)
-switch verdict.Kind {
-case queue.VerdictNoWorkers:
-    w.slack.PostMessage(pt.ChannelID,
-        RenderHardReject(verdict), pt.ThreadTS)
-    w.clearDedup(pt)
-    return
-case queue.VerdictBusyEnqueueOK:
-    pt.busyHint = RenderBusyHint(verdict) // attached to lifecycle message
-case queue.VerdictOK:
-    // continue
+// submit is the single chokepoint for sending a Pending to the queue-submission
+// closure. Replacing 3 onSubmit call sites in executeStep with this helper means
+// future pre-submit checks (rate limit, quota, etc.) only need to be added once.
+func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
+    if w.availability != nil {
+        verdict := w.availability.CheckHard(ctx)
+        switch verdict.Kind {
+        case queue.VerdictNoWorkers:
+            _ = w.slack.PostMessage(p.ChannelID,
+                RenderHardReject(verdict), p.ThreadTS)
+            if w.handler != nil {
+                w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+            }
+            return
+        case queue.VerdictBusyEnqueueOK:
+            p.BusyHint = RenderBusyHint(verdict)
+        case queue.VerdictOK:
+            // continue
+        }
+    }
+    if w.onSubmit != nil {
+        w.onSubmit(ctx, p)
+    } else {
+        w.logger.Warn("submit but no onSubmit hook set", "phase", "失敗")
+    }
 }
 ```
 
-`pendingTriage` gains an unexported `busyHint string` field. The existing block that builds the post-submit `statusMsg` (`workflow.go:537–544`) is amended:
+The three `executeStep` call sites that today read `if w.onSubmit != nil { w.onSubmit(ctx, ...) }` collapse to a single `w.submit(ctx, ...)`. (The `nil` check moves into `submit()`.)
+
+**`app/workflow/workflow.go`** changes:
+
+`Pending` gains an exported `BusyHint string` field (cross-package: shim sets it, `app/app.go` `submitJob` reads it):
 
 ```go
-if pos <= 1 {
-    statusMsg = ":hourglass_flowing_sand: 正在處理你的請求..."
-} else {
-    statusMsg = fmt.Sprintf(":hourglass_flowing_sand: 已加入排隊，前面有 %d 個請求", pos-1)
-}
-if pt.busyHint != "" {
-    statusMsg += " " + pt.busyHint
+type Pending struct {
+    // ... existing fields ...
+    State    any    // per-workflow state struct
+    BusyHint string // populated by the shim's submit() when verdict is BusyEnqueueOK; appended to lifecycle status text
 }
 ```
+
+**`app/app.go`** `submitJob` closure changes:
+
+After `BuildJob` returns `statusText`, append the busy hint before posting the lifecycle status message:
+
+```go
+job, statusText, err := wfImpl.BuildJob(ctx, p)
+if err != nil { /* ... */ return }
+
+if p.BusyHint != "" {
+    statusText += " " + p.BusyHint
+}
+
+statusMsgTS, postErr := slackPort.PostMessageWithTS(p.ChannelID, statusText, p.ThreadTS)
+```
+
+Two-line insertion only; no other changes to `submitJob`.
 
 ### 4. Verdict Rendering
 
@@ -214,13 +256,22 @@ This file is the single point of change when (a) oncall handles need to be appen
 
 ### 5. Wiring
 
-**`app/app.go`** — construct availability after `coordinator` and `jobStore` exist (currently around `metrics.Register` at line 184), then pass into `NewWorkflow`:
+**`app/app.go`** — construct `availability` after `coordinator` and `jobStore` are built (around the existing dispatcher construction, ~line 168), then pass into `bot.NewWorkflow`:
 
 ```go
 availability := queue.NewWorkerAvailability(coordinator, jobStore, queue.AvailabilityConfig{
     AvgJobDuration: cfg.Availability.AvgJobDuration,
-})
-workflow := bot.NewWorkflow(..., availability)
+},
+    queue.WithVerdictHook(func(kind, stage string, d time.Duration) {
+        metrics.WorkerAvailabilityVerdictTotal.WithLabelValues(kind, stage).Inc()
+        metrics.WorkerAvailabilityCheckDuration.Observe(d.Seconds())
+    }),
+    queue.WithDepErrorHook(func(dep string) {
+        metrics.WorkerAvailabilityCheckErrors.WithLabelValues(dep).Inc()
+    }),
+)
+
+wf := bot.NewWorkflow(cfg, dispatcher, slackPort, repoDiscovery, appLogger, availability)
 ```
 
 **`app/config/`** — add an `Availability` block to `app.yaml` schema:
@@ -234,13 +285,15 @@ Field is optional; absent → service default of `3 * time.Minute`.
 
 ### 6. Worker-side Change
 
-**`worker/worker.go`** — when calling `JobQueue.Register`, populate `Slots`:
+**`worker/pool/pool.go`** — `workerHeartbeat` (around line 241) builds `WorkerInfo` in two places (initial registration and the 20s ticker re-registration). Both literals get a `Slots: 1`:
 
 ```go
 info := queue.WorkerInfo{
-    WorkerID: ...,
-    Slots:    1, // hardcoded today; future: read from worker.yaml
-    ...
+    WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
+    Name:        p.cfg.Hostname,
+    Nickname:    p.nicknameForIndex(i),
+    Slots:       1, // hardcoded; future: read from worker.yaml when concurrent execution lands
+    ConnectedAt: now,
 }
 ```
 
@@ -275,8 +328,9 @@ Explicitly **not** doing: retry, circuit breaker, verdict caching. All YAGNI for
 
 - Soft check runs **after** `channel-guard` (`autoBound` / `AutoBind`) — never broadcast worker status to channels the bot is not bound to.
 - Soft check runs **after** `event.ThreadTS == ""` guard — outside-thread triggers get the existing usage hint, not a worker status.
-- Hard check runs **before** the first lifecycle `PostMessage` in `runTriage` — never leave a `":mag:"` orphan when rejecting.
-- Hard reject **must** call `clearDedup(pt)` — otherwise the user's retry within `DedupTTL` (5m default) is silently swallowed.
+- Hard check runs **inside the `submit()` helper, before** any call to `onSubmit` — never let a job reach `submitJob` (which posts the `:mag:` lifecycle text) when verdict is `NoWorkers`.
+- Hard reject **must** call `handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)` — otherwise the user's retry within `DedupTTL` (5m default) is silently swallowed.
+- BusyHint append in `submitJob` runs **after** `BuildJob` and **before** `slackPort.PostMessageWithTS` — appending later (after Post) would require an additional Slack edit call.
 
 ## Testing
 
@@ -298,11 +352,13 @@ Drive `WorkerAvailability` against the in-memory `queuetest` bundle:
 
 ### Integration — `app/bot/workflow_test.go`
 
-Add three cases using the existing `slackAPI` stub and a stub `WorkerAvailability`:
+Add three cases using the existing `shimSlack` and `fakeIssueWorkflow` test fixtures and a stub `WorkerAvailability`:
 
-- `TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues` — assert: soft warn message posted; repo selector still appears.
-- `TestRunTriage_NoWorkers_HardRejects` — assert: hard reject message posted; no `queue.Submit`; no lifecycle message; `clearDedup` invoked.
-- `TestRunTriage_BusyEnqueueOK_LifecycleMessageIncludesETA` — assert: `queue.Submit` called; lifecycle message contains `預估等候`.
+- `TestHandleTrigger_NoWorkers_PostsSoftWarnButContinues` — assert: soft warn message posted; `dispatcher.Dispatch` was still reached (e.g. assert a follow-on selector post or `submitHook` invocation).
+- `TestSubmit_NoWorkers_HardRejects` — drive `executeStep` with `NextStepSubmit` and a stub availability returning `NoWorkers`; assert: hard reject posted, `handler.ClearThreadDedup` invoked, `onSubmit` **not** called.
+- `TestSubmit_BusyEnqueueOK_SetsBusyHint` — drive `executeStep` with `NextStepSubmit` and a stub availability returning `BusyEnqueueOK`; assert: `onSubmit` **was** called, the `*workflow.Pending` arg has `BusyHint != ""` containing `預估等候`.
+
+(End-to-end "lifecycle message contains ETA" is split: the shim's responsibility is setting `Pending.BusyHint`; the closure in `app/app.go` appends it to `statusText`. Each side is testable in isolation; an integration test of the closure can live in a separate file if desired but is not in this spec.)
 
 ### Out of Scope
 

--- a/shared/metrics/metrics.go
+++ b/shared/metrics/metrics.go
@@ -138,6 +138,27 @@ var WatchdogKillsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Jobs killed by the watchdog.",
 }, []string{"reason"})
 
+// ---- Availability ----
+
+var WorkerAvailabilityVerdictTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_verdict_total",
+	Help:      "Counts of availability verdicts by kind and stage.",
+}, []string{"kind", "stage"})
+
+var WorkerAvailabilityCheckDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_check_duration_seconds",
+	Help:      "Latency of WorkerAvailability.compute.",
+	Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
+})
+
+var WorkerAvailabilityCheckErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "worker_availability_check_errors_total",
+	Help:      "Errors from availability dependencies.",
+}, []string{"dependency"})
+
 // ---- External ----
 
 var ExternalDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -184,6 +205,9 @@ func Register(reg prometheus.Registerer, q queue.JobQueue, store queue.JobStore)
 		WatchdogKillsTotal,
 		ExternalDuration,
 		ExternalErrorsTotal,
+		WorkerAvailabilityVerdictTotal,
+		WorkerAvailabilityCheckDuration,
+		WorkerAvailabilityCheckErrors,
 	)
 
 	// GaugeFunc metrics — computed on each scrape.

--- a/shared/queue/availability.go
+++ b/shared/queue/availability.go
@@ -1,0 +1,79 @@
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type VerdictKind string
+
+const (
+	VerdictOK            VerdictKind = "ok"
+	VerdictBusyEnqueueOK VerdictKind = "busy_enqueue"
+	VerdictNoWorkers     VerdictKind = "no_workers"
+)
+
+type Verdict struct {
+	Kind          VerdictKind
+	WorkerCount   int
+	ActiveJobs    int
+	TotalSlots    int
+	EstimatedWait time.Duration
+}
+
+type WorkerAvailability interface {
+	CheckSoft(ctx context.Context) Verdict
+	CheckHard(ctx context.Context) Verdict
+}
+
+type AvailabilityConfig struct {
+	AvgJobDuration time.Duration
+}
+
+type availability struct {
+	queue   JobQueue
+	store   JobStore
+	avgJob  time.Duration
+	logger  *slog.Logger
+}
+
+func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig) WorkerAvailability {
+	avg := cfg.AvgJobDuration
+	if avg <= 0 {
+		avg = 3 * time.Minute
+	}
+	return &availability{
+		queue:  q,
+		store:  store,
+		avgJob: avg,
+		logger: slog.Default(),
+	}
+}
+
+func (a *availability) CheckSoft(ctx context.Context) Verdict { return a.compute(ctx) }
+func (a *availability) CheckHard(ctx context.Context) Verdict { return a.compute(ctx) }
+
+func (a *availability) compute(ctx context.Context) Verdict {
+	workers, err := a.queue.ListWorkers(ctx)
+	if err != nil {
+		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		return Verdict{Kind: VerdictOK}
+	}
+	totalSlots := 0
+	for _, w := range workers {
+		totalSlots += normaliseSlots(w.Slots)
+	}
+	return Verdict{
+		Kind:        VerdictOK,
+		WorkerCount: len(workers),
+		TotalSlots:  totalSlots,
+	}
+}
+
+func normaliseSlots(s int) int {
+	if s <= 0 {
+		return 1
+	}
+	return s
+}

--- a/shared/queue/availability.go
+++ b/shared/queue/availability.go
@@ -31,33 +31,71 @@ type AvailabilityConfig struct {
 	AvgJobDuration time.Duration
 }
 
-type availability struct {
-	queue  JobQueue
-	store  JobStore
-	avgJob time.Duration
-	logger *slog.Logger
+// AvailabilityOption configures observability hooks without creating an
+// import cycle with shared/metrics.
+type AvailabilityOption func(*availability)
+
+// WithVerdictHook is invoked on every compute() call with kind, stage, and duration.
+func WithVerdictHook(fn func(kind, stage string, d time.Duration)) AvailabilityOption {
+	return func(a *availability) { a.verdictHook = fn }
 }
 
-func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig) WorkerAvailability {
+// WithDepErrorHook is invoked when a dependency call fails, with the
+// dependency name (e.g. "list_workers", "list_all").
+func WithDepErrorHook(fn func(dep string)) AvailabilityOption {
+	return func(a *availability) { a.depErrorHook = fn }
+}
+
+type availability struct {
+	queue        JobQueue
+	store        JobStore
+	avgJob       time.Duration
+	logger       *slog.Logger
+	verdictHook  func(kind, stage string, d time.Duration)
+	depErrorHook func(dep string)
+}
+
+func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig, opts ...AvailabilityOption) WorkerAvailability {
 	avg := cfg.AvgJobDuration
 	if avg <= 0 {
 		avg = 3 * time.Minute
 	}
-	return &availability{
+	a := &availability{
 		queue:  q,
 		store:  store,
 		avgJob: avg,
 		logger: slog.Default(),
 	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
 }
 
-func (a *availability) CheckSoft(ctx context.Context) Verdict { return a.compute(ctx) }
-func (a *availability) CheckHard(ctx context.Context) Verdict { return a.compute(ctx) }
+func (a *availability) CheckSoft(ctx context.Context) Verdict {
+	return a.observe(ctx, "soft")
+}
+
+func (a *availability) CheckHard(ctx context.Context) Verdict {
+	return a.observe(ctx, "hard")
+}
+
+func (a *availability) observe(ctx context.Context, stage string) Verdict {
+	start := time.Now()
+	v := a.compute(ctx)
+	if a.verdictHook != nil {
+		a.verdictHook(string(v.Kind), stage, time.Since(start))
+	}
+	return v
+}
 
 func (a *availability) compute(ctx context.Context) Verdict {
 	workers, err := a.queue.ListWorkers(ctx)
 	if err != nil {
 		a.logger.Warn("可用性檢查: 列舉 worker 失敗", "phase", "失敗", "error", err)
+		if a.depErrorHook != nil {
+			a.depErrorHook("list_workers")
+		}
 		return Verdict{Kind: VerdictOK}
 	}
 	totalSlots := 0
@@ -72,6 +110,9 @@ func (a *availability) compute(ctx context.Context) Verdict {
 	states, err := a.store.ListAll()
 	if err != nil {
 		a.logger.Warn("可用性檢查: 列舉工作狀態失敗", "phase", "失敗", "error", err)
+		if a.depErrorHook != nil {
+			a.depErrorHook("list_all")
+		}
 		return Verdict{Kind: VerdictOK, WorkerCount: len(workers), TotalSlots: totalSlots}
 	}
 	running := 0

--- a/shared/queue/availability.go
+++ b/shared/queue/availability.go
@@ -106,6 +106,9 @@ func (a *availability) compute(ctx context.Context) Verdict {
 		return Verdict{Kind: VerdictNoWorkers}
 	}
 
+	// QueueDepth() has no error return (interface signature in queue.JobQueue),
+	// so it never contributes to depErrorHook. Spec test matrix lists it as a
+	// fail-open dep, but the interface makes that case unreachable today.
 	depth := a.queue.QueueDepth()
 	states, err := a.store.ListAll()
 	if err != nil {

--- a/shared/queue/availability.go
+++ b/shared/queue/availability.go
@@ -32,10 +32,10 @@ type AvailabilityConfig struct {
 }
 
 type availability struct {
-	queue   JobQueue
-	store   JobStore
-	avgJob  time.Duration
-	logger  *slog.Logger
+	queue  JobQueue
+	store  JobStore
+	avgJob time.Duration
+	logger *slog.Logger
 }
 
 func NewWorkerAvailability(q JobQueue, store JobStore, cfg AvailabilityConfig) WorkerAvailability {
@@ -57,12 +57,15 @@ func (a *availability) CheckHard(ctx context.Context) Verdict { return a.compute
 func (a *availability) compute(ctx context.Context) Verdict {
 	workers, err := a.queue.ListWorkers(ctx)
 	if err != nil {
-		a.logger.Warn("availability: ListWorkers failed", "error", err)
+		a.logger.Warn("可用性檢查: 列舉 worker 失敗", "phase", "失敗", "error", err)
 		return Verdict{Kind: VerdictOK}
 	}
 	totalSlots := 0
 	for _, w := range workers {
 		totalSlots += normaliseSlots(w.Slots)
+	}
+	if len(workers) == 0 {
+		return Verdict{Kind: VerdictNoWorkers}
 	}
 	return Verdict{
 		Kind:        VerdictOK,

--- a/shared/queue/availability.go
+++ b/shared/queue/availability.go
@@ -67,10 +67,36 @@ func (a *availability) compute(ctx context.Context) Verdict {
 	if len(workers) == 0 {
 		return Verdict{Kind: VerdictNoWorkers}
 	}
+
+	depth := a.queue.QueueDepth()
+	states, err := a.store.ListAll()
+	if err != nil {
+		a.logger.Warn("可用性檢查: 列舉工作狀態失敗", "phase", "失敗", "error", err)
+		return Verdict{Kind: VerdictOK, WorkerCount: len(workers), TotalSlots: totalSlots}
+	}
+	running := 0
+	for _, s := range states {
+		if s.Status == JobPreparing || s.Status == JobRunning {
+			running++
+		}
+	}
+	active := depth + running
+
+	if active >= totalSlots {
+		overflow := active - totalSlots + 1
+		return Verdict{
+			Kind:          VerdictBusyEnqueueOK,
+			WorkerCount:   len(workers),
+			TotalSlots:    totalSlots,
+			ActiveJobs:    active,
+			EstimatedWait: time.Duration(overflow) * a.avgJob,
+		}
+	}
 	return Verdict{
 		Kind:        VerdictOK,
 		WorkerCount: len(workers),
 		TotalSlots:  totalSlots,
+		ActiveJobs:  active,
 	}
 }
 

--- a/shared/queue/availability_failopen_test.go
+++ b/shared/queue/availability_failopen_test.go
@@ -98,3 +98,13 @@ type workerListingQueue struct {
 func (w *workerListingQueue) ListWorkers(context.Context) ([]queue.WorkerInfo, error) {
 	return w.workers, nil
 }
+
+// fakeDepthQueue is workerListingQueue with a fixed QueueDepth — used by
+// availability tests that need a deterministic depth value without the
+// race-prone async drain in queuetest.JobQueue.
+type fakeDepthQueue struct {
+	workerListingQueue
+	depth int
+}
+
+func (f *fakeDepthQueue) QueueDepth() int { return f.depth }

--- a/shared/queue/availability_failopen_test.go
+++ b/shared/queue/availability_failopen_test.go
@@ -1,0 +1,100 @@
+package queue_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// erroringQueue satisfies queue.JobQueue but returns errors on the methods
+// availability depends on. Other methods panic — they should never be called
+// by the availability service.
+type erroringQueue struct {
+	listWorkersErr error
+}
+
+func (e *erroringQueue) Submit(context.Context, *queue.Job) error { panic("unused") }
+func (e *erroringQueue) QueuePosition(string) (int, error)        { panic("unused") }
+func (e *erroringQueue) QueueDepth() int                          { return 0 }
+func (e *erroringQueue) Receive(context.Context) (<-chan *queue.Job, error) {
+	panic("unused")
+}
+func (e *erroringQueue) Ack(context.Context, string) error { panic("unused") }
+func (e *erroringQueue) Register(context.Context, queue.WorkerInfo) error {
+	panic("unused")
+}
+func (e *erroringQueue) Unregister(context.Context, string) error { panic("unused") }
+func (e *erroringQueue) ListWorkers(context.Context) ([]queue.WorkerInfo, error) {
+	if e.listWorkersErr != nil {
+		return nil, e.listWorkersErr
+	}
+	return nil, nil
+}
+func (e *erroringQueue) Close() error { return nil }
+
+// erroringStore satisfies queue.JobStore but errors on ListAll.
+type erroringStore struct {
+	listAllErr error
+}
+
+func (s *erroringStore) Put(*queue.Job) error                { panic("unused") }
+func (s *erroringStore) Get(string) (*queue.JobState, error) { panic("unused") }
+func (s *erroringStore) GetByThread(string, string) (*queue.JobState, error) {
+	panic("unused")
+}
+func (s *erroringStore) ListPending() ([]*queue.JobState, error) { panic("unused") }
+func (s *erroringStore) UpdateStatus(string, queue.JobStatus) error {
+	panic("unused")
+}
+func (s *erroringStore) SetWorker(string, string) error { panic("unused") }
+func (s *erroringStore) SetAgentStatus(string, queue.StatusReport) error {
+	panic("unused")
+}
+func (s *erroringStore) Delete(string) error { panic("unused") }
+func (s *erroringStore) ListAll() ([]*queue.JobState, error) {
+	if s.listAllErr != nil {
+		return nil, s.listAllErr
+	}
+	return nil, nil
+}
+
+func TestAvailability_FailOpen_ListWorkersError(t *testing.T) {
+	q := &erroringQueue{listWorkersErr: errors.New("redis down")}
+	store := queue.NewMemJobStore()
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (fail-open)", v.Kind, queue.VerdictOK)
+	}
+}
+
+func TestAvailability_FailOpen_ListAllError(t *testing.T) {
+	// Need a queue that returns at least one worker (so we pass the NoWorkers gate)
+	// AND a store that errors on ListAll.
+	q := &workerListingQueue{erroringQueue: erroringQueue{}, workers: []queue.WorkerInfo{{WorkerID: "w1"}}}
+	store := &erroringStore{listAllErr: errors.New("store down")}
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (fail-open on store error)", v.Kind, queue.VerdictOK)
+	}
+}
+
+// workerListingQueue is erroringQueue but with a configurable workers list.
+type workerListingQueue struct {
+	erroringQueue
+	workers []queue.WorkerInfo
+}
+
+func (w *workerListingQueue) ListWorkers(context.Context) ([]queue.WorkerInfo, error) {
+	return w.workers, nil
+}

--- a/shared/queue/availability_test.go
+++ b/shared/queue/availability_test.go
@@ -76,19 +76,26 @@ func TestAvailability_BusyEnqueueOK_FullySaturated(t *testing.T) {
 }
 
 func TestAvailability_BusyEnqueueOK_WithQueueDepth(t *testing.T) {
-	q, store, a := newAvail(t)
-	ctx := context.Background()
+	// queuetest.JobQueue.Submit pushes onto a heap that a background dispatch
+	// goroutine drains into a channel; QueueDepth races against that drain
+	// and is unreliable for "I just submitted N, expect depth=N" assertions.
+	// Use a deterministic stub instead so the math under test isn't flaky.
+	store := queue.NewMemJobStore()
+	q := &fakeDepthQueue{
+		workerListingQueue: workerListingQueue{
+			workers: []queue.WorkerInfo{{WorkerID: "w1", Slots: 1}},
+		},
+		depth: 4,
+	}
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
 
-	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 1})
-
-	// 1 running + 4 queued = 5 active, slots = 1, overflow = 5
+	// 1 running in store + 4 from queue depth = 5 active, slots = 1, overflow = 5
 	store.Put(&queue.Job{ID: "j1"})
 	store.UpdateStatus("j1", queue.JobRunning)
-	for i := 0; i < 4; i++ {
-		q.Submit(ctx, &queue.Job{ID: "p" + string(rune('a'+i))})
-	}
 
-	v := a.CheckHard(ctx)
+	v := a.CheckHard(context.Background())
 	if v.Kind != queue.VerdictBusyEnqueueOK {
 		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictBusyEnqueueOK)
 	}

--- a/shared/queue/availability_test.go
+++ b/shared/queue/availability_test.go
@@ -1,0 +1,38 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+	"github.com/Ivantseng123/agentdock/shared/queue/queuetest"
+)
+
+func newAvail(t *testing.T) (*queuetest.JobQueue, queue.JobStore, queue.WorkerAvailability) {
+	t.Helper()
+	store := queue.NewMemJobStore()
+	q := queuetest.NewJobQueue(50, store)
+	a := queue.NewWorkerAvailability(q, store, queue.AvailabilityConfig{
+		AvgJobDuration: 3 * time.Minute,
+	})
+	return q, store, a
+}
+
+func TestAvailability_HealthyOK(t *testing.T) {
+	q, _, a := newAvail(t)
+
+	q.Register(context.Background(), queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+	q.Register(context.Background(), queue.WorkerInfo{WorkerID: "w2", Slots: 1})
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictOK)
+	}
+	if v.WorkerCount != 2 {
+		t.Errorf("WorkerCount = %d, want 2", v.WorkerCount)
+	}
+	if v.TotalSlots != 2 {
+		t.Errorf("TotalSlots = %d, want 2", v.TotalSlots)
+	}
+}

--- a/shared/queue/availability_test.go
+++ b/shared/queue/availability_test.go
@@ -97,3 +97,39 @@ func TestAvailability_BusyEnqueueOK_WithQueueDepth(t *testing.T) {
 		t.Errorf("EstimatedWait = %v, want %v", v.EstimatedWait, wantETA)
 	}
 }
+
+func TestAvailability_MultiSlotWorker(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	// One worker with 3 slots, two running jobs → 1 spare slot → OK.
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 3})
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	store.Put(&queue.Job{ID: "j2"})
+	store.UpdateStatus("j2", queue.JobRunning)
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q (3 slots, 2 active)", v.Kind, queue.VerdictOK)
+	}
+	if v.TotalSlots != 3 {
+		t.Errorf("TotalSlots = %d, want 3", v.TotalSlots)
+	}
+}
+
+func TestAvailability_ZeroSlotsNormalisedToOne(t *testing.T) {
+	q, _, a := newAvail(t)
+	ctx := context.Background()
+
+	// Slots=0 (e.g. older worker that didn't set the field) → treated as 1.
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "old", Slots: 0})
+
+	v := a.CheckHard(ctx)
+	if v.TotalSlots != 1 {
+		t.Errorf("TotalSlots = %d, want 1 (normalised)", v.TotalSlots)
+	}
+	if v.Kind != queue.VerdictOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictOK)
+	}
+}

--- a/shared/queue/availability_test.go
+++ b/shared/queue/availability_test.go
@@ -48,3 +48,52 @@ func TestAvailability_NoWorkers(t *testing.T) {
 		t.Errorf("WorkerCount = %d, want 0", v.WorkerCount)
 	}
 }
+
+func TestAvailability_BusyEnqueueOK_FullySaturated(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w2", Slots: 1})
+
+	// Two jobs in JobRunning consume both slots; queue depth = 0.
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	store.Put(&queue.Job{ID: "j2"})
+	store.UpdateStatus("j2", queue.JobRunning)
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictBusyEnqueueOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictBusyEnqueueOK)
+	}
+	if v.ActiveJobs != 2 {
+		t.Errorf("ActiveJobs = %d, want 2", v.ActiveJobs)
+	}
+	wantETA := 1 * 3 * time.Minute // overflow=1
+	if v.EstimatedWait != wantETA {
+		t.Errorf("EstimatedWait = %v, want %v", v.EstimatedWait, wantETA)
+	}
+}
+
+func TestAvailability_BusyEnqueueOK_WithQueueDepth(t *testing.T) {
+	q, store, a := newAvail(t)
+	ctx := context.Background()
+
+	q.Register(ctx, queue.WorkerInfo{WorkerID: "w1", Slots: 1})
+
+	// 1 running + 4 queued = 5 active, slots = 1, overflow = 5
+	store.Put(&queue.Job{ID: "j1"})
+	store.UpdateStatus("j1", queue.JobRunning)
+	for i := 0; i < 4; i++ {
+		q.Submit(ctx, &queue.Job{ID: "p" + string(rune('a'+i))})
+	}
+
+	v := a.CheckHard(ctx)
+	if v.Kind != queue.VerdictBusyEnqueueOK {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictBusyEnqueueOK)
+	}
+	wantETA := time.Duration(5) * 3 * time.Minute
+	if v.EstimatedWait != wantETA {
+		t.Errorf("EstimatedWait = %v, want %v", v.EstimatedWait, wantETA)
+	}
+}

--- a/shared/queue/availability_test.go
+++ b/shared/queue/availability_test.go
@@ -36,3 +36,15 @@ func TestAvailability_HealthyOK(t *testing.T) {
 		t.Errorf("TotalSlots = %d, want 2", v.TotalSlots)
 	}
 }
+
+func TestAvailability_NoWorkers(t *testing.T) {
+	_, _, a := newAvail(t)
+
+	v := a.CheckHard(context.Background())
+	if v.Kind != queue.VerdictNoWorkers {
+		t.Errorf("Kind = %q, want %q", v.Kind, queue.VerdictNoWorkers)
+	}
+	if v.WorkerCount != 0 {
+		t.Errorf("WorkerCount = %d, want 0", v.WorkerCount)
+	}
+}

--- a/shared/queue/job.go
+++ b/shared/queue/job.go
@@ -114,6 +114,7 @@ type WorkerInfo struct {
 	Nickname    string   `json:"nickname,omitempty"`
 	Agents      []string `json:"agents"`
 	Tags        []string `json:"tags"`
+	Slots       int      `json:"slots,omitempty"` // concurrent jobs this worker handles; 0 normalised to 1 by consumers
 	ConnectedAt time.Time
 }
 

--- a/shared/queue/redis_jobqueue.go
+++ b/shared/queue/redis_jobqueue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -19,6 +20,7 @@ type RedisJobQueue struct {
 	group      string
 	consumerID string
 	stopCh     chan struct{}
+	seqCounter atomic.Uint64
 }
 
 // NewRedisJobQueue creates a new Redis-backed job queue for the given task type.
@@ -35,7 +37,15 @@ func NewRedisJobQueue(rdb *redis.Client, store JobStore, taskType string) *Redis
 }
 
 // Submit adds a job to the Redis stream and stores it in the job store.
+//
+// The Seq field is assigned from a process-local monotonic counter so that
+// QueuePosition can compute submission order without an extra Redis round-trip.
+// Only this app instance's QueuePosition consults the value — across-instance
+// ordering is irrelevant because each app's MemJobStore only sees its own
+// submissions.
 func (q *RedisJobQueue) Submit(ctx context.Context, job *Job) error {
+	job.Seq = q.seqCounter.Add(1)
+
 	data, err := json.Marshal(job)
 	if err != nil {
 		return fmt.Errorf("marshal job: %w", err)
@@ -51,10 +61,33 @@ func (q *RedisJobQueue) Submit(ctx context.Context, job *Job) error {
 	}).Err()
 }
 
-// QueuePosition returns 0 in Redis mode (position tracking is not meaningful
-// with consumer groups since jobs are distributed across consumers).
-func (q *RedisJobQueue) QueuePosition(_ string) (int, error) {
-	return 0, nil
+// QueuePosition returns the 1-based position of a still-pending job in this
+// app instance's submission queue. Returns 0 once the job has been picked up
+// by a worker (status != JobPending) — it is no longer "queued".
+//
+// Counting is local to this app instance's JobStore; in a multi-app deployment
+// each instance reports its own backlog. That is the same fidelity the
+// in-memory queue gives, and matches how callers use the value (UX hint, not
+// distributed consensus).
+func (q *RedisJobQueue) QueuePosition(jobID string) (int, error) {
+	state, err := q.store.Get(jobID)
+	if err != nil {
+		return 0, err
+	}
+	if state.Status != JobPending {
+		return 0, nil
+	}
+	pending, err := q.store.ListPending()
+	if err != nil {
+		return 0, err
+	}
+	pos := 0
+	for _, p := range pending {
+		if p.Job.Seq <= state.Job.Seq {
+			pos++
+		}
+	}
+	return pos, nil
 }
 
 // QueueDepth returns the number of jobs still awaiting dispatch to any worker

--- a/shared/queue/redis_jobqueue_test.go
+++ b/shared/queue/redis_jobqueue_test.go
@@ -101,13 +101,102 @@ func TestRedisJobQueue_AckAndDepth(t *testing.T) {
 		t.Fatal("timed out waiting for job")
 	}
 
-	// QueuePosition always returns 0 in Redis mode.
+	// job-depth-001 is the first delivery (Streams preserve submit order); after
+	// Ack moved it to JobPreparing, QueuePosition reports 0 — it is no longer
+	// queued. job-depth-002 is now alone at the head, position 1.
 	pos, err := q.QueuePosition("job-depth-001")
 	if err != nil {
-		t.Fatalf("QueuePosition failed: %v", err)
+		t.Fatalf("QueuePosition(acked) failed: %v", err)
 	}
 	if pos != 0 {
-		t.Errorf("QueuePosition = %d, want 0", pos)
+		t.Errorf("QueuePosition(acked) = %d, want 0", pos)
+	}
+	pos, err = q.QueuePosition("job-depth-002")
+	if err != nil {
+		t.Fatalf("QueuePosition(pending) failed: %v", err)
+	}
+	if pos != 1 {
+		t.Errorf("QueuePosition(pending) = %d, want 1", pos)
+	}
+}
+
+func TestRedisJobQueue_QueuePositionTracksSubmissionOrder(t *testing.T) {
+	client := testRedisClient(t)
+	store := NewMemJobStore()
+	q := NewRedisJobQueue(client, store, "triage")
+	defer q.Close()
+
+	ctx := context.Background()
+
+	jobs := []*Job{
+		{ID: "qp-001", TaskType: "triage", SubmittedAt: time.Now()},
+		{ID: "qp-002", TaskType: "triage", SubmittedAt: time.Now()},
+		{ID: "qp-003", TaskType: "triage", SubmittedAt: time.Now()},
+	}
+	for _, j := range jobs {
+		if err := q.Submit(ctx, j); err != nil {
+			t.Fatalf("Submit %s: %v", j.ID, err)
+		}
+	}
+
+	cases := []struct {
+		id   string
+		want int
+	}{
+		{"qp-001", 1},
+		{"qp-002", 2},
+		{"qp-003", 3},
+	}
+	for _, c := range cases {
+		pos, err := q.QueuePosition(c.id)
+		if err != nil {
+			t.Fatalf("QueuePosition(%s): %v", c.id, err)
+		}
+		if pos != c.want {
+			t.Errorf("QueuePosition(%s) = %d, want %d", c.id, pos, c.want)
+		}
+	}
+}
+
+func TestRedisJobQueue_QueuePositionRecedesAfterAck(t *testing.T) {
+	client := testRedisClient(t)
+	store := NewMemJobStore()
+	q := NewRedisJobQueue(client, store, "triage")
+	defer q.Close()
+
+	ctx := context.Background()
+
+	jobs := []*Job{
+		{ID: "qp-recede-001", TaskType: "triage", SubmittedAt: time.Now()},
+		{ID: "qp-recede-002", TaskType: "triage", SubmittedAt: time.Now()},
+		{ID: "qp-recede-003", TaskType: "triage", SubmittedAt: time.Now()},
+	}
+	for _, j := range jobs {
+		if err := q.Submit(ctx, j); err != nil {
+			t.Fatalf("Submit %s: %v", j.ID, err)
+		}
+	}
+
+	if err := q.Ack(ctx, jobs[0].ID); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+
+	cases := []struct {
+		id   string
+		want int
+	}{
+		{jobs[0].ID, 0}, // acked → no longer pending
+		{jobs[1].ID, 1}, // promoted to head
+		{jobs[2].ID, 2},
+	}
+	for _, c := range cases {
+		pos, err := q.QueuePosition(c.id)
+		if err != nil {
+			t.Fatalf("QueuePosition(%s): %v", c.id, err)
+		}
+		if pos != c.want {
+			t.Errorf("QueuePosition(%s) = %d, want %d", c.id, pos, c.want)
+		}
 	}
 }
 

--- a/worker/pool/pool.go
+++ b/worker/pool/pool.go
@@ -245,6 +245,7 @@ func (p *Pool) workerHeartbeat(ctx context.Context) {
 			WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
 			Name:        p.cfg.Hostname,
 			Nickname:    p.nicknameForIndex(i),
+			Slots:       1, // hardcoded; future work: read from worker.yaml when concurrent execution lands
 			ConnectedAt: now,
 		}
 		if err := p.cfg.Queue.Register(ctx, info); err != nil {
@@ -263,6 +264,7 @@ func (p *Pool) workerHeartbeat(ctx context.Context) {
 					WorkerID:    fmt.Sprintf("%s/worker-%d", p.cfg.Hostname, i),
 					Name:        p.cfg.Hostname,
 					Nickname:    p.nicknameForIndex(i),
+					Slots:       1, // see initial-registration comment above
 					ConnectedAt: now,
 				}
 				p.cfg.Queue.Register(ctx, info)


### PR DESCRIPTION
## Summary

Two-stage worker availability check so users get told when no workers are online instead of silently waiting for a watchdog timeout.

- **Trigger time:** non-blocking soft warning when no workers are registered (selection still proceeds).
- **Submit time:** hard reject with `:x:` message + `ClearThreadDedup` when no workers; appends `(預估等候 ~Xm)` to the lifecycle status when capacity is saturated.
- New `shared/queue.WorkerAvailability` service (typed `Verdict`, fail-open on Redis blips) + 3 Prometheus metrics wired via functional-option hooks (no `queue → metrics` import cycle).
- New `app/bot/verdict_message.go` is the single Slack-text seam — future mediums (X, Discord, …) plug in their own renderers without touching `shared/queue`.
- Hard check lives in a new `Workflow.submit()` chokepoint that consolidates the three former `executeStep → onSubmit` call sites; future pre-submit checks (rate limit, quota, …) only need to land in one place.

Specs / plans: `docs/superpowers/specs/2026-04-22-worker-liveness-precheck-design.md`, `docs/superpowers/plans/2026-04-22-worker-liveness-precheck.md`.

## Test Plan

- [ ] CI: full `go test ./...` green (locally: yes, including new availability + verdict_message + workflow integration tests).
- [ ] CI: `TestImportDirection` still passes (verified: `shared/queue` does not import `shared/metrics`).
- [ ] Manual smoke: bring up app + Redis with NO worker → `@bot` in a thread shows `:warning: 目前沒有 worker 在線` immediately, and after completing repo selection shows `:x: 目前沒有 worker 在線` (no `:mag:` orphan).
- [ ] Manual smoke: with worker running normally → no warn, normal triage flow unchanged.
- [ ] Manual smoke: saturate the queue (one worker, multiple requests) → lifecycle message includes `(預估等候 ~Xm)`.
- [ ] Prometheus: scrape `/metrics`, verify `agentdock_worker_availability_verdict_total{kind=ok|busy_enqueue|no_workers,stage=soft|hard}` increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)