### PR TITLE
fix(workflow): guard against empty-repo race in selector click + back

### DIFF
--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -159,10 +159,25 @@ var dSelectorLabel = map[string]string{
 // pending; NextStepPostSelector re-keys it under a new selectorTS inside
 // executeStep via storePending.
 func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, triggerID string) {
+	// Atomically claim the pending — look up and remove in one critical
+	// section so two rapid clicks on the same selector can't both get the
+	// same pointer. The second click observes an empty map entry and
+	// silently drops. NextStepOpenModal re-stores the pending under a fresh
+	// key inside executeStep (via storePending).
 	w.mu.Lock()
 	pending, ok := w.pending[selectorMsgTS]
+	if ok {
+		delete(w.pending, selectorMsgTS)
+	}
 	w.mu.Unlock()
 	if !ok {
+		return
+	}
+
+	// Invalidated pendings (e.g. back-to-repo fired first) must not advance
+	// state. Ack the user so they know the button is dead.
+	if pending.IsInvalidated() {
+		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":information_source: 此選單已失效，請使用新的選單")
 		return
 	}
 
@@ -180,15 +195,7 @@ func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, tr
 	step, err := w.dispatcher.HandleSelection(ctx, pending, value)
 	if err != nil {
 		w.logger.Error("HandleSelection dispatch failed", "phase", "失敗", "error", err)
-		w.mu.Lock()
-		delete(w.pending, selectorMsgTS)
-		w.mu.Unlock()
 		return
-	}
-	if step.Kind != workflow.NextStepOpenModal {
-		w.mu.Lock()
-		delete(w.pending, selectorMsgTS)
-		w.mu.Unlock()
 	}
 	w.executeStep(ctx, pending, step, triggerID)
 }
@@ -261,21 +268,55 @@ func (w *Workflow) HandleBackToRepo(channelID, selectorMsgTS string) {
 	pending, ok := w.pending[selectorMsgTS]
 	if ok {
 		delete(w.pending, selectorMsgTS)
+		// Invalidate the current pending generation so any in-flight repo
+		// preparation (slow clone + branch enumerate) that's still racing
+		// towards a PostSelector/storePending will observe this flag and
+		// early-return instead of posting an orphan branch selector the
+		// user has already navigated away from.
+		pending.Invalidate()
 	}
 	w.mu.Unlock()
 	if !ok {
 		return
 	}
 
+	// HandleBackToRepo starts a fresh generation. Use a brand-new Pending
+	// so the dispatcher's re-dispatch (repo picker / external search) can't
+	// collide with the invalidated one.
+	fresh := &workflow.Pending{
+		ChannelID:   pending.ChannelID,
+		ThreadTS:    pending.ThreadTS,
+		TriggerTS:   pending.TriggerTS,
+		UserID:      pending.UserID,
+		Reporter:    pending.Reporter,
+		ChannelName: pending.ChannelName,
+		RequestID:   pending.RequestID,
+		TaskType:    pending.TaskType,
+	}
+	// Re-seed State by delegating to the owning workflow via back_to_repo
+	// value. We still pass the (invalidated) old pending to HandleSelection
+	// because IssueWorkflow.handleBackToRepo operates on its State to clear
+	// SelectedRepo/Branch/ExtraDesc. But what storePending below sees must be
+	// the fresh pending — which the dispatcher's NextStep carries via
+	// step.Pending only when the workflow decides to. Fall back to fresh
+	// when the step's Pending is the same (invalidated) pointer.
 	ctx := context.Background()
 	step, err := w.dispatcher.HandleSelection(ctx, pending, "back_to_repo")
 	if err != nil {
 		w.logger.Error("HandleBackToRepo dispatch failed", "phase", "失敗", "error", err)
 		return
 	}
+	// If the workflow returned the same invalidated pending, substitute the
+	// fresh one so subsequent store paths don't hit the invalidation guard.
+	if step.Pending == pending {
+		// Copy over State (workflow mutated it) onto fresh.
+		fresh.State = pending.State
+		fresh.Phase = pending.Phase
+		step.Pending = fresh
+	}
 	// Update old selector to show we navigated back.
 	_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":leftwards_arrow_with_hook: 已返回 repo 選擇")
-	w.executeStep(ctx, pending, step, "")
+	w.executeStep(ctx, fresh, step, "")
 }
 
 // executeStep applies a NextStep from a workflow: posts a selector, opens a
