### PR TITLE
fix(docker): symlink /agentdock into /usr/local/bin so PATH lookups resolve

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -33,6 +33,12 @@ RUN mkdir -p /data/repos && chown node:node /data/repos
 # COPY preserves the 0755 mode Go's linker writes; no chmod needed.
 COPY agentdock /agentdock
 
+# Symlink so child processes spawned by ENTRYPOINT (e.g. opencode → bash →
+# `agentdock pr-review-helper`) can resolve the binary via PATH lookup.
+# /agentdock alone works for ENTRYPOINT since the path is absolute, but
+# spawned tooling that runs `agentdock <subcommand>` would fail: not found.
+RUN ln -s /agentdock /usr/local/bin/agentdock
+
 USER node
 # Runtime picks the subcommand (app / worker / init). Pass e.g.:
 #   docker run ... agentdock:X app -c /etc/agentdock/config.yaml


### PR DESCRIPTION
## Summary

Worker container's `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` does NOT include `/`, where `agentdock` binary is COPY'd to. `ENTRYPOINT ["/agentdock"]` works (absolute path), but child processes spawned by `/agentdock` — e.g. opencode → bash running `agentdock pr-review-helper` from the github-pr-review skill — get `/bin/sh: agentdock: not found`.

Symlinking `/agentdock` into `/usr/local/bin/agentdock` (a one-line `RUN ln -s ...`) unblocks any spawned tooling that does PATH lookup.

## Why now

Confirmed in production worker pod 2026-04-23. PR Review on PR #130 ran the github-pr-review skill end-to-end:

1. opencode loaded `.opencode/skills/github-pr-review/SKILL.md` (after `tool: skill` failed with `RipgrepExtractionFailedError`, agent fell back to `read`)
2. tried `agentdock pr-review-helper fingerprint --pr-url ...` → **`/bin/sh: agentdock: not found`**
3. tried `cd cmd/agentdock && go build` → **`go: not found`** (no Go compiler in container by design)
4. used `gh api` to fetch the PR diff, manually analysed the changes, wrote a review JSON to `/tmp/pr_review.json`
5. couldn't pipe through `agentdock pr-review-helper validate-and-post` (binary still missing), never emitted `===REVIEW_RESULT===` marker
6. App's `pr_review_parser` saw no marker → Slack showed `:x: Review 失敗：parse error`

The skill explicitly documents the binary-on-PATH precondition at `agents/skills/github-pr-review/SKILL.md:22` ("The helper `agentdock pr-review-helper` is on PATH (it is this worker's binary)"). The Dockerfile contradicts that.

## Test Plan

- [ ] CI: GoReleaser builds the image; image build succeeds with the new `RUN` step
- [ ] After deploy: `kubectl exec <worker-pod> -- which agentdock` returns `/usr/local/bin/agentdock`
- [ ] After deploy: re-trigger PR Review on PR #130 (or any other open PR), expect:
  - Slack shows `Review 完成` (or honest `Review 跳過` for purely-doc PRs)
  - PR receives a `COMMENT`-event review with line-level comments
  - Worker pod log shows `Agent 執行成功` followed by the result marker being parsed (no `parse failed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)