### PR TITLE
feat(selector): unify button/static/external selectors — fixes branch picker crash

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -613,7 +613,7 @@ func handleInteraction(
 		wf.HandleDescriptionSubmit(meta, firstModalValue(cb.View.State.Values))
 	case slack.InteractionTypeViewClosed:
 		meta := cb.View.PrivateMetadata
-		wf.HandleDescriptionSubmit(meta, "")
+		wf.HandleModalClosed(meta)
 	}
 }
 

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -147,6 +147,25 @@ var dSelectorLabel = map[string]string{
 	"pr_review": "🔍 Review PR",
 }
 
+// transitionalValues are selector picks whose ack would just clutter the
+// thread — the user skipped a step or backed out, and the next rendered
+// step (a new selector, a modal, or a status message) is the real signal
+// that the pick was accepted. Dropping the ack stops the thread from
+// growing by one message per no-op click.
+var transitionalValues = map[string]bool{
+	"skip":           true, // ask attach prompt: "不用"
+	"跳過":             true, // description prompt: "跳過"
+	"back_to_repo":   true, // issue/ask back button to repo picker
+	"back_to_attach": true, // ask back from repo picker to attach prompt
+}
+
+// isTransitionalValue reports whether a selection value represents a pure
+// navigation step (skip / back) rather than a substantive choice the user
+// might want a thread record of.
+func isTransitionalValue(value string) bool {
+	return transitionalValues[value]
+}
+
 // HandleSelection handles a button click or external-selector pick on a
 // selector message. It looks up the pending state by selectorMsgTS and
 // calls dispatcher.HandleSelection. triggerID is forwarded to executeStep
@@ -178,16 +197,26 @@ func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, tr
 	}
 
 	ctx := context.Background()