@@ -293,6 +334,18 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 	}
 	if pending == nil {
 		return
+	}
+	// Invalidated pending — any post/store/advance path must early-return.
+	// Error/Noop/Cancel still render their Slack surface area, but selectors
+	// and modals must not re-attach stale state to new message TSes.
+	if pending.IsInvalidated() {
+		switch step.Kind {
+		case workflow.NextStepPostSelector,
+			workflow.NextStepPostExternalSelector,
+			workflow.NextStepOpenModal,
+			workflow.NextStepSubmit:
+			return
+		}
 	}
 	switch step.Kind {
 	case workflow.NextStepPostSelector:
@@ -459,7 +512,14 @@ func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
 
 // storePending registers a pending workflow state under selectorTS and starts
 // a goroutine that evicts the entry after pendingTimeout.
+//
+// Invalidated pendings are refused — a late in-flight repo-prep goroutine
+// that finishes after back-to-repo would otherwise post an orphan selector
+// and re-attach the user's old (stale) state to a fresh TS.
 func (w *Workflow) storePending(selectorTS string, p *workflow.Pending) {
+	if p.IsInvalidated() {
+		return
+	}
 	p.SelectorTS = selectorTS
 	w.mu.Lock()
 	w.pending[selectorTS] = p

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -494,3 +494,182 @@ func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
 		}
 	}
 }
