### PR TITLE
fix(slack): decode HTML entities in thread message text

### DIFF
--- a/app/slack/client.go
+++ b/app/slack/client.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -661,17 +662,29 @@ func classifyAttachment(filetype, mimetype string) string {
 // extractMessageText returns m.Text if non-empty, otherwise reconstructs
 // text from blocks (modern integrations) or attachments (legacy). Returns
 // "" only when no renderable text is present.
+//
+// Slack pre-encodes <, >, & as HTML entities (&lt;, &gt;, &amp;) so they
+// don't collide with mention/link syntax. We decode here at the adapter
+// boundary so downstream consumers (workflow, prompt builder) work with
+// plain text — otherwise the worker's xmlEscape runs a second round and
+// dependency chains like "exceljs -> archiver" reach the LLM as
+// "exceljs -&amp;gt; archiver".
 func extractMessageText(m slack.Message) string {
-	if strings.TrimSpace(m.Text) != "" {
-		return m.Text
+	var text string
+	switch {
+	case strings.TrimSpace(m.Text) != "":
+		text = m.Text
+	default:
+		if s := extractFromBlocks(m.Blocks.BlockSet); s != "" {
+			text = s
+		} else if s := extractFromAttachments(m.Attachments); s != "" {
+			text = s
+		}
 	}
-	if s := extractFromBlocks(m.Blocks.BlockSet); s != "" {
-		return s
+	if text == "" {
+		return ""
 	}
-	if s := extractFromAttachments(m.Attachments); s != "" {
-		return s
-	}
-	return ""
+	return html.UnescapeString(text)
 }
 
 // extractFromBlocks walks block kit content pulling text from

--- a/app/slack/client_test.go
+++ b/app/slack/client_test.go
@@ -247,6 +247,35 @@ func TestExtractMessageText_AllEmpty(t *testing.T) {
 	}
 }
 
+// Slack pre-encodes <, >, & in m.Text so they don't collide with mention/link
+// syntax. If we forward the encoded form downstream, the worker's xmlEscape
+// runs a second round (&gt; → &amp;gt;), so dependency chains and code
+// snippets reach the LLM as encoded noise. Decode at the adapter boundary.
+func TestExtractMessageText_DecodesHTMLEntitiesFromText(t *testing.T) {
+	msg := slack.Message{Msg: slack.Msg{
+		Text: "exceljs -&gt; archiver &amp; glob &lt;user&gt; &quot;quoted&quot;",
+	}}
+	got := extractMessageText(msg)
+	want := `exceljs -> archiver & glob <user> "quoted"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractMessageText_DecodesHTMLEntitiesFromBlocks(t *testing.T) {
+	blocks := slack.Blocks{BlockSet: []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", "A &amp; B &gt; C", false, false),
+			nil, nil,
+		),
+	}}
+	msg := slack.Message{Msg: slack.Msg{Text: "", Blocks: blocks}}
+	got := extractMessageText(msg)
+	if !strings.Contains(got, "A & B > C") {
+		t.Errorf("blocks not decoded; got %q", got)
+	}
+}
+
 func TestExtractMessageText_RichTextQuoteAndPreformatted(t *testing.T) {
 	msg := slack.Message{Msg: slack.Msg{Blocks: slack.Blocks{BlockSet: []slack.Block{
 		&slack.RichTextBlock{


### PR DESCRIPTION
## Summary

Closes #89.

Slack pre-encodes `<`, `>`, `&` as `&lt;`, `&gt;`, `&amp;` in `m.Text` so they don't collide with mention/link syntax. The encoded form was forwarded into `queue.PromptContext.ThreadMessages`, then the worker's `xmlEscape` ran a second round → dependency chains like `exceljs -> archiver` reached the LLM as `exceljs -&amp;gt; archiver`.

Fix decodes at the Slack adapter boundary in `extractMessageText` — both the `m.Text` path and the blocks/attachments fallback. Downstream code keeps working with plain text; the worker's single layer of XML escape is the only encoding the LLM has to undo.

## Test plan

- [x] New unit tests in `app/slack/client_test.go` cover `m.Text` and blocks paths
- [x] Existing `TestExtractMessageText_*` and `TestBuildPrompt_XMLEscaping` still pass — decode happens upstream of xmlEscape
- [ ] Manual: trigger a triage on a Slack thread containing `>`, `<`, `&` in code/dependency text; verify worker XML output has single layer of entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)