-	// Update the selector message to show the selection.
-	// For D-selector clicks use a friendly label; other selectors show the raw value.
-	ackLabel := value
-	if pending.Phase == "d_selector" {
-		if label, ok := dSelectorLabel[value]; ok {
-			ackLabel = label
+	// Transitional picks (skip / back_*) just navigate; the next step's own
+	// message conveys acceptance, so drop the selector entirely instead of
+	// leaving a trail of ":white_check_mark: skip" acks.
+	if isTransitionalValue(value) {
+		_ = w.slack.DeleteMessage(channelID, selectorMsgTS)
+	} else {
+		ackLabel := value
+		if pending.Phase == "d_selector" {
+			if label, ok := dSelectorLabel[value]; ok {
+				ackLabel = label
+			}
+		}
+		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":white_check_mark: "+ackLabel)
+		// Remember the repo ack so a later "重新選 repo" click can delete it —
+		// otherwise every rejected repo pick leaves behind a ":white_check_mark:
+		// owner/repo" line the user already disowned.
+		if pending.Phase == "repo" || pending.Phase == "repo_search" {
+			pending.RepoAckTS = selectorMsgTS
 		}
 	}
-	_ = w.slack.UpdateMessage(channelID, selectorMsgTS,
-		":white_check_mark: "+ackLabel)
 	step, err := w.dispatcher.HandleSelection(ctx, pending, value)
 	if err != nil {
 		w.logger.Error("HandleSelection dispatch failed", "phase", "失敗", "error", err)
@@ -214,10 +243,23 @@ func (w *Workflow) HandleDescriptionAction(channelID, value, selectorMsgTS, trig
 		w.mu.Unlock()
 		return
 	}
+	// Defensive rewind: a button click here means the user is back on the
+	// selector. If the phase is still *_modal (the workflow set it before
+	// OpenModal and Slack never delivered a ViewClosed/ViewSubmission to
+	// reset it — a very real case when the user dismisses the modal with
+	// escape or an outside tap), treating "補充說明"/"跳過" as the modal's
+	// submitted text would append it to the description and fire the job.
+	// Rewind first so the downstream Selection re-enters the prompt branch.
+	if prev, rewind := rewindModalPhase(pending.Phase); rewind {
+		pending.Phase = prev
+	}
 	if value == "跳過" {
 		delete(w.pending, selectorMsgTS)
 		w.mu.Unlock()
-		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":fast_forward: 跳過補充說明")
+		// Drop the prompt rather than leaving a ":fast_forward: 跳過補充說明"
+		// ack — the "分析 codebase 中..." status message that follows is
+		// the user-visible confirmation.
+		_ = w.slack.DeleteMessage(channelID, selectorMsgTS)
 		ctx := context.Background()
 		step, err := w.dispatcher.HandleSelection(ctx, pending, value)
 		if err != nil {
@@ -238,8 +280,68 @@ func (w *Workflow) HandleDescriptionAction(channelID, value, selectorMsgTS, trig
 	w.executeStep(ctx, pending, step, triggerID)
 }
 
-// HandleDescriptionSubmit handles a modal submission (or close) carrying
-// the extra description text.
+// rewindModalPhase maps a *_modal phase (the state a workflow sets right
+// before OpenModal) back to its prompt phase. Returns ok=true when the
+// cancelled modal can be rewound to a selector the user can re-click;
+// returns ok=false when the modal has no reversible prompt (e.g. PR Review's
+// URL modal — closing that one should surface the usual empty-URL error).
+func rewindModalPhase(phase string) (string, bool) {
+	switch phase {
+	case "description_modal":
+		return "description", true
+	case "ask_description_modal":
+		return "ask_description_prompt", true
+	}
+	return "", false
+}
+
+// HandleModalClosed handles the ViewClosed event — the user dismissed the
+// modal via the ✕ button / 取消 / escape without submitting.
+//
+// Three outcomes depending on the workflow's phase:
+//
+//  1. Description modals (description_modal / ask_description_modal): the
+//     pending stays alive and the phase rewinds to the prompt state so a
+//     subsequent click on the still-visible selector button re-opens the
+//     modal. Without this, the stuck *_modal phase would make the next
+//     button click feed "補充說明" into the workflow as the modal's
+//     submitted text.
+//
+//  2. PR Review URL modal (pr_review_modal): no reversible prompt exists
+//     (the modal was the entry point). Drop the pending, post a cancel
+//     acknowledgement, and clear dedup so the user can @bot again.
+//
+//  3. Any other phase falls through to HandleDescriptionSubmit("") — keeps
+//     the old empty-submit semantics for paths this handler doesn't know
+//     about, so new workflows don't silently break.
+func (w *Workflow) HandleModalClosed(selectorMsgTS string) {
+	w.mu.Lock()
+	pending, ok := w.pending[selectorMsgTS]
+	w.mu.Unlock()
+	if !ok {
+		return
+	}
+	if prev, canRewind := rewindModalPhase(pending.Phase); canRewind {
+		pending.Phase = prev
+		return
+	}
+	if pending.Phase == "pr_review_modal" {
+		w.mu.Lock()
+		delete(w.pending, selectorMsgTS)
+		w.mu.Unlock()
+		_ = w.slack.PostMessage(pending.ChannelID, ":white_check_mark: 已取消 PR Review", pending.ThreadTS)
+		if w.handler != nil {
+			w.handler.ClearThreadDedup(pending.ChannelID, pending.ThreadTS)
+		}
+		return
+	}
+	w.HandleDescriptionSubmit(selectorMsgTS, "")
+}
+
+// HandleDescriptionSubmit handles a modal submission carrying the extra
+// description text. ViewClosed events are routed through HandleModalClosed
+// so description modals can be rewound; this function handles the real
+// submit path.
 func (w *Workflow) HandleDescriptionSubmit(selectorMsgTS, extraText string) {
 	w.mu.Lock()
 	pending, ok := w.pending[selectorMsgTS]
@@ -286,6 +388,13 @@ func (w *Workflow) HandleBackToRepo(channelID, selectorMsgTS string) {
 	w.mu.Unlock()
 	if !ok {
 		return
+	}
+
+	// Drop the stale "✅ <repo>" ack so backing out doesn't leave abandoned
+	// picks piling up in the thread. The "已返回 repo 選擇" breadcrumb below
+	// is the one message we want to retain.
+	if oldPending.RepoAckTS != "" {
+		_ = w.slack.DeleteMessage(channelID, oldPending.RepoAckTS)
 	}
 
 	ctx := context.Background()

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -13,7 +13,10 @@ import (
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
-const pendingTimeout = 1 * time.Minute
+// pendingTimeout is the idle window before a wizard pending is evicted and
+// the thread is condensed to the "selection timed out" breadcrumb. Declared
+// var so tests can shorten it.
+var pendingTimeout = 1 * time.Minute
 
 // Workflow is the thin Slack-side handler. Real triage logic lives in
 // app/workflow workflows reached through the dispatcher.
@@ -202,14 +205,19 @@ func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, tr
 	// leaving a trail of ":white_check_mark: skip" acks.
 	if isTransitionalValue(value) {
 		_ = w.slack.DeleteMessage(channelID, selectorMsgTS)
-	} else {
+		pending.SessionMsgTSs = removeTS(pending.SessionMsgTSs, selectorMsgTS)
+	} else if pending.Phase == "d_selector" {
 		ackLabel := value
-		if pending.Phase == "d_selector" {
-			if label, ok := dSelectorLabel[value]; ok {
-				ackLabel = label
-			}
+		if label, ok := dSelectorLabel[value]; ok {
+			ackLabel = label
 		}
 		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":white_check_mark: "+ackLabel)
+		// Promote this TS to the session-wide "breadcrumb" slot. Timeout
+		// cleanup keeps this one, deletes everything else.
+		pending.DSelectorAckTS = selectorMsgTS
+		pending.SessionMsgTSs = removeTS(pending.SessionMsgTSs, selectorMsgTS)
+	} else {
+		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":white_check_mark: "+value)
 		// Remember the repo ack so a later "重新選 repo" click can delete it —
 		// otherwise every rejected repo pick leaves behind a ":white_check_mark:
 		// owner/repo" line the user already disowned.
@@ -430,18 +438,23 @@ func clonePendingForRegeneration(src *workflow.Pending) *workflow.Pending {
 		return nil
 	}
 	return &workflow.Pending{
-		ChannelID:   src.ChannelID,
-		ThreadTS:    src.ThreadTS,
-		TriggerTS:   src.TriggerTS,
-		UserID:      src.UserID,
-		Reporter:    src.Reporter,
-		ChannelName: src.ChannelName,
-		RequestID:   src.RequestID,
-		SelectorTS:  "",
-		Phase:       src.Phase,
-		TaskType:    src.TaskType,
-		State:       src.State,
-		BusyHint:    src.BusyHint,
+		ChannelID:      src.ChannelID,
+		ThreadTS:       src.ThreadTS,
+		TriggerTS:      src.TriggerTS,
+		UserID:         src.UserID,
+		Reporter:       src.Reporter,
+		ChannelName:    src.ChannelName,
+		RequestID:      src.RequestID,
+		SelectorTS:     "",
+		Phase:          src.Phase,
+		TaskType:       src.TaskType,
+		State:          src.State,
+		BusyHint:       src.BusyHint,
+		DSelectorAckTS: src.DSelectorAckTS,
+		SessionMsgTSs:  append([]string(nil), src.SessionMsgTSs...),
+		// RepoAckTS intentionally left zero — back-to-repo starts a fresh
+		// repo pick, and the old pick's ack has already been deleted by
+		// HandleBackToRepo.
 	}
 }
 
@@ -600,29 +613,72 @@ func (w *Workflow) submit(ctx context.Context, p *workflow.Pending) {
 }
 
 // storePending registers a pending workflow state under selectorTS and starts
-// a goroutine that evicts the entry after pendingTimeout.
+// a goroutine that evicts the entry after pendingTimeout. The selector TS is
+// also tracked on pending.SessionMsgTSs so timeout cleanup can find every
+// bot-posted message in this flow.
 func (w *Workflow) storePending(selectorTS string, p *workflow.Pending) {
 	p.SelectorTS = selectorTS
 	w.mu.Lock()
 	w.pending[selectorTS] = p
+	// Register this message on the session trail (deduped — executeStep may
+	// re-key an existing pending under a new TS after a modal flow).
+	if !containsTS(p.SessionMsgTSs, selectorTS) {
+		p.SessionMsgTSs = append(p.SessionMsgTSs, selectorTS)
+	}
 	w.mu.Unlock()
 
 	go func() {
 		time.Sleep(pendingTimeout)
 		w.mu.Lock()
 		_, stillPending := w.pending[selectorTS]
+		var sessionTSs []string
+		var dsTS string
 		if stillPending {
 			delete(w.pending, selectorTS)
+			dsTS = p.DSelectorAckTS
+			sessionTSs = append([]string(nil), p.SessionMsgTSs...)
 		}
 		w.mu.Unlock()
 
-		if stillPending {
-			_ = w.slack.UpdateMessage(p.ChannelID, selectorTS, ":hourglass: 已超時")
-			_ = w.slack.PostMessage(p.ChannelID, ":hourglass: 選擇已超時，請重新觸發。", p.ThreadTS)
-			if w.handler != nil {
-				w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
+		if !stillPending {
+			return
+		}
+		// Condense the thread: delete every session message (including the
+		// current selector) except the D-selector breadcrumb, then post the
+		// single timeout notice.
+		for _, ts := range sessionTSs {
+			if ts == dsTS {
+				continue
 			}
+			_ = w.slack.DeleteMessage(p.ChannelID, ts)
+		}
+		_ = w.slack.PostMessage(p.ChannelID, ":hourglass: 選擇已超時，請重新觸發。", p.ThreadTS)
+		if w.handler != nil {
+			w.handler.ClearThreadDedup(p.ChannelID, p.ThreadTS)
 		}
 	}()
+}
+
+// containsTS reports whether tsList contains ts.
+func containsTS(tsList []string, ts string) bool {
+	for _, v := range tsList {
+		if v == ts {
+			return true
+		}
+	}
+	return false
+}
+
+// removeTS returns tsList with the first occurrence of ts removed. Returns
+// the input unchanged when ts isn't present. Used when a TS transitions
+// from the session trail into a more specific slot (DSelectorAckTS) or gets
+// deleted outright, so timeout cleanup doesn't double-delete.
+func removeTS(tsList []string, ts string) []string {
+	for i, v := range tsList {
+		if v == ts {
+			return append(tsList[:i], tsList[i+1:]...)
+		}
+	}
+	return tsList
 }
 

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -359,8 +359,7 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 	// Only applies to the "act on the user's flow" steps — Error/Cancel/Noop
 	// still clear dedup and are safe to run.
 	switch step.Kind {
-	case workflow.NextStepPostSelector,
-		workflow.NextStepPostExternalSelector,
+	case workflow.NextStepSelector,
 		workflow.NextStepOpenModal,
 		workflow.NextStepSubmit:
 		if pending.IsInvalidated() {
@@ -369,59 +368,19 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 		}
 	}
 	switch step.Kind {
-	case workflow.NextStepPostSelector:
-		labels := make([]string, len(step.SelectorActions))
-		values := make([]string, len(step.SelectorActions))
-		for i, a := range step.SelectorActions {
-			labels[i] = a.Label
-			values[i] = a.Value
-		}
-		var selectorTS string
-		var err error
-		if step.SelectorBack != "" {
-			selectorTS, err = w.slack.PostSelectorWithBack(
-				pending.ChannelID,
-				step.SelectorPrompt,
-				actionPrefix(step.SelectorActions),
-				labels,
-				values,
-				pending.ThreadTS,
-				step.SelectorBack,
-				"← 重新選 repo",
-			)
-		} else {
-			selectorTS, err = w.slack.PostSelector(
-				pending.ChannelID,
-				step.SelectorPrompt,
-				actionPrefix(step.SelectorActions),
-				labels,
-				values,
-				pending.ThreadTS,
-			)
-		}
-		if err != nil {
-			w.logger.Error("PostSelector failed", "phase", "失敗", "error", err)
-			_ = w.slack.PostMessage(pending.ChannelID, ":x: 無法顯示選單，請重試", pending.ThreadTS)
+	case workflow.NextStepSelector:
+		if step.Selector == nil {
+			w.logger.Error("NextStepSelector missing spec", "phase", "失敗", "request_id", pending.RequestID)
+			_ = w.slack.PostMessage(pending.ChannelID, ":x: 內部錯誤：selector spec 未設置", pending.ThreadTS)
 			if w.handler != nil {
 				w.handler.ClearThreadDedup(pending.ChannelID, pending.ThreadTS)
 			}
 			return
 		}
-		w.storePending(selectorTS, pending)
-
-	case workflow.NextStepPostExternalSelector:
-		selectorTS, err := w.slack.PostExternalSelector(
-			pending.ChannelID,
-			step.SelectorPrompt,
-			step.SelectorActionID,
-			step.SelectorPlaceholder,
-			pending.ThreadTS,
-			step.SelectorCancelActionID,
-			step.SelectorCancelLabel,
-		)
+		selectorTS, err := w.slack.PostSmartSelector(pending.ChannelID, pending.ThreadTS, *step.Selector)
 		if err != nil {
-			w.logger.Error("PostExternalSelector failed", "phase", "失敗", "error", err)
-			_ = w.slack.PostMessage(pending.ChannelID, ":x: 無法顯示搜尋選單，請重試", pending.ThreadTS)
+			w.logger.Error("PostSmartSelector failed", "phase", "失敗", "error", err, "action_id", step.Selector.ActionID)
+			_ = w.slack.PostMessage(pending.ChannelID, ":x: 無法顯示選單，請重試", pending.ThreadTS)
 			if w.handler != nil {
 				w.handler.ClearThreadDedup(pending.ChannelID, pending.ThreadTS)
 			}
@@ -558,11 +517,3 @@ func (w *Workflow) storePending(selectorTS string, p *workflow.Pending) {
 	}()
 }
 
-// actionPrefix returns the ActionID of the first action, used as the Slack
-// action prefix when posting a selector. Returns "" for empty slices.
-func actionPrefix(actions []workflow.SelectorAction) string {
-	if len(actions) == 0 {
-		return ""
-	}
-	return actions[0].ActionID
-}

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -13,10 +13,11 @@ import (
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
-// pendingTimeout is the idle window before a wizard pending is evicted and
-// the thread is condensed to the "selection timed out" breadcrumb. Declared
-// var so tests can shorten it.
-var pendingTimeout = 1 * time.Minute
+// defaultPendingTimeout is the idle window before a wizard pending is
+// evicted and the thread is condensed to the "selection timed out"
+// breadcrumb. Per-Workflow field so tests can shorten it without racing on
+// package state.
+const defaultPendingTimeout = 1 * time.Minute
 
 // Workflow is the thin Slack-side handler. Real triage logic lives in
 // app/workflow workflows reached through the dispatcher.
@@ -32,6 +33,11 @@ type Workflow struct {
 	mu        sync.Mutex
 	pending   map[string]*workflow.Pending
 	autoBound map[string]bool
+
+	// pendingTimeout is how long storePending keeps a pending alive before
+	// the cleanup goroutine condenses the thread. Exposed as a field so
+	// tests can override it without racing on package-level state.
+	pendingTimeout time.Duration
 
 	// onSubmit is called when a workflow returns NextStepSubmit.
 	// Filled by app/app.go via SetSubmitHook.
@@ -49,14 +55,15 @@ func NewWorkflow(
 	availability queue.WorkerAvailability,
 ) *Workflow {
 	return &Workflow{
-		cfg:           cfg,
-		dispatcher:    dispatcher,
-		slack:         slack,
-		repoDiscovery: repoDiscovery,
-		logger:        logger,
-		availability:  availability,
-		pending:       make(map[string]*workflow.Pending),
-		autoBound:     make(map[string]bool),
+		cfg:            cfg,
+		dispatcher:     dispatcher,
+		slack:          slack,
+		repoDiscovery:  repoDiscovery,
+		logger:         logger,
+		availability:   availability,
+		pending:        make(map[string]*workflow.Pending),
+		autoBound:      make(map[string]bool),
+		pendingTimeout: defaultPendingTimeout,
 	}
 }
 
@@ -628,7 +635,7 @@ func (w *Workflow) storePending(selectorTS string, p *workflow.Pending) {
 	w.mu.Unlock()
 
 	go func() {
-		time.Sleep(pendingTimeout)
+		time.Sleep(w.pendingTimeout)
 		w.mu.Lock()
 		_, stillPending := w.pending[selectorTS]
 		var sessionTSs []string

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -18,7 +18,8 @@ import (
 // ── fake SlackPort for shim tests ──────────────────────────────────────────
 
 type shimSlack struct {
-	posted []string
+	posted  []string
+	deleted []string
 }
 
 func (s *shimSlack) PostMessage(ch, text, ts string) error {
@@ -30,6 +31,10 @@ func (s *shimSlack) PostMessageWithButton(ch, text, ts, aid, bt, val string) (st
 	return "ts", nil
 }
 func (s *shimSlack) UpdateMessage(ch, mts, text string) error                         { return nil }
+func (s *shimSlack) DeleteMessage(ch, mts string) error {
+	s.deleted = append(s.deleted, mts)
+	return nil
+}
 func (s *shimSlack) UpdateMessageWithButton(ch, mts, text, aid, bt, val string) error { return nil }
 func (s *shimSlack) PostSmartSelector(ch, ts string, spec workflow.SelectorSpec) (string, error) {
 	if spec.Searchable {
@@ -766,5 +771,311 @@ func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
 		if strings.Contains(m, "沒有 worker") {
 			t.Errorf("OK verdict should not post soft warn; got %q", m)
 		}
+	}
+}
+
+// TestHandleBackToRepo_DeletesStaleRepoAck guards the "thread doesn't grow
+// forever" UX: when the user picks a repo and then clicks 重新選 repo, the
+// rejected "✅ owner/repo" line must be deleted so the thread keeps only
+// the "已返回 repo 選擇" breadcrumb + the fresh repo picker.
+func TestHandleBackToRepo_DeletesStaleRepoAck(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	fake := &countingSelectionWorkflow{
+		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
+			return workflow.NextStep{
+				Kind: workflow.NextStepSelector,
+				Selector: &workflow.SelectorSpec{
+					Prompt:   "pick a repo",
+					ActionID: "repo_select",
+					Options:  []workflow.SelectorOption{{Label: "foo/bar", Value: "foo/bar"}},
+				},
+				Pending: p,
+			}
+		},
+	}
+	reg.Register(fake)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	const branchTS = "branch-sel-1"
+	const repoAckTS = "repo-ack-1"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1", TaskType: "issue",
+		Phase: "branch", SelectorTS: branchTS, RequestID: "req-back",
+		RepoAckTS: repoAckTS,
+	}
+	wf.mu.Lock()
+	wf.pending[branchTS] = p
+	wf.mu.Unlock()
+
+	wf.HandleBackToRepo("C1", branchTS)
+
+	found := false
+	for _, d := range sl.deleted {
+		if d == repoAckTS {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected DeleteMessage(%q); got deleted=%v", repoAckTS, sl.deleted)
+	}
+}
+
+// TestHandleModalClosed_DescriptionPhase_RewindsWithoutSubmit is the guard
+// for: user clicks "補充說明" → modal opens → user clicks ✕ → user clicks
+// "補充說明" again → should re-open modal, not submit with junk.
+//
+// Before the fix, ViewClosed went through HandleDescriptionSubmit which
+// deleted the pending and triggered the workflow's `*_description_modal`
+// phase branch with value="" → NextStepSubmit. The second button click
+// either found no pending (delete won) or fed "補充說明" into the modal
+// branch as the submitted description.
+func TestHandleModalClosed_DescriptionPhase_RewindsWithoutSubmit(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	submitted := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) { submitted = true })
+
+	const selectorTS = "desc-sel-789"
+	cases := []struct {
+		name      string
+		phase     string
+		wantPhase string
+	}{
+		{"issue description modal", "description_modal", "description"},
+		{"ask description modal", "ask_description_modal", "ask_description_prompt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &workflow.Pending{
+				ChannelID: "C1", ThreadTS: "T1",
+				TaskType: "issue", Phase: tc.phase, SelectorTS: selectorTS,
+			}
+			wf.mu.Lock()
+			wf.pending[selectorTS] = p
+			wf.mu.Unlock()
+
+			submitted = false
+			wf.HandleModalClosed(selectorTS)
+
+			if submitted {
+				t.Error("closing the description modal must not trigger submit")
+			}
+			wf.mu.Lock()
+			still, ok := wf.pending[selectorTS]
+			wf.mu.Unlock()
+			if !ok || still != p {
+				t.Error("pending must stay in the map so the user can re-click the selector button")
+			}
+			if p.Phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q (rewind so the next click re-enters the prompt)", p.Phase, tc.wantPhase)
+			}
+
+			// Cleanup for next sub-test.
+			wf.mu.Lock()
+			delete(wf.pending, selectorTS)
+			wf.mu.Unlock()
+		})
+	}
+}
+
+// TestHandleDescriptionAction_PhaseStuckInModal_RewindsBeforeDispatch
+// guards the real production scenario: Slack does not reliably deliver
+// ViewClosed when a user dismisses the modal (✕ button, escape key, click
+// outside). The phase stays at *_modal, and the next click on the still-
+// visible "補充說明" / "跳過" selector buttons would feed the button label
+// into the workflow's modal branch and submit.
+//
+// This is a stronger guard than HandleModalClosed — it doesn't depend on
+// Slack sending the event at all.
+func TestHandleDescriptionAction_PhaseStuckInModal_RewindsBeforeDispatch(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+
+	// Record what value the workflow's Selection received and in what phase
+	// — if rewind happens, phase should be the prompt, not the modal.
+	var gotPhase, gotValue string
+	fake := &countingSelectionWorkflow{
+		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
+			gotPhase = p.Phase
+			gotValue = value
+			// Simulate the workflow's prompt branch: user clicked 補充說明
+			// → OpenModal with phase flipped back to *_modal.
+			p.Phase = "ask_description_modal"
+			return workflow.NextStep{
+				Kind:           workflow.NextStepOpenModal,
+				ModalTitle:     "補充說明",
+				ModalLabel:     "補充你想讓 agent 做什麼",
+				ModalInputName: "description",
+				ModalMetadata:  p.SelectorTS,
+				Pending:        p,
+			}
+		},
+	}
+	reg.Register(fake)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	submitted := false
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) { submitted = true })
+
+	const selectorTS = "desc-sel-stuck"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1",
+		TaskType:   "issue",
+		Phase:      "ask_description_modal", // stuck here because Slack never sent ViewClosed
+		SelectorTS: selectorTS,
+	}
+	wf.mu.Lock()
+	wf.pending[selectorTS] = p
+	wf.mu.Unlock()
+
+	wf.HandleDescriptionAction("C1", "補充說明", selectorTS, "trigger-xyz")
+
+	if submitted {
+		t.Error("second click on 補充說明 must not trigger submit")
+	}
+	if gotPhase != "ask_description_prompt" {
+		t.Errorf("Selection saw phase=%q, want ask_description_prompt (rewound before dispatch)", gotPhase)
+	}
+	if gotValue != "補充說明" {
+		t.Errorf("Selection value = %q, want 補充說明", gotValue)
+	}
+}
+
+// TestHandleDescriptionAction_SkipWhileStuckInModal_RewindsBeforeDispatch
+// mirrors the test above for the 跳過 path. Without the rewind, 跳過 would
+// be appended to the description as the modal's submitted text.
+func TestHandleDescriptionAction_SkipWhileStuckInModal_RewindsBeforeDispatch(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+
+	var gotPhase, gotValue string
+	fake := &countingSelectionWorkflow{
+		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
+			gotPhase = p.Phase
+			gotValue = value
+			return workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+		},
+	}
+	reg.Register(fake)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {})
+
+	const selectorTS = "desc-sel-skip-stuck"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1",
+		TaskType:   "issue",
+		Phase:      "description_modal",
+		SelectorTS: selectorTS,
+	}
+	wf.mu.Lock()
+	wf.pending[selectorTS] = p
+	wf.mu.Unlock()
+
+	wf.HandleDescriptionAction("C1", "跳過", selectorTS, "")
+
+	if gotPhase != "description" {
+		t.Errorf("Selection saw phase=%q, want description (rewound before dispatch)", gotPhase)
+	}
+	if gotValue != "跳過" {
+		t.Errorf("Selection value = %q, want 跳過", gotValue)
+	}
+}
+
+// TestHandleModalClosed_PRReviewModal_PostsCancelAndClearsDedup covers the
+// PR Review URL modal: closing it can't rewind to a prior selector (the
+// modal was the entry point), so we cancel cleanly — drop pending, post a
+// confirmation, clear dedup — rather than treating it as an empty submit
+// that surfaces a confusing "請貼完整 PR URL" error.
+func TestHandleModalClosed_PRReviewModal_PostsCancelAndClearsDedup(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		t.Error("cancelled PR Review modal must not trigger submit")
+	})
+
+	const metaKey = "modal-req-pr"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1",
+		TaskType: "pr_review", Phase: "pr_review_modal", SelectorTS: metaKey,
+	}
+	wf.mu.Lock()
+	wf.pending[metaKey] = p
+	wf.mu.Unlock()
+
+	wf.HandleModalClosed(metaKey)
+
+	wf.mu.Lock()
+	_, stillPending := wf.pending[metaKey]
+	wf.mu.Unlock()
+	if stillPending {
+		t.Error("pending must be dropped after PR Review modal cancel")
+	}
+	sawCancelMsg := false
+	for _, m := range sl.posted {
+		if strings.Contains(m, "已取消 PR Review") {
+			sawCancelMsg = true
+		}
+	}
+	if !sawCancelMsg {
+		t.Errorf("expected cancel acknowledgement posted; got %v", sl.posted)
+	}
+}
+
+// TestHandleModalClosed_IrreversiblePhase_FallsThroughToSubmit covers an
+// unknown modal phase — falls through to HandleDescriptionSubmit("") so
+// future workflows that add modals don't silently break while we catch up
+// on the explicit branches above.
+func TestHandleModalClosed_IrreversiblePhase_FallsThroughToSubmit(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	// Workflow that records what Selection received so we can assert the
+	// fall-through path actually ran.
+	received := ""
+	fake := &countingSelectionWorkflow{
+		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
+			received = value
+			return workflow.NextStep{Kind: workflow.NextStepError, ErrorText: "empty", Pending: p}
+		},
+	}
+	reg.Register(fake)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	const selectorTS = "unknown-modal-1"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1",
+		TaskType: "issue", Phase: "some_future_modal", SelectorTS: selectorTS,
+	}
+	wf.mu.Lock()
+	wf.pending[selectorTS] = p
+	wf.mu.Unlock()
+
+	wf.HandleModalClosed(selectorTS)
+
+	if received != "" {
+		t.Errorf("expected workflow.Selection to receive empty value, got %q", received)
+	}
+	wf.mu.Lock()
+	_, stillPending := wf.pending[selectorTS]
+	wf.mu.Unlock()
+	if stillPending {
+		t.Error("fall-through path must consume pending (old HandleDescriptionSubmit semantics)")
 	}
 }

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -774,6 +774,66 @@ func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
 	}
 }
 