+
+// ── RED/GREEN #1: in-flight dedup for rapid repeated clicks ─────────────────
+//
+// Two rapid clicks on the same selector TS must yield only one dispatched
+// Selection — the second click finds no pending in the map and no-ops. Without
+// the fix, both clicks share the same *Pending pointer and race on its State.
+func TestHandleSelection_RapidDoubleClick_DispatchesOnce(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{"C1": {}}}
+	reg := workflow.NewRegistry()
+	counter := &countingWorkflow{}
+	reg.Register(counter)
+	disp := workflow.NewDispatcher(reg, sl, slog.Default())
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	const selectorTS = "sel-dup"
+	p := &workflow.Pending{
+		ChannelID:  "C1",
+		ThreadTS:   "T1",
+		TaskType:   "count",
+		Phase:      "repo",
+		SelectorTS: selectorTS,
+	}
+	wf.mu.Lock()
+	wf.pending[selectorTS] = p
+	wf.mu.Unlock()
+
+	// Fire two clicks back-to-back. Since the test drives them serially,
+	// the first click atomically removes the pending; the second must miss.
+	wf.HandleSelection("C1", "repo_select", "owner/A", selectorTS, "")
+	wf.HandleSelection("C1", "repo_select", "owner/B", selectorTS, "")
+
+	if got := counter.selectionCalls(); got != 1 {
+		t.Errorf("Selection called %d times, want 1 (second click must find no pending)", got)
+	}
+}
+
+// ── RED/GREEN #2: back-to-repo invalidates the pending so late selectors no-op.
+//
+// After HandleBackToRepo, any still-in-flight executeStep that tries to
+// PostSelector + storePending for the OLD pending must early-return — no
+// Slack post, no new map entry. We drive this by invalidating the pending
+// and feeding a PostSelector NextStep through executeStep.
+func TestExecuteStep_InvalidatedPending_DoesNotPostSelector(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	p.Invalidate()
+
+	step := workflow.NextStep{
+		Kind:           workflow.NextStepPostSelector,
+		SelectorPrompt: "Which branch?",
+		SelectorActions: []workflow.SelectorAction{
+			{ActionID: "branch_select", Label: "main", Value: "main"},
+		},
+		Pending: p,
+	}
+	wf.executeStep(context.Background(), p, step, "")
+
+	// No pending should have been stored.
+	wf.mu.Lock()
+	n := len(wf.pending)
+	wf.mu.Unlock()
+	if n != 0 {
+		t.Errorf("pending map size = %d, want 0 (invalidated pending must not be stored)", n)
+	}
+}
+
+// ── RED/GREEN #3: invalidated pending must not submit jobs either. ──────────
+func TestExecuteStep_InvalidatedPending_DoesNotSubmit(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	called := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) { called = true })
+
+	p := &workflow.Pending{ChannelID: "C1", ThreadTS: "T1", TaskType: "issue"}
+	p.Invalidate()
+	step := workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+	wf.executeStep(context.Background(), p, step, "")
+
+	if called {
+		t.Error("onSubmit must not fire for invalidated pending")
+	}
+}
+
+// HandleBackToRepo: must invalidate the old pending and NOT carry the
+// invalidated pointer into the re-dispatched step. Any subsequent Selection
+// click on the OLD selectorTS is a no-op (entry removed + pending invalidated).
+func TestHandleBackToRepo_InvalidatesOldPending(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{
+		Channels:        map[string]config.ChannelConfig{"C1": {Repos: []string{"owner/A", "owner/B"}}},
+		ChannelDefaults: config.ChannelConfig{},
+	}
+	reg := workflow.NewRegistry()
+	// Use the real IssueWorkflow — it implements handleBackToRepo correctly.
+	issueWf := workflow.NewIssueWorkflow(cfg, sl, nil, nil, nil, slog.Default())
+	reg.Register(issueWf)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	// Seed a pending on a branch selector.
+	const selectorTS = "sel-old"
+	oldPending := &workflow.Pending{
+		ChannelID:   "C1",
+		ThreadTS:    "T1",
+		TaskType:    "issue",
+		Phase:       "branch",
+		SelectorTS:  selectorTS,
+		RequestID:   "req-1",
+		ChannelName: "C1",
+		Reporter:    "U1",
+	}
+	// The issue workflow expects its own state struct; build one with a
+	// picked repo so back-to-repo is a valid transition.
+	// The concrete state struct is unexported; we drive back-to-repo via a
+	// minimal surrogate by calling the shim handler and asserting map/flag
+	// effects only.
+	wf.mu.Lock()
+	wf.pending[selectorTS] = oldPending
+	wf.mu.Unlock()
+
+	wf.HandleBackToRepo("C1", selectorTS)
+
+	// The old pending must be marked invalidated.
+	if !oldPending.IsInvalidated() {
+		t.Error("expected old pending to be invalidated after HandleBackToRepo")
+	}
+
+	// The old selectorTS entry must be gone.
+	wf.mu.Lock()
+	_, stillThere := wf.pending[selectorTS]
+	wf.mu.Unlock()
+	if stillThere {
+		t.Errorf("old selectorTS %q still in pending map", selectorTS)
+	}
+
+	// A click on the invalidated selectorTS after back is a no-op.
+	wf.HandleSelection("C1", "branch_select", "main", selectorTS, "")
+	// (No panic, no submit — nothing to assert besides non-crash.)
+}
+
+// countingWorkflow records Selection invocations so we can assert dedup.
+type countingWorkflow struct {
+	mu        sync.Mutex
+	selection int
+}
+
+func (f *countingWorkflow) Type() string { return "count" }
+func (f *countingWorkflow) Trigger(ctx context.Context, ev workflow.TriggerEvent, args string) (workflow.NextStep, error) {
+	return workflow.NextStep{Kind: workflow.NextStepNoop}, nil
+}
+func (f *countingWorkflow) Selection(ctx context.Context, p *workflow.Pending, value string) (workflow.NextStep, error) {
+	f.mu.Lock()
+	f.selection++
+	f.mu.Unlock()
+	return workflow.NextStep{Kind: workflow.NextStepNoop, Pending: p}, nil
+}
+func (f *countingWorkflow) BuildJob(ctx context.Context, p *workflow.Pending) (*queue.Job, string, error) {
+	return &queue.Job{TaskType: "count"}, "status", nil
+}
+func (f *countingWorkflow) HandleResult(ctx context.Context, s *queue.JobState, r *queue.JobResult) error {
+	return nil
+}
+func (f *countingWorkflow) selectionCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.selection
+}

--- a/app/workflow/issue.go
+++ b/app/workflow/issue.go
@@ -202,6 +202,16 @@ func (w *IssueWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, s
 		return nil, "", fmt.Errorf("IssueWorkflow.BuildJob: unexpected state type")
 	}
 
+	// Guard against empty repo — the state-machine race (selector click on a
+	// late-arriving orphan branch selector after back-to-repo) can leave
+	// SelectedRepo blank while SelectedBranch is set. Refusing here means
+	// app.submitJob's BuildJob-err branch posts ":x: internal state error" and
+	// clears dedup, instead of shipping `CloneURL=https://github.com/.git` to
+	// the worker. Matching language used in worker guard: "empty repo reference".
+	if strings.TrimSpace(st.SelectedRepo) == "" {
+		return nil, "", fmt.Errorf("empty repo reference: 內部狀態錯誤，請重試 /triage")
+	}
+
 	reqID := p.RequestID
 	if reqID == "" {
 		reqID = logging.NewRequestID()

--- a/app/workflow/issue_test.go
+++ b/app/workflow/issue_test.go
@@ -380,6 +380,54 @@ func TestIssueWorkflow_HandleResult_FallsBackToStateWorkerID(t *testing.T) {
 	}
 }
 
