### PR TITLE
feat(prompt): add response_schema default for issue workflow

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -141,9 +141,25 @@ func TestPromptConfig_ResponseSchemaDefaults(t *testing.T) {
 	cfg := &Config{}
 	ApplyDefaults(cfg)
 
-	// Ask and PRReview must have a ResponseSchema; Issue intentionally does
-	// not (its output contract lives in app/workflow/issue.go as spec
-	// language).
+	// Issue ResponseSchema — mirrors issue_parser.TriageResult (CREATED /
+	// REJECTED / ERROR shapes).
+	if cfg.Prompt.Issue.ResponseSchema == "" {
+		t.Error("Issue.ResponseSchema default is empty")
+	}
+	if !strings.Contains(cfg.Prompt.Issue.ResponseSchema, "===TRIAGE_RESULT===") {
+		t.Errorf("Issue.ResponseSchema missing TRIAGE_RESULT marker: %q", cfg.Prompt.Issue.ResponseSchema)
+	}
+	for _, field := range []string{
+		`"status"`, `"title"`, `"body"`, `"labels"`,
+		`"confidence"`, `"files_found"`, `"open_questions"`, `"message"`,
+	} {
+		if !strings.Contains(cfg.Prompt.Issue.ResponseSchema, field) {
+			t.Errorf("Issue.ResponseSchema missing required field %s; current:\n%s",
+				field, cfg.Prompt.Issue.ResponseSchema)
+		}
+	}
+
+	// Ask ResponseSchema — single shape, literal "answer" key required.
 	if cfg.Prompt.Ask.ResponseSchema == "" {
 		t.Error("Ask.ResponseSchema default is empty")
 	}
@@ -154,14 +170,15 @@ func TestPromptConfig_ResponseSchemaDefaults(t *testing.T) {
 		t.Errorf("Ask.ResponseSchema missing literal \"answer\" key: %q", cfg.Prompt.Ask.ResponseSchema)
 	}
 
+	// PRReview ResponseSchema — must mention every field the
+	// pr_review_parser.ReviewResult cares about; losing any of these
+	// silently degrades Slack output.
 	if cfg.Prompt.PRReview.ResponseSchema == "" {
 		t.Error("PRReview.ResponseSchema default is empty")
 	}
 	if !strings.Contains(cfg.Prompt.PRReview.ResponseSchema, "===REVIEW_RESULT===") {
 		t.Errorf("PRReview.ResponseSchema missing REVIEW_RESULT marker: %q", cfg.Prompt.PRReview.ResponseSchema)
 	}
-	// Must mention every field the pr_review_parser.ReviewResult cares
-	// about — losing any of these silently degrades Slack output.
 	for _, field := range []string{
 		`"status"`,
 		`"summary"`,
@@ -185,6 +202,9 @@ func TestPromptConfig_GoalDoesNotDuplicateSchema(t *testing.T) {
 	cfg := &Config{}
 	ApplyDefaults(cfg)
 
+	if strings.Contains(cfg.Prompt.Issue.Goal, "===TRIAGE_RESULT===") {
+		t.Errorf("Issue.Goal must NOT contain the TRIAGE_RESULT marker (belongs in ResponseSchema): %q", cfg.Prompt.Issue.Goal)
+	}
 	if strings.Contains(cfg.Prompt.Ask.Goal, "===ASK_RESULT===") {
 		t.Errorf("Ask.Goal must NOT contain the ASK_RESULT marker (belongs in ResponseSchema): %q", cfg.Prompt.Ask.Goal)
 	}

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -158,6 +158,20 @@ func TestPromptConfig_ResponseSchemaDefaults(t *testing.T) {
 				field, cfg.Prompt.Issue.ResponseSchema)
 		}
 	}
+}
+
+func TestPromptConfig_IssueSchemaCarriesStripTriageHeaders(t *testing.T) {
+	// app/workflow/issue.go:stripTriageSection uses these exact header
+	// strings to trim low-confidence content in degraded runs. If the
+	// schema stops promising them, degraded issues will publish full
+	// low-confidence RCA/TDD content to GitHub. Keep both sides in sync.
+	cfg := &Config{}
+	ApplyDefaults(cfg)
+	for _, header := range []string{"## Root Cause Analysis", "## TDD Fix Plan"} {
+		if !strings.Contains(cfg.Prompt.Issue.ResponseSchema, header) {
+			t.Errorf("Issue.ResponseSchema missing stripTriageSection header %q — must stay in sync with app/workflow/issue.go:stripTriageSection", header)
+		}
+	}
 
 	// Ask ResponseSchema — single shape, literal "answer" key required.
 	if cfg.Prompt.Ask.ResponseSchema == "" {

--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -140,6 +140,26 @@ ERROR (review failed, helper exit != 0):
 {"status": "ERROR", "error": "<diagnostic message operators can act on>", "summary": "<what you would have posted>"}
 
 Use exactly these keys — no synonyms. Do NOT merge shapes (e.g. never emit "reason" when status is POSTED).`
+
+	// Mirrors app/workflow/issue_parser.go:TriageResult and the
+	// triage-issue skill's "Output result" section. Three discriminated
+	// shapes by status. Title is required when status is CREATED; missing
+	// title is a hard parse failure in the workflow.
+	defaultIssueResponseSchema = `Your final response MUST end with this exact block:
+
+===TRIAGE_RESULT===
+<ONE of the three JSON shapes below, chosen by status>
+
+CREATED (confidence is high or medium — issue should be filed):
+{"status": "CREATED", "title": "<concise issue title — REQUIRED>", "body": "<full markdown body as a single JSON string, \n for newlines>", "labels": ["bug"], "confidence": "high|medium", "files_found": <int>, "open_questions": <int>}
+
+REJECTED (confidence is low — not related to this repo):
+{"status": "REJECTED", "message": "<brief explanation why this is out of scope>"}
+
+ERROR (investigation couldn't complete):
+{"status": "ERROR", "message": "<what went wrong>"}
+
+Use exactly these keys — no synonyms. CREATED without a non-empty title is a hard failure. Do NOT run gh issue create yourself — just emit the JSON; the app creates the issue from your output.`
 )
 
 var (
@@ -173,6 +193,9 @@ func applyPromptDefaults(p *PromptConfig) {
 	if p.PRReview.Goal == "" {
 		p.PRReview.Goal = defaultPRReviewGoal
 	}
+	if p.Issue.ResponseSchema == "" {
+		p.Issue.ResponseSchema = defaultIssueResponseSchema
+	}
 	if p.Ask.ResponseSchema == "" {
 		p.Ask.ResponseSchema = defaultAskResponseSchema
 	}
@@ -185,9 +208,11 @@ func applyPromptDefaults(p *PromptConfig) {
 	if len(p.PRReview.OutputRules) == 0 {
 		p.PRReview.OutputRules = defaultPRReviewOutputRules
 	}
-	// Issue.OutputRules is intentionally left empty if operator didn't set
-	// it; the current spec's hardcoded Issue rules travel in
-	// app/workflow/issue.go as spec language, not as defaults here.
+	// Issue.OutputRules is intentionally left empty — formatting rules for
+	// triage output live in the triage-issue skill's SKILL.md body template,
+	// not here. The machine-readable contract (CREATED/REJECTED/ERROR
+	// shapes) now lives in Issue.ResponseSchema instead of being implicit
+	// in the skill.
 
 	// Preserve prior AllowWorkerRules default (pointer to true).
 	if p.AllowWorkerRules == nil {

--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -145,6 +145,14 @@ Use exactly these keys — no synonyms. Do NOT merge shapes (e.g. never emit "re
 	// triage-issue skill's "Output result" section. Three discriminated
 	// shapes by status. Title is required when status is CREATED; missing
 	// title is a hard parse failure in the workflow.
+	//
+	// LOAD-BEARING HEADERS: app/workflow/issue.go:stripTriageSection uses
+	// literal "## Root Cause Analysis" and "## TDD Fix Plan" to trim
+	// low-confidence content in degraded runs (files_found == 0 ||
+	// open_questions >= 5). The schema promises those headers exist in the
+	// body; the triage-issue skill's body template carries their actual
+	// content. Change one and the other must follow — the test
+	// TestPromptConfig_IssueSchemaCarriesStripTriageHeaders enforces it.
 	defaultIssueResponseSchema = `Your final response MUST end with this exact block:
 
 ===TRIAGE_RESULT===
@@ -159,7 +167,12 @@ REJECTED (confidence is low — not related to this repo):
 ERROR (investigation couldn't complete):
 {"status": "ERROR", "message": "<what went wrong>"}
 
-Use exactly these keys — no synonyms. CREATED without a non-empty title is a hard failure. Do NOT run gh issue create yourself — just emit the JSON; the app creates the issue from your output.`
+Use exactly these keys — no synonyms. CREATED without a non-empty title is a hard failure. Do NOT run gh issue create yourself — just emit the JSON; the app creates the issue from your output.
+
+BODY STRUCTURE (load-bearing): When status is CREATED, the "body" JSON string MUST contain these two markdown headers verbatim, spelled exactly as shown:
+  "## Root Cause Analysis"
+  "## TDD Fix Plan"
+The app strips those sections in degraded runs (low files_found / high open_questions). Without them, low-confidence analysis leaks into the published GitHub issue.`
 )
 
 var (

--- a/app/workflow/issue_test.go
+++ b/app/workflow/issue_test.go
@@ -129,6 +129,9 @@ func TestIssueWorkflow_BuildJob_SetsTaskType(t *testing.T) {
 	if job.PromptContext == nil || job.PromptContext.Goal == "" {
 		t.Error("PromptContext.Goal must be populated (from config or default)")
 	}
+	if job.PromptContext.ResponseSchema == "" {
+		t.Error("PromptContext.ResponseSchema must be populated (ApplyDefaults)")
+	}
 	if status == "" {
 		t.Error("status text should be non-empty; spec says :mag: 分析 codebase 中...")
 	}

--- a/docs/configuration-app.en.md
+++ b/docs/configuration-app.en.md
@@ -54,8 +54,12 @@ prompt:
   # One goal + response_schema + output_rules block per workflow. Unset fields fall back to hardcoded defaults.
   issue:
     goal: "Use the /triage-issue skill to investigate and produce a triage result."
-    response_schema: ""               # issue workflow's output contract lives in its spec
-    output_rules: []                  # same as above
+    response_schema: |
+      Your final response MUST end with ONE of these three shapes after ===TRIAGE_RESULT===:
+      CREATED  → {"status":"CREATED","title":"<required>","body":"...","labels":[...],"confidence":"high|medium","files_found":<int>,"open_questions":<int>}
+      REJECTED → {"status":"REJECTED","message":"..."}
+      ERROR    → {"status":"ERROR","message":"..."}
+    output_rules: []                  # formatting rules live in the triage-issue skill's SKILL.md body template, not here
   ask:
     goal: "Answer the user's question using the thread, and (if a codebase is attached) the repo. Follow the ask-assistant skill for scope, boundaries, and punt rules."
     response_schema: |
@@ -133,7 +137,7 @@ secrets:
 - `goal` is the **task description** — what to do, which skill to invoke (`triage-issue` / `ask-assistant` / `github-pr-review`). Keep output format OUT of the goal.
 - `response_schema` is the **machine-readable output contract** — marker + JSON shape (`===ASK_RESULT===` / `===REVIEW_RESULT===`, etc). This section is **NOT** XML-escaped in the rendered prompt — literal `"` and `<` reach the LLM verbatim, so weaker models don't copy `&quot;` into their output and break downstream JSON parsing.
 - `output_rules` are **formatting rules** (Slack mrkdwn, length caps, self-reference handle) rendered at the end of the prompt, XML-escaped.
-- Any unset field is filled from `app/config/defaults.go` (`defaultIssueGoal` / `defaultAskGoal` / `defaultPRReviewGoal` / `defaultAskResponseSchema` / `defaultPRReviewResponseSchema` / `defaultAskOutputRules` / `defaultPRReviewOutputRules`). `issue.response_schema` and `issue.output_rules` default to empty — issue workflow's hard rules live inline in `app/workflow/issue.go`'s spec.
+- Any unset field is filled from `app/config/defaults.go` (`defaultIssueGoal` / `defaultAskGoal` / `defaultPRReviewGoal` / `defaultIssueResponseSchema` / `defaultAskResponseSchema` / `defaultPRReviewResponseSchema` / `defaultAskOutputRules` / `defaultPRReviewOutputRules`). `issue.output_rules` defaults to empty — formatting rules live in the triage-issue skill's SKILL.md body template, not here.
 
 **Legacy alias**: the flat `prompt.goal` / `prompt.output_rules` fields are copied into `prompt.issue.*` at load time, but only if `prompt.issue.*` is empty. This keeps pre-v2.1 yaml valid; new configs should write `prompt.issue.*` directly.
 

--- a/docs/configuration-app.md
+++ b/docs/configuration-app.md
@@ -54,8 +54,12 @@ prompt:
   # 每個 workflow 各自一組 goal + response_schema + output_rules。留空就用內建預設。
   issue:
     goal: "Use the /triage-issue skill to investigate and produce a triage result."
-    response_schema: ""               # issue workflow 的輸出契約寫在 spec 裡，這裡通常留空
-    output_rules: []                  # 同上
+    response_schema: |
+      Your final response MUST end with ONE of these three shapes after ===TRIAGE_RESULT===:
+      CREATED  → {"status":"CREATED","title":"<required>","body":"...","labels":[...],"confidence":"high|medium","files_found":<int>,"open_questions":<int>}
+      REJECTED → {"status":"REJECTED","message":"..."}
+      ERROR    → {"status":"ERROR","message":"..."}
+    output_rules: []                  # 格式規則寫在 triage-issue skill 的 SKILL.md body template，不在這
   ask:
     goal: "Answer the user's question using the thread, and (if a codebase is attached) the repo. Follow the ask-assistant skill for scope, boundaries, and punt rules."
     response_schema: |
@@ -133,7 +137,7 @@ secrets:
 - `goal` 是給 agent 的**任務描述**——做什麼事、該呼叫哪個 skill（`triage-issue` / `ask-assistant` / `github-pr-review`）。不要在 goal 裡寫輸出格式。
 - `response_schema` 是**輸出契約**——機器可讀的 marker + JSON 結構（`===ASK_RESULT===` / `===REVIEW_RESULT===` 等）。此區塊在 prompt builder 裡**不會**被 XML escape，literal `"` 和 `<` 原樣送給 LLM，避免弱模型看到 `&quot;` 後把它複製成字面輸出導致 JSON parse 失敗。
 - `output_rules` 是**格式規則**——Slack mrkdwn 語法、字數限制、自稱 handle 等。會被 xml-escape 後 render 到 prompt 尾端。
-- 任何欄位留空都會由 `app/config/defaults.go` 的 `defaultIssueGoal` / `defaultAskGoal` / `defaultPRReviewGoal` / `defaultAskResponseSchema` / `defaultPRReviewResponseSchema` / `defaultAskOutputRules` / `defaultPRReviewOutputRules` 填上。`issue.response_schema` 和 `issue.output_rules` 預設為空——issue workflow 的硬規則寫在 `app/workflow/issue.go` 的 spec 裡。
+- 任何欄位留空都會由 `app/config/defaults.go` 的 `defaultIssueGoal` / `defaultAskGoal` / `defaultPRReviewGoal` / `defaultIssueResponseSchema` / `defaultAskResponseSchema` / `defaultPRReviewResponseSchema` / `defaultAskOutputRules` / `defaultPRReviewOutputRules` 填上。`issue.output_rules` 預設為空——格式規則走 `triage-issue` skill 的 SKILL.md body template，config 這層不重複。
 
 **Legacy alias**：`prompt.goal` / `prompt.output_rules`（扁平）在載入時會被拷到 `prompt.issue.*`（前提是 `prompt.issue.*` 還沒設）。這只是為了讓 v2.1 之前的 yaml 還能跑；新配置直接寫 `prompt.issue.*`。
 


### PR DESCRIPTION
## Summary

- Consistency pass on #130: all three workflows (issue / ask / pr_review) now ship with a default `ResponseSchema`.
- Lift Issue's output contract from the triage-issue skill into `defaultIssueResponseSchema` — three discriminated shapes (CREATED / REJECTED / ERROR) matching `TriageResult` in `app/workflow/issue_parser.go`.
- Old comment claiming \"Issue rules are hardcoded in issue.go spec\" was stale; the spec was actually implicit in the skill's SKILL.md. Now it's explicit in config and can be overridden.

## Why

After #130 merged, two of three workflows (ask, pr_review) let operators override the machine-readable output contract via `prompt.<workflow>.response_schema`. Issue silently kept its contract in the skill, which:
- Made the three workflow behaviors inconsistent.
- Left no knob for operators who want to tweak label values, add `confidence=critical`, etc., without editing the skill markdown.
- Broke the \"goal vs schema vs rules\" separation we just formalized.

This PR closes that gap.

## Scope

- `app/config/defaults.go`: new `defaultIssueResponseSchema`; applied when `Issue.ResponseSchema == \"\"`.
- `app/config/config_test.go`: asserts every `TriageResult` field appears verbatim in the default schema; asserts `Issue.Goal` doesn't embed the marker (regression guard mirroring the existing Ask/PRReview checks).
- `app/workflow/issue_test.go`: `Job.PromptContext.ResponseSchema` populated after ApplyDefaults.
- `docs/configuration-app.{md,en.md}`: example block for `issue.response_schema`; remove \"hardcoded in spec\" note.

No runtime behavior change for the triage-issue skill's SKILL.md body template — that still owns the markdown structure (Channel/Reporter/Problem/RCA/TDD/Acceptance). This PR only moves the machine-readable contract into config.

## Test plan

- [ ] CI: `go test ./...` green on shared/app/worker/root (local ✓)
- [ ] Trigger `@bot issue` against test channel; verify issue is still created with full body template
- [ ] Check worker debug log (`logs/YYYY-MM-DD.jsonl` → `Prompt XML 內容`) contains `<response_schema>` with `===TRIAGE_RESULT===` and the three shapes, rendered unescaped (literal `\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)