+// TestStorePending_Timeout_CondensesThreadKeepingDSelectorAck guards the
+// "selection timed out" cleanup: after pendingTimeout fires, every session
+// message the bot posted should be deleted except the D-selector ack
+// (":white_check_mark: 📝 建 Issue" / 問問題 / Review PR). The thread ends
+// up as: one breadcrumb + the timeout notice — not 5+ abandoned steps.
+func TestStorePending_Timeout_CondensesThreadKeepingDSelectorAck(t *testing.T) {
+	// Keep the test fast by overriding the package-level timeout; put it
+	// back at the end so later tests don't race against a shorter window.
+	origTimeout := pendingTimeout
+	pendingTimeout = 40 * time.Millisecond
+	defer func() { pendingTimeout = origTimeout }()
+
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+	reg.Register(&fakeIssueWorkflow{})
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+
+	const dsAckTS = "ds-ack-1"
+	const step1TS = "step1-ts"
+	const step2TS = "step2-ts"
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1", TaskType: "issue", RequestID: "req-timeout",
+		DSelectorAckTS: dsAckTS,
+		SessionMsgTSs:  []string{step1TS}, // pre-existing trail from earlier steps
+	}
+
+	wf.storePending(step2TS, p)
+
+	// Wait past the timeout window + a buffer for the goroutine's Slack calls.
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify exactly the right set of TSs was deleted.
+	deleted := map[string]bool{}
+	for _, d := range sl.deleted {
+		deleted[d] = true
+	}
+	if deleted[dsAckTS] {
+		t.Errorf("D-selector ack %q must not be deleted on timeout", dsAckTS)
+	}
+	if !deleted[step1TS] {
+		t.Errorf("expected step1 ack %q deleted; got deleted=%v", step1TS, sl.deleted)
+	}
+	if !deleted[step2TS] {
+		t.Errorf("expected current selector %q deleted; got deleted=%v", step2TS, sl.deleted)
+	}
+
+	// Verify the single timeout notice was posted.
+	sawTimeoutNotice := false
+	for _, m := range sl.posted {
+		if strings.Contains(m, "選擇已超時") {
+			sawTimeoutNotice = true
+		}
+	}
+	if !sawTimeoutNotice {
+		t.Errorf("expected timeout notice posted; got posted=%v", sl.posted)
+	}
+}
+
 // TestHandleBackToRepo_DeletesStaleRepoAck guards the "thread doesn't grow
 // forever" UX: when the user picks a repo and then clicks 重新選 repo, the
 // rejected "✅ owner/repo" line must be deleted so the thread keeps only

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -17,12 +17,34 @@ import (
 
 // ── fake SlackPort for shim tests ──────────────────────────────────────────
 
+// shimSlack guards its slices with a mutex because the pending-timeout
+// goroutine can call Post/Update/Delete concurrently with the test body's
+// reads. Without the lock the race detector flags every timeout test.
 type shimSlack struct {
+	mu      sync.Mutex
 	posted  []string
 	deleted []string
 }
 
+// snapshotPosted returns a defensive copy of posted — use this in tests
+// instead of reading sl.posted directly when a goroutine might still be
+// writing.
+func (s *shimSlack) snapshotPosted() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.posted...)
+}
+
+// snapshotDeleted returns a defensive copy of deleted.
+func (s *shimSlack) snapshotDeleted() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deleted...)
+}
+
 func (s *shimSlack) PostMessage(ch, text, ts string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.posted = append(s.posted, text)
 	return nil
 }