+// ── RED/GREEN #4: BuildJob guards against empty repo ───────────────────────
+//
+// When the state-machine race leaves SelectedRepo blank (e.g. back-to-repo
+// after orphan branch click), BuildJob must refuse instead of letting a job
+// with CloneURL=https://github.com/.git reach the worker.
+func TestIssueWorkflow_BuildJob_RejectsEmptyRepo(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t)
+	p := &Pending{
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		TaskType:  "issue",
+		State: &issueState{
+			SelectedRepo:   "",     // empty — the race outcome
+			SelectedBranch: "main", // non-empty branch makes the failure mode realistic
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err == nil {
+		t.Fatal("BuildJob: expected error for empty SelectedRepo, got nil")
+	}
+	if job != nil {
+		t.Errorf("BuildJob: job should be nil on error, got %+v", job)
+	}
+	if !strings.Contains(err.Error(), "empty repo") {
+		t.Errorf("error should mention empty repo, got %q", err.Error())
+	}
+}
+
+func TestIssueWorkflow_BuildJob_AcceptsNonEmptyRepo(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t)
+	p := &Pending{
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		TaskType:  "issue",
+		State: &issueState{
+			SelectedRepo:   "owner/repo",
+			SelectedBranch: "main",
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatalf("BuildJob: unexpected error: %v", err)
+	}
+	if job == nil || job.Repo != "owner/repo" {
+		t.Errorf("BuildJob: want Repo=owner/repo, got %+v", job)
+	}
+}
+
 // ── test helpers ─────────────────────────────────────────────────────────────
 
 type issueOpt func(*config.Config)

--- a/app/workflow/pr_review.go
+++ b/app/workflow/pr_review.go
@@ -244,6 +244,13 @@ func (w *PRReviewWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job
 		return nil, "", fmt.Errorf("PRReviewWorkflow.BuildJob: unexpected state type")
 	}
 
+	// Guard against empty head repo — if state is missing the PR head repo
+	// (malformed flow or race), refuse rather than build a job with
+	// CloneURL=https://github.com/.git.
+	if strings.TrimSpace(st.HeadRepo) == "" {
+		return nil, "", fmt.Errorf("empty repo reference: 內部狀態錯誤，請重試 /triage")
+	}
+
 	reqID := p.RequestID
 	if reqID == "" {
 		reqID = logging.NewRequestID()

--- a/app/workflow/pr_review_test.go
+++ b/app/workflow/pr_review_test.go
@@ -260,6 +260,34 @@ func TestPRReviewWorkflow_ValidateAndBuild_PopulatesHeadSHA(t *testing.T) {
 	}
 }
 
+// ── RED/GREEN #4: PR Review BuildJob rejects empty head repo. ──────────────
+func TestPRReviewWorkflow_BuildJob_RejectsEmptyHeadRepo(t *testing.T) {
+	w, _ := newTestPRReviewWorkflow(t)
+	p := &Pending{
+		ChannelID: "C1",
+		ThreadTS:  "T1",
+		TaskType:  "pr_review",
+		State: &prReviewState{
+			URL:      "https://github.com/foo/bar/pull/7",
+			Owner:    "foo",
+			Repo:     "bar",
+			Number:   7,
+			HeadRepo: "", // empty — refuse
+			HeadSHA:  "abc",
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err == nil {
+		t.Fatal("BuildJob: expected error for empty HeadRepo, got nil")
+	}
+	if job != nil {
+		t.Errorf("BuildJob: expected nil job on error, got %+v", job)
+	}
+	if !strings.Contains(err.Error(), "empty repo") {
+		t.Errorf("error should mention empty repo, got %q", err.Error())
+	}
+}
+
 func newTestPRReviewWorkflow(t *testing.T) (*PRReviewWorkflow, *fakeSlackPort) {
 	t.Helper()
 	cfg := &config.Config{}

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -40,6 +40,29 @@ type Pending struct {
 	TaskType    string // workflow identity, equal to Workflow.Type()
 	State       any    // per-workflow state struct
 	BusyHint    string // populated by bot.Workflow.submit() when verdict is BusyEnqueueOK; app.submitJob appends to statusText
+
+	// Invalidated marks this pending as no longer usable. Set by the shim
+	// when the user presses back-to-repo; any in-flight selector / store /
+	// advance path that observes Invalidated == true must early-return instead
+	// of posting new UI or advancing state. This closes the race where a late
+	// repo-prep goroutine posts an orphan branch selector under a pending the
+	// user has already abandoned.
+	Invalidated bool
+}
+
+// Invalidate marks the pending unusable. Safe to call multiple times.
+// Callers should hold the shim's pending-map lock when setting this so
+// concurrent lookups observe a consistent flag.
+func (p *Pending) Invalidate() {
+	if p == nil {
+		return
+	}
+	p.Invalidated = true
+}
+
+// IsInvalidated reports whether this pending has been invalidated.
+func (p *Pending) IsInvalidated() bool {
+	return p != nil && p.Invalidated
 }
 
 // NextStepKind enumerates the actions a workflow's Trigger/Selection can

--- a/worker/pool/executor.go
+++ b/worker/pool/executor.go
@@ -91,6 +91,16 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 	if err := ctx.Err(); err != nil {
 		return classifyResult(job, startedAt, err, "", ctx, deps.store)
 	}
+	// Guard against empty repo reference: if the job needs a clone (CloneURL
+	// is set) but carries no real repo identity, refuse up-front instead of
+	// asking git to clone "https://github.com/.git". cleanCloneURL on the
+	// app side normalises empty owner/repo strings into that URL, so the
+	// worker must catch both shapes — the raw empty string AND the
+	// github-prefixed placeholder — to produce a clear error message.
+	if isEmptyRepoReference(job) {
+		logger.Error("Repo 準備失敗", "phase", "失敗", "error", "empty repo reference")
+		return failedResult(job, startedAt, fmt.Errorf("empty repo reference: job has no usable repo/clone_url"), "")
+	}
 	provider := selectProvider(job, deps.repoCache, ghToken)
 	repoPath, err := provider.Prepare(job)
 	if err != nil {
@@ -191,6 +201,32 @@ func writeAttachments(attachments []queue.AttachmentReady, dir string) ([]prompt
 		})
 	}
 	return infos, nil
+}
+
+// isEmptyRepoReference returns true when the job wants a repo clone but no
+// real repo is addressable. Two shapes matter:
+//  1. CloneURL is blank string — selectProvider picks EmptyDirProvider so this
+//     path is fine (Ask-style no-repo). We must not flag it.
+//  2. CloneURL is set but Repo is empty or whitespace — the app-side state
+//     machine fell through to cleanCloneURL("") which yields the placeholder
+//     "https://github.com/.git". Either the placeholder exactly, or a
+//     non-empty CloneURL paired with an empty Repo, is a sign of the race.
+func isEmptyRepoReference(job *queue.Job) bool {
+	if job == nil {
+		return false
+	}
+	cloneURL := strings.TrimSpace(job.CloneURL)
+	if cloneURL == "" {
+		// No clone needed — EmptyDirProvider path.
+		return false
+	}
+	if cloneURL == "https://github.com/.git" {
+		return true
+	}
+	if strings.TrimSpace(job.Repo) == "" {
+		return true
+	}
+	return false
 }
 
 func classifyResult(job *queue.Job, startedAt time.Time, err error, repoPath string, ctx context.Context, store queue.JobStore) *queue.JobResult {

--- a/worker/pool/executor_test.go
+++ b/worker/pool/executor_test.go
@@ -132,6 +132,109 @@ func TestExecuteJob_NilPromptContextFailsMalformed(t *testing.T) {
 	}
 }
 
+// ── RED/GREEN #5: empty repo reference → fail before git clone. ────────────
+//
+// When the app-side state-machine race leaves Job.Repo="" and CloneURL as the
+// placeholder "https://github.com/.git" (cleanCloneURL("") output), the
+// worker must refuse before invoking Prepare rather than asking git to clone
+// a nonsense URL.
+func TestExecuteJob_EmptyRepoPlaceholderCloneURL_FailsBeforeClone(t *testing.T) {
+	store := queue.NewMemJobStore()
+	job := &queue.Job{
+		ID:            "jempty1",
+		Repo:          "",
+		CloneURL:      "https://github.com/.git",
+		Branch:        "master",
+		PromptContext: &queue.PromptContext{},
+	}
+	store.Put(job)
+
+	prepareCalled := false
+	deps := executionDeps{
+		attachments: queuetest.NewAttachmentStore(),
+		repoCache: &mockRepo{
+			path:        "/tmp/r",
+			prepareHook: func() { prepareCalled = true },
+		},
+		runner: &mockRunner{},
+		store:  store,
+	}
+
+	result := executeJob(context.Background(), job, deps, agent.RunOptions{}, slog.Default())
+
+	if prepareCalled {
+		t.Error("Prepare must not run for empty-repo placeholder CloneURL")
+	}
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "empty repo reference") {
+		t.Errorf("error should mention empty repo reference, got %q", result.Error)
+	}
+}
+
+func TestExecuteJob_EmptyRepoStringWithNonEmptyCloneURL_FailsBeforeClone(t *testing.T) {
+	// Edge case: CloneURL is some URL but Repo is blank — still a race
+	// symptom, still refuse.
+	store := queue.NewMemJobStore()
+	job := &queue.Job{
+		ID:            "jempty2",
+		Repo:          "",
+		CloneURL:      "https://github.com/something.git",
+		Branch:        "master",
+		PromptContext: &queue.PromptContext{},
+	}
+	store.Put(job)
+
+	prepareCalled := false
+	deps := executionDeps{
+		attachments: queuetest.NewAttachmentStore(),
+		repoCache: &mockRepo{
+			path:        "/tmp/r",
+			prepareHook: func() { prepareCalled = true },
+		},
+		runner: &mockRunner{},
+		store:  store,
+	}
+
+	result := executeJob(context.Background(), job, deps, agent.RunOptions{}, slog.Default())
+
+	if prepareCalled {
+		t.Error("Prepare must not run when Repo is empty but CloneURL is set")
+	}
+	if result.Status != "failed" {
+		t.Errorf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "empty repo reference") {
+		t.Errorf("error should mention empty repo reference, got %q", result.Error)
+	}
+}
+
+func TestExecuteJob_EmptyCloneURLIsAskPath_NotFlaggedEmpty(t *testing.T) {
+	// Ask-with-no-repo: CloneURL is "" and EmptyDirProvider handles it. The
+	// empty-repo guard must NOT fire here — otherwise every Ask job breaks.
+	store := queue.NewMemJobStore()
+	job := &queue.Job{
+		ID:            "jask",
+		Repo:          "",
+		CloneURL:      "",
+		PromptContext: &queue.PromptContext{},
+	}
+	store.Put(job)
+
+	deps := executionDeps{
+		attachments: queuetest.NewAttachmentStore(),
+		repoCache:   &mockRepo{path: "/tmp/r"},
+		runner:      &mockRunner{output: "ok"},
+		store:       store,
+	}
+
+	result := executeJob(context.Background(), job, deps, agent.RunOptions{}, slog.Default())
+	if result.Status == "failed" && strings.Contains(result.Error, "empty repo reference") {
+		t.Error("Ask-style empty CloneURL must not be flagged as empty repo reference")
+	}
+}
+
 // Scenario B-race — Pre-Prepare ctx guard: store set to JobCancelled before Prepare runs
 // → Prepare is not invoked and the result is cancelled.
 func TestExecuteJob_PrePrepareGuardSkipsClone(t *testing.T) {

--- a/worker/pool/pool_test.go
+++ b/worker/pool/pool_test.go
@@ -257,6 +257,7 @@ func TestExecuteJob_DecryptsAndMergesSecrets(t *testing.T) {
 
 	job := &queue.Job{
 		ID:               "test-job",
+		Repo:             "owner/repo",
 		CloneURL:         "https://github.com/owner/repo.git",
 		EncryptedSecrets: encrypted,
 		PromptContext: &queue.PromptContext{
@@ -294,6 +295,7 @@ func TestExecuteJob_NoSecretKey_EncryptedSecrets_Fails(t *testing.T) {
 
 	job := &queue.Job{
 		ID:               "test-job",
+		Repo:             "owner/repo",
 		CloneURL:         "https://github.com/owner/repo.git",
 		EncryptedSecrets: []byte("some-encrypted-data"),
 	}


### PR DESCRIPTION
#### What type of PR is this?

Bug fix — state-machine race condition in Slack workflow dispatch.

#### What this PR does / why we need it:

Fixes a race in the `repo_search` → back-to-repo flow that caused jobs to
reach the worker with `Repo=""` and `CloneURL="https://github.com/.git"`,
which then failed as `git clone failed: exit status 128`.

The user-visible reproduction: rapidly pick two repos in the external
repo search dropdown, press back-to-repo on the first branch selector
that appears, then click whichever branch selector arrives late, skip
the description → worker crashes on a bogus clone.

Four layers of defense, each independently prevents the crash but all
four land here because each addresses a distinct root cause:

1. **Pending generation / invalidation.** `Pending` gains
   `Invalidated` + `Invalidate()` / `IsInvalidated()`. `HandleBackToRepo`
   invalidates the abandoned pending; `storePending` and `executeStep`
   early-return on Post/Submit/OpenModal paths when the pending is
   invalidated, so a late repo-prep goroutine can't post an orphan
   selector or re-attach stale state to a new TS.
2. **In-flight dedup on selector clicks.** `HandleSelection` now
   atomically looks up AND removes the pending entry in one critical
   section, so a second rapid click on the same selectorTS finds
   nothing and silently drops instead of sharing the pointer.
3. **BuildJob guards.** `IssueWorkflow.BuildJob` and
   `PRReviewWorkflow.BuildJob` refuse when `SelectedRepo` /
   `HeadRepo` is empty and return a clear error; `app.submitJob`'s
   existing err branch posts `:x: internal state error` and clears
   dedup instead of enqueuing the job.
4. **Worker-side guard.** `executeJob` detects empty repo references
   (`CloneURL` blank → OK, it's the Ask path; `CloneURL =
   https://github.com/.git` OR `Repo == ""` with non-blank `CloneURL`
   → fail with `empty repo reference`). `Prepare` is not invoked,
   so `git clone` never runs.

#### Which issue(s) this PR fixes:

Closes #137

#### Special notes for your reviewer:

- Scope intentionally excludes the #6 end-to-end integration test from
  the issue plan — too heavy for this PR. The four unit/behaviour test
  files below cover the state transitions individually.
- `cleanCloneURL` is deliberately unchanged (other callers depend on
  its exact output shape). The guard catches the placeholder URL on
  the worker side instead.
- `RepoProvider.Prepare` interface is unchanged.
- `HandleBackToRepo` now constructs a fresh `Pending` envelope and, if
  the workflow's `back_to_repo` handler returns the old (now
  invalidated) pointer via `step.Pending`, substitutes the fresh one so
  subsequent `storePending` isn't blocked by the invalidation guard.
  The fresh envelope copies over the workflow's mutated `State` /
  `Phase` so the repo picker that just got re-posted behaves as before.
- Two pre-existing `pool_test.go` tests needed `Repo: "owner/repo"`
  added alongside their `CloneURL` to satisfy the new worker guard.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., user guides, godoc, design proposals:

```docs
N/A
```

#### Test plan:

Added tests (all passing):
- `app/bot/workflow_test.go`:
  - `TestHandleSelection_RapidDoubleClick_DispatchesOnce` — second click on same selectorTS no-ops
  - `TestExecuteStep_InvalidatedPending_DoesNotPostSelector` — invalidated pending blocks PostSelector
  - `TestExecuteStep_InvalidatedPending_DoesNotSubmit` — invalidated pending blocks submit hook
  - `TestHandleBackToRepo_InvalidatesOldPending` — back marks old pending dead and removes the map entry
- `app/workflow/issue_test.go`:
  - `TestIssueWorkflow_BuildJob_RejectsEmptyRepo` — guard fires on empty `SelectedRepo`
  - `TestIssueWorkflow_BuildJob_AcceptsNonEmptyRepo` — non-empty still builds cleanly
- `app/workflow/pr_review_test.go`:
  - `TestPRReviewWorkflow_BuildJob_RejectsEmptyHeadRepo` — guard fires on empty `HeadRepo`
- `worker/pool/executor_test.go`:
  - `TestExecuteJob_EmptyRepoPlaceholderCloneURL_FailsBeforeClone` — `https://github.com/.git` blocked pre-Prepare
  - `TestExecuteJob_EmptyRepoStringWithNonEmptyCloneURL_FailsBeforeClone` — empty `Repo` + real-looking `CloneURL` blocked
  - `TestExecuteJob_EmptyCloneURLIsAskPath_NotFlaggedEmpty` — regression: Ask's empty-CloneURL path still runs

Verification run:
```
go build ./...   # clean
go test ./...    # all modules green, incl. test/import_direction_test
```