### PR TITLE
fix(queue): log XReadGroup failures + exponential backoff

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -119,7 +119,8 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 		}
-		bundle = queue.NewRedisBundle(rdb, jobStore, "triage")
+		bundle = queue.NewRedisBundle(rdb, jobStore, "triage",
+			queue.WithRedisJobQueueLogger(queueLogger))
 		appLogger.Info("已連線至 Redis", "phase", "處理中", "addr", cfg.Redis.Addr)
 
 		sk, err := crypto.DecodeSecretKey(cfg.SecretKey)

--- a/shared/queue/redis_bundle.go
+++ b/shared/queue/redis_bundle.go
@@ -2,10 +2,12 @@ package queue
 
 import "github.com/redis/go-redis/v9"
 
-// NewRedisBundle creates a Bundle backed by Redis.
-func NewRedisBundle(rdb *redis.Client, store JobStore, taskType string) *Bundle {
+// NewRedisBundle creates a Bundle backed by Redis. Options are forwarded to the
+// underlying RedisJobQueue so callers can wire a component-scoped logger for
+// receive-loop diagnostics without reaching past the bundle.
+func NewRedisBundle(rdb *redis.Client, store JobStore, taskType string, opts ...RedisJobQueueOption) *Bundle {
 	return &Bundle{
-		Queue:       NewRedisJobQueue(rdb, store, taskType),
+		Queue:       NewRedisJobQueue(rdb, store, taskType, opts...),
 		Results:     NewRedisResultBus(rdb),
 		Attachments: NewRedisAttachmentStore(rdb),
 		Commands:    NewRedisCommandBus(rdb),

--- a/shared/queue/redis_jobqueue.go
+++ b/shared/queue/redis_jobqueue.go
@@ -3,7 +3,9 @@ package queue
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -21,11 +23,29 @@ type RedisJobQueue struct {
 	consumerID string
 	stopCh     chan struct{}
 	seqCounter atomic.Uint64
+	logger     *slog.Logger
+}
+
+// RedisJobQueueOption configures optional behaviour on NewRedisJobQueue.
+type RedisJobQueueOption func(*RedisJobQueue)
+
+// WithRedisJobQueueLogger overrides the default logger (slog.Default) used for
+// receive-loop warnings. Callers should pass a component-scoped logger so
+// diagnostic output carries the Queue component tag.
+func WithRedisJobQueueLogger(l *slog.Logger) RedisJobQueueOption {
+	return func(q *RedisJobQueue) {
+		if l != nil {
+			q.logger = l
+		}
+	}
 }
 
 // NewRedisJobQueue creates a new Redis-backed job queue for the given task type.
-func NewRedisJobQueue(rdb *redis.Client, store JobStore, taskType string) *RedisJobQueue {
-	return &RedisJobQueue{
+// When no WithRedisJobQueueLogger option is supplied the default logger is
+// scoped to the Queue component so receive-loop warnings still carry the
+// conventional component tag in the fallback path.
+func NewRedisJobQueue(rdb *redis.Client, store JobStore, taskType string, opts ...RedisJobQueueOption) *RedisJobQueue {
+	q := &RedisJobQueue{
 		rdb:        rdb,
 		store:      store,
 		taskType:   taskType,
@@ -33,7 +53,12 @@ func NewRedisJobQueue(rdb *redis.Client, store JobStore, taskType string) *Redis
 		group:      "workers",
 		consumerID: fmt.Sprintf("worker-%d", time.Now().UnixNano()),
 		stopCh:     make(chan struct{}),
+		logger:     slog.Default().With("component", "Queue"),
 	}
+	for _, o := range opts {
+		o(q)
+	}
+	return q
 }
 
 // Submit adds a job to the Redis stream and stores it in the job store.
@@ -145,6 +170,10 @@ func (q *RedisJobQueue) Receive(ctx context.Context) (<-chan *Job, error) {
 	ch := make(chan *Job, 64)
 	go func() {
 		defer close(ch)
+		// consecutive counts non-redis.Nil XReadGroup failures in a row. Reset
+		// on any successful call (even empty) so transient blips don't ratchet
+		// backoff for the rest of the process's life.
+		consecutive := 0
 		for {
 			select {
 			case <-q.stopCh:
@@ -161,7 +190,14 @@ func (q *RedisJobQueue) Receive(ctx context.Context) (<-chan *Job, error) {
 			}).Result()
 			if err != nil {
 				if err == redis.Nil {
+					consecutive = 0
 					continue
+				}
+				// Only stopCh / parent ctx are shutdown signals here. Treat
+				// XReadGroup's own context.Canceled the same way — if the
+				// caller cancelled, we should stop.
+				if errors.Is(err, context.Canceled) {
+					return
 				}
 				select {
 				case <-q.stopCh:
@@ -169,9 +205,34 @@ func (q *RedisJobQueue) Receive(ctx context.Context) (<-chan *Job, error) {
 				case <-ctx.Done():
 					return
 				default:
-					continue
 				}
+				consecutive++
+				sleep := receiveBackoffDuration(consecutive)
+				// Warn on every failure — the previous silent `continue` is
+				// exactly what made a wedged consumer invisible in production.
+				// consecutive + sleep attrs let operators tell the difference
+				// between a one-off blip and a stuck loop without digging
+				// through timestamps.
+				q.logger.Warn("XReadGroup 失敗",
+					"phase", "失敗",
+					"stream", q.stream,
+					"consumer", q.consumerID,
+					"consecutive", consecutive,
+					"sleep_ms", sleep.Milliseconds(),
+					"error", err,
+				)
+				if sleep > 0 {
+					select {
+					case <-time.After(sleep):
+					case <-q.stopCh:
+						return
+					case <-ctx.Done():
+						return
+					}
+				}
+				continue
 			}
+			consecutive = 0
 
 			for _, stream := range streams {
 				for _, msg := range stream.Messages {
@@ -203,6 +264,33 @@ func (q *RedisJobQueue) Receive(ctx context.Context) (<-chan *Job, error) {
 	}()
 
 	return ch, nil
+}
+
+// receiveBackoffDuration returns the sleep between consecutive XReadGroup
+// failures in the Receive loop. The curve doubles every failure starting at
+// 1 second and caps at 30 seconds (reached at n=6). Kept deterministic — no
+// jitter — because a single consumer group has only one live worker at a time
+// and jitter would just make the logs harder to eyeball.
+//
+// n is the 1-based count of failures since the last successful (or empty)
+// XReadGroup. n<=0 returns 0 so the caller doesn't need its own guard.
+func receiveBackoffDuration(n int) time.Duration {
+	const (
+		base = 1 * time.Second
+		max  = 30 * time.Second
+	)
+	if n <= 0 {
+		return 0
+	}
+	// Guard against shift overflow: anything past 6 is already at the cap.
+	if n >= 6 {
+		return max
+	}
+	d := base * (1 << (n - 1))
+	if d > max {
+		return max
+	}
+	return d
 }
 
 // Ack acknowledges a job by updating its status and acking all pending

--- a/shared/queue/redis_jobqueue_backoff_test.go
+++ b/shared/queue/redis_jobqueue_backoff_test.go
@@ -1,0 +1,37 @@
+package queue
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReceiveBackoffDuration pins the escalation curve used by RedisJobQueue.Receive
+// when XReadGroup returns a non-nil, non-redis.Nil error. Keeping this deterministic
+// (no jitter) means production logs can be read alongside these values to verify the
+// loop is actually backing off as designed.
+func TestReceiveBackoffDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+		want time.Duration
+	}{
+		{"non-positive returns zero", 0, 0},
+		{"negative returns zero", -3, 0},
+		{"first error", 1, 1 * time.Second},
+		{"second error doubles", 2, 2 * time.Second},
+		{"third error doubles", 3, 4 * time.Second},
+		{"fourth error doubles", 4, 8 * time.Second},
+		{"fifth error doubles", 5, 16 * time.Second},
+		{"sixth error caps at max", 6, 30 * time.Second},
+		{"tenth error still capped", 10, 30 * time.Second},
+		{"huge count stays capped", 1_000_000, 30 * time.Second},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := receiveBackoffDuration(c.n)
+			if got != c.want {
+				t.Errorf("receiveBackoffDuration(%d) = %v, want %v", c.n, got, c.want)
+			}
+		})
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -52,7 +52,9 @@ func Run(cfg *config.Config) error {
 			return fmt.Errorf("failed to connect to Redis: %w", err)
 		}
 		appLogger.Info("已連線至 Redis", "phase", "處理中", "addr", cfg.Redis.Addr)
-		bundle = queue.NewRedisBundle(rdb, jobStore, "triage")
+		queueLogger := logging.ComponentLogger(slog.Default(), logging.CompQueue)
+		bundle = queue.NewRedisBundle(rdb, jobStore, "triage",
+			queue.WithRedisJobQueueLogger(queueLogger))
 	default:
 		return fmt.Errorf("unsupported queue.transport %q (supported: redis)", cfg.Queue.Transport)
 	}


### PR DESCRIPTION
## Summary

- **Root fix**: the Redis `Receive` goroutine silently `continue`'d past every XReadGroup error other than `redis.Nil`. That's what made today's wedged-consumer incident invisible — heartbeat kept ticking on a different goroutine so the worker looked idle in `/jobs` while the job sat in the stream forever, with zero log output to point at a cause.
- Injects a component-scoped `*slog.Logger` into `RedisJobQueue` via a new `WithRedisJobQueueLogger` option (threaded through `NewRedisBundle` too). App and worker entry points wire their existing `queueLogger` / new `CompQueue` logger in.
- On non-`redis.Nil` / non-`context.Canceled` errors, logs a WARN with `stream`, `consumer`, `consecutive`, `sleep_ms`, and the error. Then sleeps a deterministic exponential backoff (1s → 30s, cap reached at n=6) before the next XReadGroup, so a persistent error doesn't flood logs.
- Goroutine lifecycle unchanged: `stopCh` and `context.Canceled` still exit; any other error keeps looping so transient blips self-heal.

## Not in this PR (intentionally)

- **PEL recovery** (`XReadGroup('0')` / `XAutoClaim`): the leading theory for today's wedge is a delivery-without-ack race, but we don't have log evidence yet. Ship observability first, read the logs next time this happens, then decide the right recovery primitive.
- **Supervisor-style receive-goroutine restart**: bigger behaviour change; needs a clear trigger condition (e.g. N consecutive errors) that the above logging will help calibrate.

## Test plan

- [x] `go test ./...` clean at repo root (build tag / import direction)
- [x] `go test ./queue/...` clean in `shared/`
- [x] `TestReceiveBackoffDuration` pins the 1s→30s curve across n = -3, 0, 1..6, 10, 1_000_000
- [x] Existing `TestRedisJobQueue_*` still pass — happy-path dispatch unchanged
- [ ] Manual k8s canary: break the worker's Redis connection (e.g. `NetworkPolicy` cut, or bounce Redis) and confirm `XReadGroup 失敗` lines appear with increasing `consecutive` and `sleep_ms` capping at 30000

🤖 Generated with [Claude Code](https://claude.com/claude-code)