@@ -30,8 +52,10 @@ func (s *shimSlack) PostMessageWithTS(ch, text, ts string) (string, error) { ret
 func (s *shimSlack) PostMessageWithButton(ch, text, ts, aid, bt, val string) (string, error) {
 	return "ts", nil
 }
-func (s *shimSlack) UpdateMessage(ch, mts, text string) error                         { return nil }
+func (s *shimSlack) UpdateMessage(ch, mts, text string) error { return nil }
 func (s *shimSlack) DeleteMessage(ch, mts string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.deleted = append(s.deleted, mts)
 	return nil
 }
@@ -780,18 +804,15 @@ func TestHandleTrigger_HealthyOK_NoSoftWarn(t *testing.T) {
 // (":white_check_mark: 📝 建 Issue" / 問問題 / Review PR). The thread ends
 // up as: one breadcrumb + the timeout notice — not 5+ abandoned steps.
 func TestStorePending_Timeout_CondensesThreadKeepingDSelectorAck(t *testing.T) {
-	// Keep the test fast by overriding the package-level timeout; put it
-	// back at the end so later tests don't race against a shorter window.
-	origTimeout := pendingTimeout
-	pendingTimeout = 40 * time.Millisecond
-	defer func() { pendingTimeout = origTimeout }()
-
 	sl := &shimSlack{}
 	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
 	reg := workflow.NewRegistry()
 	reg.Register(&fakeIssueWorkflow{})
 	disp := workflow.NewDispatcher(reg, sl, nil)
 	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+	// Per-instance timeout override — no package-level state touched so
+	// parallel tests can't race on it.
+	wf.pendingTimeout = 40 * time.Millisecond
 
 	const dsAckTS = "ds-ack-1"
 	const step1TS = "step1-ts"
@@ -807,30 +828,34 @@ func TestStorePending_Timeout_CondensesThreadKeepingDSelectorAck(t *testing.T) {
 	// Wait past the timeout window + a buffer for the goroutine's Slack calls.
 	time.Sleep(150 * time.Millisecond)
 
-	// Verify exactly the right set of TSs was deleted.
+	// Snapshot under the shim's lock so the race detector stays happy even
+	// if a stray goroutine is still writing (shouldn't be, but defensive).
+	deletedList := sl.snapshotDeleted()
+	postedList := sl.snapshotPosted()
+
 	deleted := map[string]bool{}
-	for _, d := range sl.deleted {
+	for _, d := range deletedList {
 		deleted[d] = true
 	}
 	if deleted[dsAckTS] {
 		t.Errorf("D-selector ack %q must not be deleted on timeout", dsAckTS)
 	}
 	if !deleted[step1TS] {
-		t.Errorf("expected step1 ack %q deleted; got deleted=%v", step1TS, sl.deleted)
+		t.Errorf("expected step1 ack %q deleted; got deleted=%v", step1TS, deletedList)
 	}
 	if !deleted[step2TS] {
-		t.Errorf("expected current selector %q deleted; got deleted=%v", step2TS, sl.deleted)
+		t.Errorf("expected current selector %q deleted; got deleted=%v", step2TS, deletedList)
 	}
 
 	// Verify the single timeout notice was posted.
 	sawTimeoutNotice := false
-	for _, m := range sl.posted {
+	for _, m := range postedList {
 		if strings.Contains(m, "選擇已超時") {
 			sawTimeoutNotice = true
 		}
 	}
 	if !sawTimeoutNotice {
-		t.Errorf("expected timeout notice posted; got posted=%v", sl.posted)
+		t.Errorf("expected timeout notice posted; got posted=%v", postedList)
 	}
 }
 

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -31,14 +31,11 @@ func (s *shimSlack) PostMessageWithButton(ch, text, ts, aid, bt, val string) (st
 }
 func (s *shimSlack) UpdateMessage(ch, mts, text string) error                         { return nil }
 func (s *shimSlack) UpdateMessageWithButton(ch, mts, text, aid, bt, val string) error { return nil }
-func (s *shimSlack) PostSelector(ch, prompt, prefix string, labels, values []string, ts string) (string, error) {
+func (s *shimSlack) PostSmartSelector(ch, ts string, spec workflow.SelectorSpec) (string, error) {
+	if spec.Searchable {
+		return "ext-ts", nil
+	}
 	return "sel-ts", nil
-}
-func (s *shimSlack) PostSelectorWithBack(ch, prompt, prefix string, labels, values []string, ts, back, bl string) (string, error) {
-	return "sel-ts", nil
-}
-func (s *shimSlack) PostExternalSelector(ch, prompt, aid, ph, ts, cancelAID, cancelLabel string) (string, error) {
-	return "ext-ts", nil
 }
 func (s *shimSlack) OpenTextInputModal(tid, title, label, name, metadata string) error { return nil }
 func (s *shimSlack) ResolveUser(uid string) string                                     { return uid }
@@ -616,10 +613,13 @@ func TestExecuteStep_InvalidatedPending_DoesNotPostSelector(t *testing.T) {
 	p.Invalidate()
 
 	step := workflow.NextStep{
-		Kind:            workflow.NextStepPostSelector,
-		SelectorPrompt:  "pick",
-		SelectorActions: []workflow.SelectorAction{{ActionID: "a", Label: "L", Value: "V"}},
-		Pending:         p,
+		Kind: workflow.NextStepSelector,
+		Selector: &workflow.SelectorSpec{
+			Prompt:   "pick",
+			ActionID: "a",
+			Options:  []workflow.SelectorOption{{Label: "L", Value: "V"}},
+		},
+		Pending: p,
 	}
 	wf.executeStep(context.Background(), p, step, "")
 
@@ -669,10 +669,13 @@ func TestHandleBackToRepo_InvalidatesOldPending(t *testing.T) {
 	fake := &countingSelectionWorkflow{
 		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
 			return workflow.NextStep{
-				Kind:            workflow.NextStepPostSelector,
-				SelectorPrompt:  "pick a repo",
-				SelectorActions: []workflow.SelectorAction{{ActionID: "a", Label: "foo/bar", Value: "foo/bar"}},
-				Pending:         p,
+				Kind: workflow.NextStepSelector,
+				Selector: &workflow.SelectorSpec{
+					Prompt:   "pick a repo",
+					ActionID: "a",
+					Options:  []workflow.SelectorOption{{Label: "foo/bar", Value: "foo/bar"}},
+				},
+				Pending: p,
 			}
 		},
 	}

--- a/app/slack/client.go
+++ b/app/slack/client.go
@@ -357,15 +357,18 @@ func (c *Client) PostSmartSelector(channelID, threadTS string, spec SmartSelecto
 	}
 }
 
-// postButtonSelectorBlock renders spec as an actions block of buttons. All
-// buttons share spec.ActionID — Slack delivers the clicked option's Value
-// via action.Value, and the common ActionID is what app.go's router switches
-// on.
+// postButtonSelectorBlock renders spec as an actions block of buttons.
+// Each button's action_id is spec.ActionID + "_<idx>" — Slack rejects an
+// actions block whose interactive elements share the same action_id with
+// invalid_blocks 400, so the suffix is structural, not cosmetic.
+// app/app.go's router matches the router branches with HasPrefix
+// (description_action, cancel_job) or relies on Pending.Phase in
+// HandleSelection, so the suffix is transparent to callers.
 func (c *Client) postButtonSelectorBlock(channelID, threadTS string, spec SmartSelectorSpec) (string, error) {
 	buttons := make([]slack.BlockElement, 0, len(spec.Options)+2)
-	for _, o := range spec.Options {
+	for i, o := range spec.Options {
 		buttons = append(buttons, slack.NewButtonBlockElement(
-			spec.ActionID,
+			fmt.Sprintf("%s_%d", spec.ActionID, i),
 			o.Value,
 			slack.NewTextBlockObject(slack.PlainTextType, o.Label, false, false),
 		))
@@ -523,6 +526,11 @@ func (c *Client) OpenTextInputModal(triggerID, title, label, inputName, metadata
 		Close:           slack.NewTextBlockObject(slack.PlainTextType, "取消", false, false),
 		Blocks:          slack.Blocks{BlockSet: []slack.Block{inputBlock}},
 		PrivateMetadata: metadata,
+		// NotifyOnClose makes Slack deliver a view_closed event when the
+		// user dismisses the modal (✕ / 取消 / escape). Without it the bot
+		// is blind to cancellation and the pending entry sits in memory
+		// until the 1-minute timeout fires — the user sees "no next step".
+		NotifyOnClose: true,
 	}
 	_, err := c.api.OpenView(triggerID, modalView)
 	if err != nil {
@@ -562,6 +570,21 @@ func (c *Client) PostMessageWithButton(channelID, text, threadTS, actionID, butt
 		return "", fmt.Errorf("post message with button: %w", err)
 	}
 	return ts, nil
+}
+
+// DeleteMessage removes a message from the thread. Used to drop acks for
+// transitional selections (skip / 跳過 / back_*) where keeping the ack
+// would just grow the thread without carrying useful information — the
+// next step's own message is the real feedback.
+func (c *Client) DeleteMessage(channelID, messageTS string) error {
+	start := time.Now()
+	_, _, err := c.api.DeleteMessage(channelID, messageTS)
+	metrics.ExternalDuration.WithLabelValues("slack", "delete_message").Observe(time.Since(start).Seconds())
+	if err != nil {
+		metrics.ExternalErrorsTotal.WithLabelValues("slack", "delete_message").Inc()
+		return fmt.Errorf("delete message: %w", err)
+	}
+	return nil
 }
 
 // UpdateMessage replaces an existing message (used to clear buttons after selection).

--- a/app/slack/client.go
+++ b/app/slack/client.go
@@ -264,129 +264,237 @@ func (c *Client) GetChannelName(channelID string) string {
 	return "#" + info.Name
 }
 
-// PostSelector sends a message with clickable buttons.
-// If threadTS is non-empty, posts in that thread.
-// labels[i] is the button text; values[i] is the payload returned as
-// action.Value on click. When values is nil/short, the label doubles as
-// the value (legacy behaviour).
-// Returns the message timestamp.
-func (c *Client) PostSelector(channelID, prompt, actionPrefix string, labels, values []string, threadTS string) (string, error) {
-	var buttons []slack.BlockElement
-	for i, label := range labels {
-		val := label
-		if i < len(values) {
-			val = values[i]
-		}
-		buttons = append(buttons, slack.NewButtonBlockElement(
-			fmt.Sprintf("%s_%d", actionPrefix, i),
-			val,
-			slack.NewTextBlockObject(slack.PlainTextType, label, false, false),
-		))
-	}
-
-	section := slack.NewSectionBlock(
-		slack.NewTextBlockObject(slack.MarkdownType, prompt, false, false),
-		nil, nil,
-	)
-	actions := slack.NewActionBlock(actionPrefix, buttons...)
-
-	opts := []slack.MsgOption{slack.MsgOptionBlocks(section, actions)}
-	if threadTS != "" {
-		opts = append(opts, slack.MsgOptionTS(threadTS))
-	}
-
-	_, ts, err := c.api.PostMessage(channelID, opts...)
-	if err != nil {
-		return "", fmt.Errorf("post selector: %w", err)
-	}
-	return ts, nil
+// SmartSelectorOption is one choice in a selector. Value is the payload
+// delivered back to the router when the user picks this option.
+type SmartSelectorOption struct {
+	Label string
+	Value string
 }
 
-// PostSelectorWithBack sends a button selector with an optional trailing back
-// button. If backActionID is empty, behaves identically to PostSelector. The
-// back button is rendered rightmost (farthest from main option buttons) and
-// uses default button style.
-func (c *Client) PostSelectorWithBack(
-	channelID, prompt, actionPrefix string,
-	labels, values []string,
-	threadTS string,
-	backActionID, backLabel string,
-) (string, error) {
-	var buttons []slack.BlockElement
-	for i, label := range labels {
-		val := label
-		if i < len(values) {
-			val = values[i]
-		}
-		buttons = append(buttons, slack.NewButtonBlockElement(
-			fmt.Sprintf("%s_%d", actionPrefix, i),
-			val,
-			slack.NewTextBlockObject(slack.PlainTextType, label, false, false),
-		))
-	}
-	if backActionID != "" {
-		buttons = append(buttons, slack.NewButtonBlockElement(
-			backActionID,
-			backActionID, // value equals actionID so router doesn't need SelectedOption
-			slack.NewTextBlockObject(slack.PlainTextType, backLabel, false, false),
-		))
-	}
+// SmartSelectorSpec is the adapter-level view of workflow.SelectorSpec.
+// Kept as a separate type so the slack package does not import workflow.
+type SmartSelectorSpec struct {
+	Prompt   string
+	ActionID string
+	Options  []SmartSelectorOption
 
-	section := slack.NewSectionBlock(
-		slack.NewTextBlockObject(slack.MarkdownType, prompt, false, false),
-		nil, nil,
-	)
-	actions := slack.NewActionBlock(actionPrefix, buttons...)
+	Searchable  bool
+	Placeholder string
 
-	opts := []slack.MsgOption{slack.MsgOptionBlocks(section, actions)}
-	if threadTS != "" {
-		opts = append(opts, slack.MsgOptionTS(threadTS))
-	}
-
-	_, ts, err := c.api.PostMessage(channelID, opts...)
-	if err != nil {
-		return "", fmt.Errorf("post selector with back: %w", err)
-	}
-	return ts, nil
+	BackActionID   string
+	BackLabel      string
+	CancelActionID string
+	CancelLabel    string
 }
 
-// PostExternalSelector sends a message with a type-ahead searchable dropdown.
-// When cancelActionID and cancelLabel are non-empty, adds a cancel button
-// alongside the dropdown so users can bail out of the selection. Returns the
-// message timestamp.
-func (c *Client) PostExternalSelector(channelID, prompt, actionID, placeholder, threadTS, cancelActionID, cancelLabel string) (string, error) {
+// Slack block-kit hard limits. Breaching either produces an `invalid_blocks`
+// 400 at the API boundary — PostSmartSelector dispatches to the right
+// rendering so callers never collide with these.
+const (
+	selectorButtonMax       = 25  // actions block: max 25 interactive elements
+	selectorStaticSelectMax = 100 // static_select: max 100 options
+)
+
+// selectorRenderKind is the concrete Slack rendering picked for a spec.
+// Kept as a distinct type so selectorRenderMode is easy to test without
+// reaching into the Slack API.
+type selectorRenderKind int
+
+const (
+	renderButton          selectorRenderKind = iota // actions block of buttons
+	renderStaticSelect                              // static_select dropdown
+	renderExternalSelect                            // external (type-ahead) select
+	renderStaticTruncated                           // static_select with options capped to selectorStaticSelectMax
+)
+
+// selectorRenderMode decides which Slack rendering fits a spec based on the
+// option count and extras (back/cancel buttons) against the block-kit caps.
+// Pure function — the only Slack-API-free entry point, which is what the
+// threshold tests exercise.
+func selectorRenderMode(spec SmartSelectorSpec) selectorRenderKind {
+	if spec.Searchable {
+		return renderExternalSelect
+	}
+	extras := 0
+	if spec.BackActionID != "" {
+		extras++
+	}
+	if spec.CancelActionID != "" {
+		extras++
+	}
+	if len(spec.Options)+extras <= selectorButtonMax {
+		return renderButton
+	}
+	if len(spec.Options) > selectorStaticSelectMax {
+		return renderStaticTruncated
+	}
+	return renderStaticSelect
+}
+
+// PostSmartSelector renders spec as a message with the appropriate Slack UI
+// (see selectorRenderMode) and returns the posted message's timestamp so
+// executeStep can key pending state under it.
+func (c *Client) PostSmartSelector(channelID, threadTS string, spec SmartSelectorSpec) (string, error) {
+	if !spec.Searchable && len(spec.Options) == 0 {
+		return "", fmt.Errorf("post smart selector: empty options and not searchable")
+	}
+	switch selectorRenderMode(spec) {
+	case renderExternalSelect:
+		return c.postExternalSelectBlock(channelID, threadTS, spec)
+	case renderButton:
+		return c.postButtonSelectorBlock(channelID, threadTS, spec)
+	case renderStaticTruncated:
+		c.logger.Warn("selector options 超過上限，已截斷至前 100 項",
+			"phase", "降級",
+			"action_id", spec.ActionID,
+			"original", len(spec.Options),
+			"capped", selectorStaticSelectMax,
+		)
+		spec.Options = spec.Options[:selectorStaticSelectMax]
+		return c.postStaticSelectBlock(channelID, threadTS, spec)
+	default: // renderStaticSelect
+		return c.postStaticSelectBlock(channelID, threadTS, spec)
+	}
+}
+
+// postButtonSelectorBlock renders spec as an actions block of buttons. All
+// buttons share spec.ActionID — Slack delivers the clicked option's Value
+// via action.Value, and the common ActionID is what app.go's router switches
+// on.
+func (c *Client) postButtonSelectorBlock(channelID, threadTS string, spec SmartSelectorSpec) (string, error) {
+	buttons := make([]slack.BlockElement, 0, len(spec.Options)+2)
+	for _, o := range spec.Options {
+		buttons = append(buttons, slack.NewButtonBlockElement(
+			spec.ActionID,
+			o.Value,
+			slack.NewTextBlockObject(slack.PlainTextType, o.Label, false, false),
+		))
+	}
+	if spec.CancelActionID != "" {
+		buttons = append(buttons, slack.NewButtonBlockElement(
+			spec.CancelActionID,
+			spec.CancelLabel,
+			slack.NewTextBlockObject(slack.PlainTextType, spec.CancelLabel, false, false),
+		))
+	}
+	if spec.BackActionID != "" {
+		buttons = append(buttons, slack.NewButtonBlockElement(
+			spec.BackActionID,
+			spec.BackActionID, // value equals actionID so router doesn't need SelectedOption
+			slack.NewTextBlockObject(slack.PlainTextType, spec.BackLabel, false, false),
+		))
+	}
+
 	section := slack.NewSectionBlock(
-		slack.NewTextBlockObject(slack.MarkdownType, prompt, false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, spec.Prompt, false, false),
 		nil, nil,
 	)
+	actions := slack.NewActionBlock(spec.ActionID, buttons...)
 
+	return c.postBlocks(channelID, threadTS, section, actions, "post button selector")
+}
+
+// postStaticSelectBlock renders spec as a static_select dropdown. Used when
+// the option count exceeds the button row's 25 cap. Optional back/cancel
+// buttons live beside the dropdown in the same actions block.
+func (c *Client) postStaticSelectBlock(channelID, threadTS string, spec SmartSelectorSpec) (string, error) {
+	options := make([]*slack.OptionBlockObject, 0, len(spec.Options))
+	for _, o := range spec.Options {
+		options = append(options, slack.NewOptionBlockObject(
+			o.Value,
+			slack.NewTextBlockObject(slack.PlainTextType, o.Label, false, false),
+			nil,
+		))
+	}
+	placeholder := spec.Placeholder
+	if placeholder == "" {
+		placeholder = "請選擇..."
+	}
+	sel := slack.NewOptionsSelectBlockElement(
+		slack.OptTypeStatic,
+		slack.NewTextBlockObject(slack.PlainTextType, placeholder, false, false),
+		spec.ActionID,
+		options...,
+	)
+
+	elements := []slack.BlockElement{sel}
+	if spec.CancelActionID != "" {
+		elements = append(elements, slack.NewButtonBlockElement(
+			spec.CancelActionID,
+			spec.CancelLabel,
+			slack.NewTextBlockObject(slack.PlainTextType, spec.CancelLabel, false, false),
+		))
+	}
+	if spec.BackActionID != "" {
+		elements = append(elements, slack.NewButtonBlockElement(
+			spec.BackActionID,
+			spec.BackActionID,
+			slack.NewTextBlockObject(slack.PlainTextType, spec.BackLabel, false, false),
+		))
+	}
+
+	section := slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.MarkdownType, spec.Prompt, false, false),
+		nil, nil,
+	)
+	actions := slack.NewActionBlock(spec.ActionID+"_block", elements...)
+
+	return c.postBlocks(channelID, threadTS, section, actions, "post static select")
+}
+
+// postExternalSelectBlock renders spec as a type-ahead external_select. The
+// user types a query and app.go's BlockSuggestion handler supplies live
+// options (see app.go:531). Back/cancel buttons live beside the dropdown in
+// the same actions block.
+func (c *Client) postExternalSelectBlock(channelID, threadTS string, spec SmartSelectorSpec) (string, error) {
+	placeholder := spec.Placeholder
+	if placeholder == "" {
+		placeholder = "Type to search..."
+	}
 	extSelect := slack.NewOptionsSelectBlockElement(
 		slack.OptTypeExternal,
 		slack.NewTextBlockObject(slack.PlainTextType, placeholder, false, false),
-		actionID,
+		spec.ActionID,
 	)
 	extSelect.MinQueryLength = new(int) // 0 = show options immediately
 	*extSelect.MinQueryLength = 0
 
 	elements := []slack.BlockElement{extSelect}
-	if cancelActionID != "" && cancelLabel != "" {
-		cancelBtn := slack.NewButtonBlockElement(
-			cancelActionID,
-			cancelLabel,
-			slack.NewTextBlockObject(slack.PlainTextType, cancelLabel, false, false),
-		)
-		elements = append(elements, cancelBtn)
+	if spec.CancelActionID != "" && spec.CancelLabel != "" {
+		elements = append(elements, slack.NewButtonBlockElement(
+			spec.CancelActionID,
+			spec.CancelLabel,
+			slack.NewTextBlockObject(slack.PlainTextType, spec.CancelLabel, false, false),
+		))
 	}
-	actions := slack.NewActionBlock(actionID+"_block", elements...)
+	if spec.BackActionID != "" {
+		elements = append(elements, slack.NewButtonBlockElement(
+			spec.BackActionID,
+			spec.BackActionID,
+			slack.NewTextBlockObject(slack.PlainTextType, spec.BackLabel, false, false),
+		))
+	}
 
+	section := slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.MarkdownType, spec.Prompt, false, false),
+		nil, nil,
+	)
+	actions := slack.NewActionBlock(spec.ActionID+"_block", elements...)
+
+	return c.postBlocks(channelID, threadTS, section, actions, "post external selector")
+}
+
+// postBlocks shares the "post section + actions, thread-scoped if threadTS
+// is set" machinery across the three rendering modes. errLabel is prefixed
+// onto any wrapped error for easier diagnosis.
+func (c *Client) postBlocks(channelID, threadTS string, section *slack.SectionBlock, actions *slack.ActionBlock, errLabel string) (string, error) {
 	opts := []slack.MsgOption{slack.MsgOptionBlocks(section, actions)}
 	if threadTS != "" {
 		opts = append(opts, slack.MsgOptionTS(threadTS))
 	}
-
 	_, ts, err := c.api.PostMessage(channelID, opts...)
 	if err != nil {
-		return "", fmt.Errorf("post external selector: %w", err)
+		return "", fmt.Errorf("%s: %w", errLabel, err)
 	}
 	return ts, nil
 }

--- a/app/slack/selector_test.go
+++ b/app/slack/selector_test.go
@@ -1,0 +1,133 @@
+package slack
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildOptions returns n placeholder SmartSelectorOptions.
+func buildOptions(n int) []SmartSelectorOption {
+	opts := make([]SmartSelectorOption, n)
+	for i := 0; i < n; i++ {
+		opts[i] = SmartSelectorOption{
+			Label: fmt.Sprintf("opt-%d", i),
+			Value: fmt.Sprintf("v-%d", i),
+		}
+	}
+	return opts
+}
+
+// TestSelectorRenderMode_Thresholds locks the boundary behaviour that
+// callers rely on. If Slack ever raises the actions-block cap, this table
+// is the single source of truth to bump.
+func TestSelectorRenderMode_Thresholds(t *testing.T) {
+	cases := []struct {
+		name   string
+		spec   SmartSelectorSpec
+		want   selectorRenderKind
+		reason string
+	}{
+		{
+			name:   "searchable overrides everything",
+			spec:   SmartSelectorSpec{Searchable: true},
+			want:   renderExternalSelect,
+			reason: "external search is explicit, options count is irrelevant",
+		},
+		{
+			name:   "1 option -> button",
+			spec:   SmartSelectorSpec{Options: buildOptions(1)},
+			want:   renderButton,
+			reason: "far under cap",
+		},
+		{
+			name:   "24 options -> button (exactly at cap, no extras)",
+			spec:   SmartSelectorSpec{Options: buildOptions(24)},
+			want:   renderButton,
+			reason: "24 + 0 extras ≤ 25",
+		},
+		{
+			name:   "25 options -> button (exactly at cap, no extras)",
+			spec:   SmartSelectorSpec{Options: buildOptions(25)},
+			want:   renderButton,
+			reason: "25 + 0 extras ≤ 25",
+		},
+		{
+			name:   "26 options -> static_select",
+			spec:   SmartSelectorSpec{Options: buildOptions(26)},
+			want:   renderStaticSelect,
+			reason: "26 exceeds actions-block cap of 25",
+		},
+		{
+			name:   "24 options + back button -> static_select",
+			spec:   SmartSelectorSpec{Options: buildOptions(24), BackActionID: "back"},
+			want:   renderButton,
+			reason: "24 + 1 extra = 25, still ≤ cap",
+		},
+		{
+			name:   "25 options + back button -> static_select",
+			spec:   SmartSelectorSpec{Options: buildOptions(25), BackActionID: "back"},
+			want:   renderStaticSelect,
+			reason: "25 + 1 extra = 26 > cap; must fall back to dropdown",
+		},
+		{
+			name: "23 options + back + cancel -> button",
+			spec: SmartSelectorSpec{
+				Options:        buildOptions(23),
+				BackActionID:   "back",
+				CancelActionID: "cancel",
+			},
+			want:   renderButton,
+			reason: "23 + 2 extras = 25, ≤ cap",
+		},
+		{
+			name: "24 options + back + cancel -> static_select",
+			spec: SmartSelectorSpec{
+				Options:        buildOptions(24),
+				BackActionID:   "back",
+				CancelActionID: "cancel",
+			},
+			want:   renderStaticSelect,
+			reason: "24 + 2 extras = 26 > cap",
+		},
+		{
+			name:   "100 options -> static_select (exactly at dropdown cap)",
+			spec:   SmartSelectorSpec{Options: buildOptions(100)},
+			want:   renderStaticSelect,
+			reason: "100 options fits static_select",
+		},
+		{
+			name:   "101 options -> static_truncated",
+			spec:   SmartSelectorSpec{Options: buildOptions(101)},
+			want:   renderStaticTruncated,
+			reason: "beyond static_select cap; callee will slice to 100",
+		},
+		{
+			name:   "500 options -> static_truncated",
+			spec:   SmartSelectorSpec{Options: buildOptions(500)},
+			want:   renderStaticTruncated,
+			reason: "any very-large list degrades gracefully",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectorRenderMode(tc.spec)
+			if got != tc.want {
+				t.Errorf("selectorRenderMode() = %d, want %d (%s)", got, tc.want, tc.reason)
+			}
+		})
+	}
+}
+
+// TestSelectorRenderMode_SearchableIgnoresOptions — when Searchable is set,
+// the option count has no effect; external select is always picked so the
+// caller's static options list can ride along as a search corpus without
+// triggering button-row rendering.
+func TestSelectorRenderMode_SearchableIgnoresOptions(t *testing.T) {
+	for _, n := range []int{0, 3, 25, 200} {
+		spec := SmartSelectorSpec{Searchable: true, Options: buildOptions(n)}
+		if got := selectorRenderMode(spec); got != renderExternalSelect {
+			t.Errorf("options=%d: got %d, want renderExternalSelect", n, got)
+		}
+	}
+}

--- a/app/slack_adapter_port.go
+++ b/app/slack_adapter_port.go
@@ -34,6 +34,10 @@ func (a *slackAdapterPort) UpdateMessage(channelID, messageTS, text string) erro
 	return a.client.UpdateMessage(channelID, messageTS, text)
 }
 
+func (a *slackAdapterPort) DeleteMessage(channelID, messageTS string) error {
+	return a.client.DeleteMessage(channelID, messageTS)
+}
+
 func (a *slackAdapterPort) UpdateMessageWithButton(channelID, messageTS, text, actionID, buttonText, value string) error {
 	return a.client.UpdateMessageWithButton(channelID, messageTS, text, actionID, buttonText, value)
 }

--- a/app/slack_adapter_port.go
+++ b/app/slack_adapter_port.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Ivantseng123/agentdock/app/bot"
 	slackclient "github.com/Ivantseng123/agentdock/app/slack"
+	"github.com/Ivantseng123/agentdock/app/workflow"
 )
 
 // slackAdapterPort wraps *slackclient.Client to satisfy workflow.SlackPort.
@@ -37,16 +38,30 @@ func (a *slackAdapterPort) UpdateMessageWithButton(channelID, messageTS, text, a
 	return a.client.UpdateMessageWithButton(channelID, messageTS, text, actionID, buttonText, value)
 }
 
-func (a *slackAdapterPort) PostSelector(channelID, prompt, actionPrefix string, labels, values []string, threadTS string) (string, error) {
-	return a.client.PostSelector(channelID, prompt, actionPrefix, labels, values, threadTS)
+func (a *slackAdapterPort) PostSmartSelector(channelID, threadTS string, spec workflow.SelectorSpec) (string, error) {
+	return a.client.PostSmartSelector(channelID, threadTS, toSlackSelectorSpec(spec))
 }
 
-func (a *slackAdapterPort) PostSelectorWithBack(channelID, prompt, actionPrefix string, labels, values []string, threadTS, backActionID, backLabel string) (string, error) {
-	return a.client.PostSelectorWithBack(channelID, prompt, actionPrefix, labels, values, threadTS, backActionID, backLabel)
-}
-
-func (a *slackAdapterPort) PostExternalSelector(channelID, prompt, actionID, placeholder, threadTS, cancelActionID, cancelLabel string) (string, error) {
-	return a.client.PostExternalSelector(channelID, prompt, actionID, placeholder, threadTS, cancelActionID, cancelLabel)
+// toSlackSelectorSpec copies the workflow-layer SelectorSpec into the
+// slack-layer SmartSelectorSpec field-for-field. The two types stay in sync
+// so the workflow package never imports the slack client; this helper is the
+// only translation point.
+func toSlackSelectorSpec(spec workflow.SelectorSpec) slackclient.SmartSelectorSpec {
+	opts := make([]slackclient.SmartSelectorOption, len(spec.Options))
+	for i, o := range spec.Options {
+		opts[i] = slackclient.SmartSelectorOption{Label: o.Label, Value: o.Value}
+	}
+	return slackclient.SmartSelectorSpec{
+		Prompt:         spec.Prompt,
+		ActionID:       spec.ActionID,
+		Options:        opts,
+		Searchable:     spec.Searchable,
+		Placeholder:    spec.Placeholder,
+		BackActionID:   spec.BackActionID,
+		BackLabel:      spec.BackLabel,
+		CancelActionID: spec.CancelActionID,
+		CancelLabel:    spec.CancelLabel,
+	}
 }
 
 func (a *slackAdapterPort) OpenTextInputModal(triggerID, title, label, inputName, metadata string) error {

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -63,18 +63,24 @@ func (w *AskWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args string)
 		TaskType:    "ask",
 		State:       &askState{Question: args},
 	}
+	return w.attachPromptStep(pending), nil
+}
+
+// attachPromptStep builds the "附加 Repository?" selector used both on the
+// initial Trigger and when the user backs out of the repo picker.
+func (w *AskWorkflow) attachPromptStep(p *Pending) NextStep {
 	return NextStep{
 		Kind: NextStepSelector,
 		Selector: &SelectorSpec{
-			Prompt:   ":question: 要附加 repo context 嗎？",
+			Prompt:   ":question: 要附加 Repository 嗎？",
 			ActionID: "ask_attach_repo",
 			Options: []SelectorOption{
 				{Label: "附加", Value: "attach"},
 				{Label: "不用", Value: "skip"},
 			},
 		},
-		Pending: pending,
-	}, nil
+		Pending: p,
+	}
 }
 
 // Selection handles follow-up button clicks for the ask wizard. Five
@@ -111,8 +117,9 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 		repos := channelCfg.GetRepos()
 		p.Phase = "ask_repo_select"
 		if len(repos) == 0 {
-			// No repos configured — fall back to external search. Cancel button
-			// rides along so the user isn't stuck if they change their mind.
+			// No repos configured — fall back to external search. Back button
+			// rides along so the user can bail to the attach prompt without
+			// abandoning the whole flow.
 			return NextStep{
 				Kind: NextStepSelector,
 				Selector: &SelectorSpec{
@@ -120,8 +127,8 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 					ActionID:       "ask_repo",
 					Searchable:     true,
 					Placeholder:    "Type to search repos...",
-					CancelActionID: "ask_cancel",
-					CancelLabel:    "取消",
+					CancelActionID: "ask_repo_back",
+					CancelLabel:    "← 返回",
 				},
 				Pending: p,
 			}, nil
@@ -130,7 +137,7 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 		for _, r := range repos {
 			options = append(options, SelectorOption{Label: r, Value: r})
 		}
-		options = append(options, SelectorOption{Label: "取消", Value: "取消"})
+		options = append(options, SelectorOption{Label: "← 返回", Value: "back_to_attach"})
 		return NextStep{
 			Kind: NextStepSelector,
 			Selector: &SelectorSpec{
@@ -142,8 +149,13 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 		}, nil
 
 	case "ask_repo_select":
-		if value == "取消" {
-			return NextStep{Kind: NextStepCancel}, nil
+		if value == "back_to_attach" || value == "← 返回" {
+			// User bailed out of the repo picker — reset the attach choice
+			// and re-emit the attach/skip prompt so they can try again.
+			st.AttachRepo = false
+			st.SelectedRepo = ""
+			p.Phase = "ask_repo_prompt"
+			return w.attachPromptStep(p), nil
 		}
 		st.SelectedRepo = value
 		return w.afterRepoSelectedStep(p), nil

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -64,11 +64,14 @@ func (w *AskWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args string)
 		State:       &askState{Question: args},
 	}
 	return NextStep{
-		Kind:           NextStepPostSelector,
-		SelectorPrompt: ":question: 要附加 repo context 嗎？",
-		SelectorActions: []SelectorAction{
-			{ActionID: "ask_attach_repo", Label: "附加", Value: "attach"},
-			{ActionID: "ask_attach_repo", Label: "不用", Value: "skip"},
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":question: 要附加 repo context 嗎？",
+			ActionID: "ask_attach_repo",
+			Options: []SelectorOption{
+				{Label: "附加", Value: "attach"},
+				{Label: "不用", Value: "skip"},
+			},
 		},
 		Pending: pending,
 	}, nil
@@ -111,25 +114,31 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 			// No repos configured — fall back to external search. Cancel button
 			// rides along so the user isn't stuck if they change their mind.
 			return NextStep{
-				Kind:                   NextStepPostExternalSelector,
-				SelectorPrompt:         ":point_right: Search and select a repo:",
-				SelectorActionID:       "ask_repo",
-				SelectorPlaceholder:    "Type to search repos...",
-				SelectorCancelActionID: "ask_cancel",
-				SelectorCancelLabel:    "取消",
-				Pending:                p,
+				Kind: NextStepSelector,
+				Selector: &SelectorSpec{
+					Prompt:         ":point_right: Search and select a repo:",
+					ActionID:       "ask_repo",
+					Searchable:     true,
+					Placeholder:    "Type to search repos...",
+					CancelActionID: "ask_cancel",
+					CancelLabel:    "取消",
+				},
+				Pending: p,
 			}, nil
 		}
-		actions := make([]SelectorAction, 0, len(repos)+1)
+		options := make([]SelectorOption, 0, len(repos)+1)
 		for _, r := range repos {
-			actions = append(actions, SelectorAction{ActionID: "ask_repo", Label: r, Value: r})
+			options = append(options, SelectorOption{Label: r, Value: r})
 		}
-		actions = append(actions, SelectorAction{ActionID: "ask_repo", Label: "取消", Value: "取消"})
+		options = append(options, SelectorOption{Label: "取消", Value: "取消"})
 		return NextStep{
-			Kind:            NextStepPostSelector,
-			SelectorPrompt:  ":point_right: Which repo?",
-			SelectorActions: actions,
-			Pending:         p,
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:   ":point_right: Which repo?",
+				ActionID: "ask_repo",
+				Options:  options,
+			},
+			Pending: p,
 		}, nil
 
 	case "ask_repo_select":
@@ -227,16 +236,19 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 	}
 
 	p.Phase = "ask_branch_select"
-	actions := make([]SelectorAction, 0, len(branches)+1)
+	options := make([]SelectorOption, 0, len(branches)+1)
 	for _, b := range branches {
-		actions = append(actions, SelectorAction{ActionID: "ask_branch", Label: b, Value: b})
+		options = append(options, SelectorOption{Label: b, Value: b})
 	}
-	actions = append(actions, SelectorAction{ActionID: "ask_branch", Label: "取消", Value: "取消"})
+	options = append(options, SelectorOption{Label: "取消", Value: "取消"})
 	return NextStep{
-		Kind:            NextStepPostSelector,
-		SelectorPrompt:  fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
-		SelectorActions: actions,
-		Pending:         p,
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
+			ActionID: "ask_branch",
+			Options:  options,
+		},
+		Pending: p,
 	}
 }
 
@@ -246,11 +258,14 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 // its own special case.
 func (w *AskWorkflow) descriptionPromptStep(p *Pending) NextStep {
 	return NextStep{
-		Kind:           NextStepPostSelector,
-		SelectorPrompt: ":pencil2: 要補充說明想讓 agent 做什麼嗎？",
-		SelectorActions: []SelectorAction{
-			{ActionID: "description_action", Label: "補充說明", Value: "補充說明"},
-			{ActionID: "description_action", Label: "跳過", Value: "跳過"},
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":pencil2: 要補充說明想讓 agent 做什麼嗎？",
+			ActionID: "description_action",
+			Options: []SelectorOption{
+				{Label: "補充說明", Value: "補充說明"},
+				{Label: "跳過", Value: "跳過"},
+			},
 		},
 		Pending: p,
 	}

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -136,21 +136,37 @@ func TestAskWorkflow_Selection_RepoChoiceWithBranchesShowsBranchSelector(t *test
 	}
 }
 
-func TestAskWorkflow_Selection_RepoSelectCancelReturnsCancel(t *testing.T) {
-	// 取消 on repo picker must yield NextStepCancel so the dispatcher clears
-	// dedup and stops — no submit, no error.
+func TestAskWorkflow_Selection_RepoSelectBackReturnsToAttachPrompt(t *testing.T) {
+	// back_to_attach on repo picker rewinds to the attach/skip prompt
+	// rather than ending the task — user changed their mind about
+	// attaching a repo but doesn't want to abandon the whole ask.
 	w, _ := newTestAskWorkflow(t)
 	p := &Pending{Phase: "ask_repo_select", State: &askState{Question: "Q", AttachRepo: true}, ChannelID: "C1", ThreadTS: "1.0"}
-	step, err := w.Selection(context.Background(), p, "取消")
+	step, err := w.Selection(context.Background(), p, "back_to_attach")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepCancel {
-		t.Errorf("expected NextStepCancel, got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (attach prompt), got %v", step.Kind)
+	}
+	if p.Phase != "ask_repo_prompt" {
+		t.Errorf("phase = %q, want ask_repo_prompt (rewound)", p.Phase)
 	}
 	st := p.State.(*askState)
+	if st.AttachRepo {
+		t.Error("AttachRepo should reset to false on back_to_attach")
+	}
 	if st.SelectedRepo != "" {
-		t.Errorf("SelectedRepo leaked on cancel: %q", st.SelectedRepo)
+		t.Errorf("SelectedRepo leaked on back: %q", st.SelectedRepo)
+	}
+	// Re-emitted prompt must be the attach/skip selector.
+	if step.Selector == nil || step.Selector.ActionID != "ask_attach_repo" {
+		t.Errorf("back must re-emit attach prompt, got action_id=%q", func() string {
+			if step.Selector == nil {
+				return "<nil>"
+			}
+			return step.Selector.ActionID
+		}())
 	}
 }
 
@@ -170,9 +186,10 @@ func TestAskWorkflow_Selection_BranchSelectCancelReturnsCancel(t *testing.T) {
 	}
 }
 
-func TestAskWorkflow_Selection_AttachWithReposIncludesCancel(t *testing.T) {
-	// Button-based repo selector must include 取消 so the user isn't stuck on
-	// the picker if they change their mind.
+func TestAskWorkflow_Selection_AttachWithReposIncludesBack(t *testing.T) {
+	// Button-based repo selector must include a back option so the user
+	// can unwind to the attach prompt instead of being stuck choosing a
+	// repo they no longer want.
 	w, _ := newTestAskWorkflow(t)
 	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
 	p := &Pending{Phase: "ask_repo_prompt", State: &askState{Question: "Q"}, ChannelID: "C1", ThreadTS: "1.0"}
@@ -180,18 +197,18 @@ func TestAskWorkflow_Selection_AttachWithReposIncludesCancel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 2 repos + 1 cancel.
+	// 2 repos + 1 back.
 	if len(step.Selector.Options) != 3 {
-		t.Errorf("expected 3 actions (2 repos + 取消), got %d", len(step.Selector.Options))
+		t.Errorf("expected 3 options (2 repos + back), got %d", len(step.Selector.Options))
 	}
-	sawCancel := false
+	sawBack := false
 	for _, o := range step.Selector.Options {
-		if o.Value == "取消" {
-			sawCancel = true
+		if o.Value == "back_to_attach" {
+			sawBack = true
 		}
 	}
-	if !sawCancel {
-		t.Error("cancel option missing from repo selector")
+	if !sawBack {
+		t.Error("back option missing from repo selector")
 	}
 }
 

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -23,11 +23,11 @@ func TestAskWorkflow_Trigger_ReturnsRepoPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector, got %v", step.Kind)
 	}
-	if len(step.SelectorActions) != 2 {
-		t.Errorf("expected 2 actions (attach/skip), got %d", len(step.SelectorActions))
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("expected 2 actions (attach/skip), got %d", len(step.Selector.Options))
 	}
 	// Identity resolution must populate RequestID on the Pending envelope
 	// so downstream BuildJob can re-use it (matches IssueWorkflow.Trigger).
@@ -51,8 +51,8 @@ func TestAskWorkflow_Selection_SkipRoutesToDescriptionPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (description prompt), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (description prompt), got %v", step.Kind)
 	}
 	if p.Phase != "ask_description_prompt" {
 		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
@@ -61,12 +61,10 @@ func TestAskWorkflow_Selection_SkipRoutesToDescriptionPrompt(t *testing.T) {
 	if st.AttachRepo {
 		t.Error("AttachRepo should be false on skip")
 	}
-	// Action IDs reuse description_action so app.go's existing route
+	// ActionID reuses description_action so app.go's existing route
 	// handles the modal-trigger-id forwarding without a new special case.
-	for _, a := range step.SelectorActions {
-		if a.ActionID != "description_action" {
-			t.Errorf("ActionID = %q, want description_action", a.ActionID)
-		}
+	if step.Selector.ActionID != "description_action" {
+		t.Errorf("ActionID = %q, want description_action", step.Selector.ActionID)
 	}
 }
 
@@ -78,8 +76,8 @@ func TestAskWorkflow_Selection_AttachShowsRepoSelector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (repo choice), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (repo choice), got %v", step.Kind)
 	}
 }
 
@@ -92,8 +90,8 @@ func TestAskWorkflow_Selection_RepoChoiceRoutesToDescriptionPrompt(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (description prompt), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (description prompt), got %v", step.Kind)
 	}
 	if p.Phase != "ask_description_prompt" {
 		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
@@ -114,27 +112,27 @@ func TestAskWorkflow_Selection_RepoChoiceWithBranchesShowsBranchSelector(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (branch selector), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (branch selector), got %v", step.Kind)
 	}
 	if p.Phase != "ask_branch_select" {
 		t.Errorf("Phase = %q, want ask_branch_select", p.Phase)
 	}
 	// 2 branches + 1 cancel button.
-	if len(step.SelectorActions) != 3 {
-		t.Errorf("expected 3 actions (2 branches + 取消), got %d", len(step.SelectorActions))
+	if len(step.Selector.Options) != 3 {
+		t.Errorf("expected 3 actions (2 branches + 取消), got %d", len(step.Selector.Options))
+	}
+	if step.Selector.ActionID != "ask_branch" {
+		t.Errorf("ActionID = %q, want ask_branch", step.Selector.ActionID)
 	}
 	sawCancel := false
-	for _, a := range step.SelectorActions {
-		if a.ActionID != "ask_branch" {
-			t.Errorf("ActionID = %q, want ask_branch", a.ActionID)
-		}
-		if a.Value == "取消" {
+	for _, o := range step.Selector.Options {
+		if o.Value == "取消" {
 			sawCancel = true
 		}
 	}
 	if !sawCancel {
-		t.Error("cancel button missing from branch selector")
+		t.Error("cancel option missing from branch selector")
 	}
 }
 
@@ -183,17 +181,17 @@ func TestAskWorkflow_Selection_AttachWithReposIncludesCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 	// 2 repos + 1 cancel.
-	if len(step.SelectorActions) != 3 {
-		t.Errorf("expected 3 actions (2 repos + 取消), got %d", len(step.SelectorActions))
+	if len(step.Selector.Options) != 3 {
+		t.Errorf("expected 3 actions (2 repos + 取消), got %d", len(step.Selector.Options))
 	}
 	sawCancel := false
-	for _, a := range step.SelectorActions {
-		if a.Value == "取消" {
+	for _, o := range step.Selector.Options {
+		if o.Value == "取消" {
 			sawCancel = true
 		}
 	}
 	if !sawCancel {
-		t.Error("cancel button missing from repo selector")
+		t.Error("cancel option missing from repo selector")
 	}
 }
 
@@ -206,12 +204,12 @@ func TestAskWorkflow_Selection_AttachExternalSearchIncludesCancel(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostExternalSelector {
-		t.Fatalf("expected NextStepPostExternalSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector /* external */ {
+		t.Fatalf("expected NextStepSelector /* external */, got %v", step.Kind)
 	}
-	if step.SelectorCancelActionID == "" || step.SelectorCancelLabel == "" {
+	if step.Selector.CancelActionID == "" || step.Selector.CancelLabel == "" {
 		t.Errorf("expected cancel info on external selector, got actionID=%q label=%q",
-			step.SelectorCancelActionID, step.SelectorCancelLabel)
+			step.Selector.CancelActionID, step.Selector.CancelLabel)
 	}
 }
 
@@ -222,8 +220,8 @@ func TestAskWorkflow_Selection_BranchPickGoesToDescriptionPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (description prompt), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (description prompt), got %v", step.Kind)
 	}
 	if p.Phase != "ask_description_prompt" {
 		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
@@ -253,7 +251,7 @@ func TestAskWorkflow_Selection_SingleBranchSkipsSelector(t *testing.T) {
 	if st.SelectedBranch != "main" {
 		t.Errorf("SelectedBranch = %q, want main (auto-selected)", st.SelectedBranch)
 	}
-	if step.Kind != NextStepPostSelector {
+	if step.Kind != NextStepSelector {
 		t.Errorf("expected description prompt selector, got %v", step.Kind)
 	}
 }
@@ -327,9 +325,9 @@ func TestAskWorkflow_Selection_DescriptionModalEmptyLeavesQuestion(t *testing.T)
 
 // TestAskWorkflow_Selection_AttachWithNoReposUsesExternalSearch covers the
 // fallback path that fires when ChannelDefaults.Repos and Channels[ID] are
-// both empty. The dispatcher routes NextStepPostExternalSelector to a
+// both empty. The dispatcher routes NextStepSelector /* external */ to a
 // searchable Slack modal rather than a button selector. Regression guard
-// for the Task 5.2 plan-deviation (plan's NextStepPostSelector+empty-actions
+// for the Task 5.2 plan-deviation (plan's NextStepSelector+empty-actions
 // approach was broken — see commit 37bc67b).
 func TestAskWorkflow_Selection_AttachWithNoReposUsesExternalSearch(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
@@ -339,13 +337,13 @@ func TestAskWorkflow_Selection_AttachWithNoReposUsesExternalSearch(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostExternalSelector {
-		t.Errorf("expected NextStepPostExternalSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector /* external */ {
+		t.Errorf("expected NextStepSelector /* external */, got %v", step.Kind)
 	}
-	if step.SelectorActionID != "ask_repo" {
-		t.Errorf("SelectorActionID = %q, want ask_repo", step.SelectorActionID)
+	if step.Selector.ActionID != "ask_repo" {
+		t.Errorf("SelectorActionID = %q, want ask_repo", step.Selector.ActionID)
 	}
-	if step.SelectorPlaceholder == "" {
+	if step.Selector.Placeholder == "" {
 		t.Error("SelectorPlaceholder should be set for external search")
 	}
 	if p.Phase != "ask_repo_select" {

--- a/app/workflow/dispatcher.go
+++ b/app/workflow/dispatcher.go
@@ -198,12 +198,15 @@ func (d *Dispatcher) postDSelector(ev TriggerEvent, warning string) (*Pending, N
 		Phase:     "d_selector",
 	}
 	step := NextStep{
-		Kind:           NextStepPostSelector,
-		SelectorPrompt: prompt,
-		SelectorActions: []SelectorAction{
-			{ActionID: "d_selector", Label: "📝 建 Issue", Value: "issue"},
-			{ActionID: "d_selector", Label: "❓ 問問題", Value: "ask"},
-			{ActionID: "d_selector", Label: "🔍 Review PR", Value: "pr_review"},
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   prompt,
+			ActionID: "d_selector",
+			Options: []SelectorOption{
+				{Label: "📝 建 Issue", Value: "issue"},
+				{Label: "❓ 問問題", Value: "ask"},
+				{Label: "🔍 Review PR", Value: "pr_review"},
+			},
 		},
 		Pending: pending,
 	}

--- a/app/workflow/dispatcher_test.go
+++ b/app/workflow/dispatcher_test.go
@@ -81,11 +81,11 @@ func TestDispatcher_UnknownVerb_YieldsDSelectorWithWarning(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector, got %v", step.Kind)
 	}
-	if !strings.Contains(step.SelectorPrompt, "不認得") {
-		t.Errorf("expected warning text, got %q", step.SelectorPrompt)
+	if !strings.Contains(step.Selector.Prompt, "不認得") {
+		t.Errorf("expected warning text, got %q", step.Selector.Prompt)
 	}
 }
 

--- a/app/workflow/issue.go
+++ b/app/workflow/issue.go
@@ -112,11 +112,14 @@ func (w *IssueWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args strin
 		// External-search: no repos configured for this channel.
 		p.Phase = "repo_search"
 		return NextStep{
-			Kind:                NextStepPostExternalSelector,
-			SelectorPrompt:      ":point_right: Search and select a repo:",
-			SelectorActionID:    "repo_search",
-			SelectorPlaceholder: "Type to search repos...",
-			Pending:             p,
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:      ":point_right: Search and select a repo:",
+				ActionID:    "repo_search",
+				Searchable:  true,
+				Placeholder: "Type to search repos...",
+			},
+			Pending: p,
 		}, nil
 
 	case 1:
@@ -124,14 +127,16 @@ func (w *IssueWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args strin
 		return w.afterRepoSelected(p, channelCfg), nil
 
 	default:
-		// Multi-repo: show button selector.
+		// Multi-repo: show selector (button for ≤24, static_select above).
 		p.Phase = "repo"
-		actions := reposToActions(repos)
 		return NextStep{
-			Kind:            NextStepPostSelector,
-			SelectorPrompt:  ":point_right: Which repo should this issue go to?",
-			SelectorActions: actions,
-			Pending:         p,
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:   ":point_right: Which repo should this issue go to?",
+				ActionID: "repo_select",
+				Options:  reposToOptions(repos),
+			},
+			Pending: p,
 		}, nil
 	}
 }
@@ -519,19 +524,26 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 		return w.descriptionPromptStep(p)
 	}
 
-	// Multi-branch: show selector.
+	// Multi-branch: show selector. The adapter picks button-row vs
+	// static_select based on len(branches) — repos with >24 branches used
+	// to hit Slack's actions-block cap and surface as ":x: 無法顯示選單".
 	p.Phase = "branch"
-	backAction := ""
+	backAction, backLabel := "", ""
 	if st.RepoWasPicked {
 		backAction = "back_to_repo"
+		backLabel = "← 重新選 repo"
 	}
-	actions := labelsToActions("branch_select", branches)
 	return NextStep{
-		Kind:            NextStepPostSelector,
-		SelectorPrompt:  fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
-		SelectorActions: actions,
-		SelectorBack:    backAction,
-		Pending:         p,
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:       fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
+			ActionID:     "branch_select",
+			Options:      labelsToOptions(branches),
+			Placeholder:  "選擇 branch...",
+			BackActionID: backAction,
+			BackLabel:    backLabel,
+		},
+		Pending: p,
 	}
 }
 
@@ -540,20 +552,25 @@ func (w *IssueWorkflow) descriptionPromptStep(p *Pending) NextStep {
 	st := p.State.(*issueState)
 	p.Phase = "description"
 
-	backAction := ""
+	backAction, backLabel := "", ""
 	if st.RepoWasPicked {
 		backAction = "back_to_repo"
+		backLabel = "← 重新選 repo"
 	}
 
 	return NextStep{
-		Kind:           NextStepPostSelector,
-		SelectorPrompt: ":memo: 需要補充說明嗎？（補充後可讓分析更精準）",
-		SelectorActions: []SelectorAction{
-			{ActionID: "description_action", Label: "補充說明", Value: "補充說明"},
-			{ActionID: "description_action", Label: "跳過", Value: "跳過"},
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":memo: 需要補充說明嗎？（補充後可讓分析更精準）",
+			ActionID: "description_action",
+			Options: []SelectorOption{
+				{Label: "補充說明", Value: "補充說明"},
+				{Label: "跳過", Value: "跳過"},
+			},
+			BackActionID: backAction,
+			BackLabel:    backLabel,
 		},
-		SelectorBack: backAction,
-		Pending:      p,
+		Pending: p,
 	}
 }
 
@@ -581,21 +598,26 @@ func (w *IssueWorkflow) handleBackToRepo(p *Pending, st *issueState) NextStep {
 	if len(repos) == 0 {
 		p.Phase = "repo_search"
 		return NextStep{
-			Kind:                NextStepPostExternalSelector,
-			SelectorPrompt:      ":point_right: Search and select a repo:",
-			SelectorActionID:    "repo_search",
-			SelectorPlaceholder: "Type to search repos...",
-			Pending:             p,
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:      ":point_right: Search and select a repo:",
+				ActionID:    "repo_search",
+				Searchable:  true,
+				Placeholder: "Type to search repos...",
+			},
+			Pending: p,
 		}
 	}
 
 	p.Phase = "repo"
-	actions := reposToActions(repos)
 	return NextStep{
-		Kind:            NextStepPostSelector,
-		SelectorPrompt:  ":point_right: Which repo should this issue go to?",
-		SelectorActions: actions,
-		Pending:         p,
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":point_right: Which repo should this issue go to?",
+			ActionID: "repo_select",
+			Options:  reposToOptions(repos),
+		},
+		Pending: p,
 	}
 }
 
@@ -613,33 +635,24 @@ func (w *IssueWorkflow) channelPriority(channelID string) int {
 	return 50
 }
 
-// reposToActions converts a slice of repo strings to SelectorActions for a
-// repo picker. Each action uses "repo_select" as the ActionID (matches the
-// old PostSelector "repo_select" prefix used in app/bot/workflow.go).
-func reposToActions(repos []string) []SelectorAction {
-	actions := make([]SelectorAction, len(repos))
+// reposToOptions converts a slice of repo strings to SelectorOptions for the
+// repo picker (label and value both equal to the repo path).
+func reposToOptions(repos []string) []SelectorOption {
+	opts := make([]SelectorOption, len(repos))
 	for i, r := range repos {
-		actions[i] = SelectorAction{
-			ActionID: "repo_select",
-			Label:    r,
-			Value:    r,
-		}
+		opts[i] = SelectorOption{Label: r, Value: r}
 	}
-	return actions
+	return opts
 }
 
-// labelsToActions converts string labels to SelectorActions using the given
-// actionID prefix for all entries.
-func labelsToActions(actionID string, labels []string) []SelectorAction {
-	actions := make([]SelectorAction, len(labels))
+// labelsToOptions converts a slice of strings to SelectorOptions, using each
+// string as both the label and the value.
+func labelsToOptions(labels []string) []SelectorOption {
+	opts := make([]SelectorOption, len(labels))
 	for i, l := range labels {
-		actions[i] = SelectorAction{
-			ActionID: actionID,
-			Label:    l,
-			Value:    l,
-		}
+		opts[i] = SelectorOption{Label: l, Value: l}
 	}
-	return actions
+	return opts
 }
 
 // cleanCloneURL normalises a repo reference to a full HTTPS clone URL. Raw

--- a/app/workflow/issue_test.go
+++ b/app/workflow/issue_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -51,17 +52,20 @@ func TestIssueWorkflow_Trigger_NoRepoSingleConfigured(t *testing.T) {
 	if step.Kind == NextStepError {
 		t.Fatalf("unexpected error step: %q", step.ErrorText)
 	}
-	// The description prompt IS a PostSelector, so we cannot assert "not
-	// NextStepPostSelector". Instead assert it doesn't look like a repo picker:
+	// The description prompt IS also a NextStepSelector, so we cannot assert
+	// on Kind. Instead assert it doesn't look like a repo picker:
 	// — it must not list the configured repo as a selector option, and
 	// — its prompt must not contain "Which repo".
-	for _, a := range step.SelectorActions {
-		if a.Value == "foo/bar" {
-			t.Errorf("single-repo channel should skip repo selector, but got repo %q as option", a.Value)
+	if step.Selector == nil {
+		t.Fatal("expected Selector spec")
+	}
+	for _, o := range step.Selector.Options {
+		if o.Value == "foo/bar" {
+			t.Errorf("single-repo channel should skip repo selector, but got repo %q as option", o.Value)
 		}
 	}
-	if strings.Contains(step.SelectorPrompt, "Which repo") {
-		t.Errorf("single-repo channel should not show repo picker, got prompt: %q", step.SelectorPrompt)
+	if strings.Contains(step.Selector.Prompt, "Which repo") {
+		t.Errorf("single-repo channel should not show repo picker, got prompt: %q", step.Selector.Prompt)
 	}
 }
 
@@ -73,11 +77,11 @@ func TestIssueWorkflow_Trigger_MultiRepoShowsSelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector, got %v", step.Kind)
 	}
-	if len(step.SelectorActions) != 2 {
-		t.Errorf("expected 2 selector options, got %d", len(step.SelectorActions))
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("expected 2 selector options, got %d", len(step.Selector.Options))
 	}
 }
 
@@ -94,8 +98,8 @@ func TestIssueWorkflow_Selection_RepoPhase_TransitionsToBranchOrDescription(t *t
 	if step.Kind == NextStepError {
 		t.Errorf("unexpected error: %q", step.ErrorText)
 	}
-	if step.Kind != NextStepPostSelector {
-		t.Errorf("expected NextStepPostSelector (description prompt), got %v", step.Kind)
+	if step.Kind != NextStepSelector {
+		t.Errorf("expected NextStepSelector (description prompt), got %v", step.Kind)
 	}
 	if step.Pending == nil || step.Pending.Phase != "description" {
 		phase := "<nil pending>"
@@ -148,16 +152,16 @@ func TestIssueWorkflow_Trigger_NoChannelRepos_UsesExternalSelector(t *testing.T)
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
-	if step.Kind != NextStepPostExternalSelector {
-		t.Errorf("expected NextStepPostExternalSelector, got %v", step.Kind)
+	if step.Kind != NextStepSelector /* external */ {
+		t.Errorf("expected NextStepSelector /* external */, got %v", step.Kind)
 	}
-	if step.SelectorPrompt == "" {
+	if step.Selector.Prompt == "" {
 		t.Error("SelectorPrompt should carry the external-search placeholder text")
 	}
-	if step.SelectorActionID != "repo_search" {
-		t.Errorf("SelectorActionID = %q, want repo_search", step.SelectorActionID)
+	if step.Selector.ActionID != "repo_search" {
+		t.Errorf("SelectorActionID = %q, want repo_search", step.Selector.ActionID)
 	}
-	if step.SelectorPlaceholder == "" {
+	if step.Selector.Placeholder == "" {
 		t.Error("SelectorPlaceholder should be non-empty")
 	}
 	if step.Pending == nil || step.Pending.Phase != "repo_search" {
@@ -422,6 +426,49 @@ func TestIssueWorkflow_BuildJob_AcceptsNonEmptyRepo(t *testing.T) {
 	}
 	if job == nil {
 		t.Fatal("expected non-nil job")
+	}
+}
+
+// TestIssueWorkflow_Selection_ManyBranches_EmitsFullSelectorSpec is the
+// regression guard for "無法顯示選單，請重試" on repos with >24 branches. The
+// workflow must pack every branch into the SelectorSpec; the adapter picks
+// static_select when the count exceeds the actions-block button cap so
+// nothing is dropped upstream.
+func TestIssueWorkflow_Selection_ManyBranches_EmitsFullSelectorSpec(t *testing.T) {
+	trueVal := true
+	branches := make([]string, 30) // well past the 25-button Slack cap
+	for i := range branches {
+		branches[i] = fmt.Sprintf("feature/%02d", i)
+	}
+	w, _, _ := newTestIssueWorkflow(t, func(c *config.Config) {
+		c.ChannelDefaults.Repos = []string{"foo/bar"}
+		c.ChannelDefaults.BranchSelect = &trueVal
+		c.ChannelDefaults.Branches = branches
+	})
+
+	p := &Pending{
+		Phase:     "repo",
+		State:     &issueState{RepoWasPicked: true},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "foo/bar")
+	if err != nil {
+		t.Fatalf("Selection: %v", err)
+	}
+	if step.Kind != NextStepSelector {
+		t.Fatalf("Kind = %v, want NextStepSelector", step.Kind)
+	}
+	if step.Selector == nil {
+		t.Fatal("expected SelectorSpec for branch picker")
+	}
+	if step.Selector.ActionID != "branch_select" {
+		t.Errorf("ActionID = %q, want branch_select", step.Selector.ActionID)
+	}
+	if got := len(step.Selector.Options); got != len(branches) {
+		t.Errorf("Options count = %d, want %d — all branches must reach the adapter", got, len(branches))
+	}
+	if step.Selector.BackActionID != "back_to_repo" {
+		t.Errorf("BackActionID = %q, want back_to_repo", step.Selector.BackActionID)
 	}
 }
 

--- a/app/workflow/ports.go
+++ b/app/workflow/ports.go
@@ -15,6 +15,7 @@ type SlackPort interface {
 	PostMessageWithTS(channelID, text, threadTS string) (string, error)
 	PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
 	UpdateMessage(channelID, messageTS, text string) error
+	DeleteMessage(channelID, messageTS string) error
 	UpdateMessageWithButton(channelID, messageTS, text, actionID, buttonText, value string) error
 	PostSmartSelector(channelID, threadTS string, spec SelectorSpec) (string, error)
 	OpenTextInputModal(triggerID, title, label, inputName, metadata string) error

--- a/app/workflow/ports.go
+++ b/app/workflow/ports.go
@@ -16,9 +16,7 @@ type SlackPort interface {
 	PostMessageWithButton(channelID, text, threadTS, actionID, buttonText, value string) (string, error)
 	UpdateMessage(channelID, messageTS, text string) error
 	UpdateMessageWithButton(channelID, messageTS, text, actionID, buttonText, value string) error
-	PostSelector(channelID, prompt, actionPrefix string, labels, values []string, threadTS string) (string, error)
-	PostSelectorWithBack(channelID, prompt, actionPrefix string, labels, values []string, threadTS, backActionID, backLabel string) (string, error)
-	PostExternalSelector(channelID, prompt, actionID, placeholder, threadTS, cancelActionID, cancelLabel string) (string, error)
+	PostSmartSelector(channelID, threadTS string, spec SelectorSpec) (string, error)
 	OpenTextInputModal(triggerID, title, label, inputName, metadata string) error
 	ResolveUser(userID string) string
 	GetChannelName(channelID string) string

--- a/app/workflow/ports_test.go
+++ b/app/workflow/ports_test.go
@@ -37,6 +37,8 @@ func (f *fakeSlackPort) UpdateMessage(ch, mts, text string) error {
 	return nil
 }
 
+func (f *fakeSlackPort) DeleteMessage(ch, mts string) error { return nil }
+
 func (f *fakeSlackPort) UpdateMessageWithButton(ch, mts, text, aid, bt, val string) error {
 	f.Posted = append(f.Posted, text)
 	return nil

--- a/app/workflow/ports_test.go
+++ b/app/workflow/ports_test.go
@@ -42,18 +42,8 @@ func (f *fakeSlackPort) UpdateMessageWithButton(ch, mts, text, aid, bt, val stri
 	return nil
 }
 
-func (f *fakeSlackPort) PostSelector(ch, prompt, prefix string, labels, values []string, ts string) (string, error) {
-	f.Selectors = append(f.Selectors, prompt)
-	return "sel-ts", nil
-}
-
-func (f *fakeSlackPort) PostSelectorWithBack(ch, prompt, prefix string, labels, values []string, ts, back, bl string) (string, error) {
-	f.Selectors = append(f.Selectors, prompt)
-	return "sel-ts", nil
-}
-
-func (f *fakeSlackPort) PostExternalSelector(ch, prompt, aid, ph, ts, cancelAID, cancelLabel string) (string, error) {
-	f.Selectors = append(f.Selectors, prompt)
+func (f *fakeSlackPort) PostSmartSelector(ch, ts string, spec SelectorSpec) (string, error) {
+	f.Selectors = append(f.Selectors, spec.Prompt)
 	return "sel-ts", nil
 }
 

--- a/app/workflow/pr_review.go
+++ b/app/workflow/pr_review.go
@@ -99,11 +99,14 @@ func (w *PRReviewWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args st
 				State:       &prReviewState{URL: url},
 			}
 			return NextStep{
-				Kind:           NextStepPostSelector,
-				SelectorPrompt: fmt.Sprintf(":eyes: 找到 `%s`，review？", url),
-				SelectorActions: []SelectorAction{
-					{ActionID: "pr_review_confirm", Label: "是", Value: url},
-					{ActionID: "pr_review_confirm", Label: "改貼 URL", Value: "manual"},
+				Kind: NextStepSelector,
+				Selector: &SelectorSpec{
+					Prompt:   fmt.Sprintf(":eyes: 找到 `%s`，review？", url),
+					ActionID: "pr_review_confirm",
+					Options: []SelectorOption{
+						{Label: "是", Value: url},
+						{Label: "改貼 URL", Value: "manual"},
+					},
 				},
 				Pending: pending,
 			}, nil

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -42,6 +42,13 @@ type Pending struct {
 	State       any    // per-workflow state struct
 	BusyHint    string // populated by bot.Workflow.submit() when verdict is BusyEnqueueOK; app.submitJob appends to statusText
 
+	// RepoAckTS is set by the bot layer after the user picks a repo — it
+	// points at the "✅ <repo>" acknowledgement message. HandleBackToRepo
+	// uses it to delete the abandoned pick so clicking "重新選 repo" leaves
+	// a single breadcrumb ("已返回 repo 選擇") instead of a growing stack of
+	// rejected repo choices. Zero value = no pending repo ack.
+	RepoAckTS string
+
 	// invalidated is set by HandleBackToRepo when the user abandons this pending
 	// generation. An in-flight repo-prep goroutine that completes after the
 	// back-button was clicked must observe this flag and skip posting the

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -49,6 +49,20 @@ type Pending struct {
 	// rejected repo choices. Zero value = no pending repo ack.
 	RepoAckTS string
 
+	// DSelectorAckTS is the "✅ 📝 建 Issue" / "✅ ❓ 問問題" / "✅ 🔍 Review
+	// PR" message posted when the session started with a D-selector click.
+	// Preserved across timeout cleanup so the thread keeps a single
+	// breadcrumb showing what the user was trying to do. Zero value for
+	// sessions triggered with a verbed mention (`@bot issue foo/bar`).
+	DSelectorAckTS string
+
+	// SessionMsgTSs accumulates every bot-posted selector / ack / modal
+	// message in this flow except DSelectorAckTS. On timeout (or other
+	// flow-ending cleanup) the bot deletes them all so the thread collapses
+	// to the D-selector ack (if any) + the timeout notice — instead of
+	// keeping every abandoned step around.
+	SessionMsgTSs []string
+
 	// invalidated is set by HandleBackToRepo when the user abandons this pending
 	// generation. An in-flight repo-prep goroutine that completes after the
 	// back-button was clicked must observe this flag and skip posting the

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -76,13 +76,12 @@ func (p *Pending) IsInvalidated() bool {
 type NextStepKind int
 
 const (
-	NextStepPostSelector NextStepKind = iota
-	NextStepOpenModal
-	NextStepSubmit
-	NextStepError
-	NextStepNoop                 // used when the workflow handled everything in-place (rare)
-	NextStepPostExternalSelector // external searchable selector (no configured repos)
-	NextStepCancel               // user aborted mid-flow; dispatcher clears dedup and stops
+	NextStepSelector  NextStepKind = iota // unified selector (button / static_select / external)
+	NextStepOpenModal                     // open a text-input modal
+	NextStepSubmit                        // submit the completed Pending to the queue
+	NextStepError                         // post an error message
+	NextStepNoop                          // workflow handled everything in-place (rare)
+	NextStepCancel                        // user aborted mid-flow; dispatcher clears dedup and stops
 )
 
 // NextStep is a discriminated union of what the dispatcher should do next.
@@ -90,16 +89,11 @@ const (
 type NextStep struct {
 	Kind NextStepKind
 
-	// PostSelector — Kind == NextStepPostSelector
-	SelectorPrompt  string
-	SelectorActions []SelectorAction
-	SelectorBack    string // optional "back" action ID; empty = no back button
-
-	// PostExternalSelector — Kind == NextStepPostExternalSelector
-	SelectorActionID       string // Slack action_id for the external select
-	SelectorPlaceholder    string // placeholder text shown in the search box
-	SelectorCancelActionID string // optional cancel button action_id; empty = no cancel
-	SelectorCancelLabel    string // cancel button label (e.g. "取消")
+	// Selector — Kind == NextStepSelector. The adapter chooses the Slack
+	// rendering (button row, static_select, external search) based on the
+	// number of options so callers never have to worry about the 25-button
+	// cap on Slack actions blocks.
+	Selector *SelectorSpec
 
 	// OpenModal — Kind == NextStepOpenModal
 	ModalTriggerID string
@@ -119,11 +113,42 @@ type NextStep struct {
 	Pending *Pending
 }
 
-// SelectorAction is one button in a button-selector message.
-type SelectorAction struct {
+// SelectorOption is one choice in a selector.
+type SelectorOption struct {
+	Label string
+	Value string
+}
+
+// SelectorSpec describes what the user should pick from. The adapter decides
+// the concrete Slack rendering:
+//   - Searchable=true                          → external_select (type-ahead)
+//   - Searchable=false, few options            → button row
+//   - Searchable=false, many options           → static_select dropdown
+//
+// ActionID is the Slack action_id shared by every option (the rendered
+// payload delivers the pick via action.Value for buttons or
+// action.SelectedOption.Value for dropdowns — app.go's router already
+// accepts either).
+//
+// BackActionID / CancelActionID describe optional extra buttons (e.g.
+// "← 重新選 repo", "取消") that render alongside the options regardless of
+// the chosen mode.
+type SelectorSpec struct {
+	Prompt   string
 	ActionID string
-	Label    string
-	Value    string
+	Options  []SelectorOption
+
+	// External-search mode. When true, Options may be empty — the user
+	// types a query and app/app.go's BlockSuggestion handler supplies
+	// live results.
+	Searchable  bool
+	Placeholder string
+
+	// Optional back/cancel buttons. Empty ActionID = button not rendered.
+	BackActionID   string
+	BackLabel      string
+	CancelActionID string
+	CancelLabel    string
 }
 
 // Workflow is the polymorphic contract each workflow type implements.

--- a/app/workflow/workflow_test.go
+++ b/app/workflow/workflow_test.go
@@ -35,7 +35,7 @@ func TestNextStepKinds(t *testing.T) {
 		name string
 		kind NextStepKind
 	}{
-		{"post selector", NextStepPostSelector},
+		{"selector", NextStepSelector},
 		{"open modal", NextStepOpenModal},
 		{"submit", NextStepSubmit},
 		{"error", NextStepError},


### PR DESCRIPTION
## Summary

Today a user hit `:x: 無法顯示選單，請重試` when the branch picker fired on `softleader-jasmine-mar-ui` (30+ branches). Root cause: `app/slack/client.go:PostSelector` builds one button per branch into a single Slack actions block, which has a **25-element hard cap** — anything more returns `invalid_blocks` 400. Only the external-search for repos had a cap (`shared/github/discovery.go:85` trims at 25); branch listing had none.

This PR replaces the whole selector family with a single `NextStepSelector` + `SelectorSpec`. The Slack adapter picks the rendering (button / static_select / external) based on option count, so callers never collide with the cap again.

## Rendering thresholds

| options + extras | rendering |
|---|---|
| `Searchable=true` | `external_select` |
| `≤ 25` | button row |
| `26–100` | `static_select` dropdown |
| `> 100` | `static_select` (truncated, logged) |

"extras" = back button + cancel button, both now supported on every mode.

## What changed

- `NextStepPostSelector` and `NextStepPostExternalSelector` collapse into `NextStepSelector` carrying `*SelectorSpec`.
- `SelectorOption` replaces `SelectorAction`; `ActionID` is one spec field instead of `"_%d"`-suffixed per button.
- `SlackPort` exposes a single `PostSmartSelector`; the adapter maps the workflow-layer spec to the slack-package `SmartSelectorSpec` (the only translation point — the slack package still doesn't import `workflow`).
- `app/slack/client.go` gains `selectorRenderMode` (pure, table-tested). `PostSelector` / `PostSelectorWithBack` / `PostExternalSelector` removed.
- All eight selector call sites migrated: dispatcher `d_selector`, `pr_review_confirm`, `ask_attach_repo`, `ask_repo` (button + external), `ask_branch`, issue `repo_select` / `repo_search` / `branch_select`, `description_action`.

## Fixes

- `softleader/softleader-jasmine-mar-ui` branch selector no longer 400s once the repo has >24 branches — it upgrades to a dropdown.
- Same auto-upgrade on Ask's branch picker (previously the `ask_branch` flow had the same cap).

## Test plan

- [x] `go test ./...` green on root, app, worker, shared (all four modules)
- [x] New `app/slack/selector_test.go` covers 0/1/24/25/26/100/101/500 boundaries + Searchable short-circuit
- [x] New `issue_test.go` regression case — 30-branch repo must emit all 30 options; adapter thins, workflow doesn't
- [ ] Manual: trigger `@bot issue` on a repo with >25 branches after merge; branch picker should render as dropdown
- [ ] Manual: smoke the short paths (≤24 branches → button row, unchanged UX)
- [ ] Manual: external repo search on a channel without configured repos still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)