### PR TITLE
refactor(worker): remove active_agent (superseded by providers)

### DIFF
--- a/docs/MIGRATION-v2.en.md
+++ b/docs/MIGRATION-v2.en.md
@@ -52,7 +52,7 @@ Old `config.yaml` → new `app.yaml` or `worker.yaml`:
 | `attachments.*` | `attachments.*` | app.yaml |
 | `server.port` | `server.port` | app.yaml |
 | `agents.*` | `agents.*` | **worker.yaml** |
-| `active_agent` | `active_agent` | **worker.yaml** |
+| `active_agent` | **removed in v2.5** — use `providers: [<name>]` instead; existing yaml with `active_agent:` is silently ignored by the loader (unknown key warning logged) | worker.yaml |
 | `providers` | `providers` | **worker.yaml** |
 | `worker.count` | **`count`** (flat) | worker.yaml |
 | `worker.prompt.extra_rules` | **`prompt.extra_rules`** (flat) | worker.yaml |

--- a/docs/MIGRATION-v2.md
+++ b/docs/MIGRATION-v2.md
@@ -52,7 +52,7 @@ agentdock init worker -c ~/.config/agentdock/worker.yaml -i
 | `attachments.*` | `attachments.*` | app.yaml |
 | `server.port` | `server.port` | app.yaml |
 | `agents.*` | `agents.*` | **worker.yaml** |
-| `active_agent` | `active_agent` | **worker.yaml** |
+| `active_agent` | **（v2.5 移除）** 改用 `providers: [<name>]`；舊 yaml 中的 `active_agent:` 欄位會被 loader 忽略並 log warn | worker.yaml |
 | `providers` | `providers` | **worker.yaml** |
 | `worker.count` | **`count`**（扁平） | worker.yaml |
 | `worker.prompt.extra_rules` | **`prompt.extra_rules`**（扁平） | worker.yaml |

--- a/docs/configuration-worker.en.md
+++ b/docs/configuration-worker.en.md
@@ -38,8 +38,7 @@ agents:
     timeout: 15m
     skill_dir: .opencode/skills
 
-active_agent: claude                  # single-agent mode
-providers: [claude, codex, opencode]  # ordered fallback chain
+providers: [claude, codex, opencode]  # ordered fallback chain; single-agent mode: providers: [claude]
 
 count: 3                              # worker goroutine count (flat! was worker.count)
 

--- a/docs/configuration-worker.md
+++ b/docs/configuration-worker.md
@@ -38,8 +38,7 @@ agents:
     timeout: 15m
     skill_dir: .opencode/skills
 
-active_agent: claude                  # 單一 agent 模式
-providers: [claude, codex, opencode]  # fallback chain（依序嘗試）
+providers: [claude, codex, opencode]  # fallback chain（依序嘗試）；單一 agent 模式：providers: [claude]
 
 count: 3                              # worker goroutine 數（扁平！舊是 worker.count）
 

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -34,13 +34,11 @@ func NewRunner(agents []config.AgentConfig) *Runner {
 
 func NewRunnerFromConfig(cfg *config.Config) *Runner {
 	var chain []config.AgentConfig
-	if len(cfg.Providers) > 0 {
-		for _, name := range cfg.Providers {
-			if agent, ok := cfg.Agents[name]; ok {
-				chain = append(chain, agent)
-			} else {
-				slog.Warn("Provider 未找到", "phase", "失敗", "name", name)
-			}
+	for _, name := range cfg.Providers {
+		if agent, ok := cfg.Agents[name]; ok {
+			chain = append(chain, agent)
+		} else {
+			slog.Warn("Provider 未找到", "phase", "失敗", "name", name)
 		}
 	}
 	runner := NewRunner(chain)

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -42,10 +42,6 @@ func NewRunnerFromConfig(cfg *config.Config) *Runner {
 				slog.Warn("Provider 未找到", "phase", "失敗", "name", name)
 			}
 		}
-	} else if cfg.ActiveAgent != "" {
-		if agent, ok := cfg.Agents[cfg.ActiveAgent]; ok {
-			chain = append(chain, agent)
-		}
 	}
 	runner := NewRunner(chain)
 	runner.githubToken = cfg.GitHub.Token

--- a/worker/agent/runner_test.go
+++ b/worker/agent/runner_test.go
@@ -210,6 +210,39 @@ echo "$2" > `+filepath.Join(dir, "captured-path.txt")+`
 	}
 }
 
+func TestNewRunnerFromConfig_EmptyProviders(t *testing.T) {
+	cfg := &config.Config{
+		Agents:    map[string]config.AgentConfig{},
+		Providers: []string{},
+	}
+	runner := NewRunnerFromConfig(cfg)
+	_, err := runner.Run(context.Background(), slog.Default(), t.TempDir(), "test", RunOptions{})
+	if err == nil {
+		t.Error("expected error when providers is empty")
+	}
+}
+
+func TestNewRunnerFromConfig_SingleProvider(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "single-agent")
+	os.WriteFile(script, []byte("#!/bin/sh\necho 'output from single provider agent padding padding padding'\n"), 0755)
+
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"myagent": {Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second},
+		},
+		Providers: []string{"myagent"},
+	}
+	runner := NewRunnerFromConfig(cfg)
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, "single provider") {
+		t.Errorf("unexpected output: %q", output)
+	}
+}
+
 func TestRunner_CancelShortCircuitsProviderChain(t *testing.T) {
 	runner := &Runner{
 		agents: []config.AgentConfig{

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -12,7 +12,6 @@ type Config struct {
 	Logging      LoggingConfig          `yaml:"logging"`
 	GitHub       GitHubConfig           `yaml:"github"`
 	Agents       map[string]AgentConfig `yaml:"agents"`
-	ActiveAgent  string                 `yaml:"active_agent"`
 	Providers    []string               `yaml:"providers"`
 	Count        int                    `yaml:"count"`
 	NicknamePool []string               `yaml:"nickname_pool"`

--- a/worker/config/config_test.go
+++ b/worker/config/config_test.go
@@ -28,7 +28,6 @@ agents:
   claude:
     command: claude
     args: ["--print", "-p", "{prompt}"]
-active_agent: claude
 providers: [claude]
 `)
 	if cfg.Count != 7 {
@@ -42,6 +41,23 @@ providers: [claude]
 	}
 	if len(cfg.Providers) != 1 || cfg.Providers[0] != "claude" {
 		t.Errorf("providers = %v", cfg.Providers)
+	}
+}
+
+// TestLoadConfig_LegacyActiveAgentIgnored verifies that a yaml file containing
+// the removed active_agent key does not panic and leaves Providers empty (the
+// caller is responsible for handling empty providers as a config error).
+func TestLoadConfig_LegacyActiveAgentIgnored(t *testing.T) {
+	cfg := loadFromString(t, `
+agents:
+  claude:
+    command: claude
+    args: ["--print", "-p", "{prompt}"]
+active_agent: claude
+`)
+	// active_agent is an unknown key after removal; Providers must remain empty.
+	if len(cfg.Providers) != 0 {
+		t.Errorf("Providers = %v, want empty (legacy active_agent must not populate providers)", cfg.Providers)
 	}
 }
 

--- a/worker/config/env.go
+++ b/worker/config/env.go
@@ -18,9 +18,6 @@ func EnvOverrideMap() map[string]any {
 	if v := os.Getenv("REDIS_PASSWORD"); v != "" {
 		out["redis.password"] = v
 	}
-	if v := os.Getenv("ACTIVE_AGENT"); v != "" {
-		out["active_agent"] = v
-	}
 	if v := os.Getenv("SECRET_KEY"); v != "" {
 		out["secret_key"] = v
 	}

--- a/worker/config/flags.go
+++ b/worker/config/flags.go
@@ -28,7 +28,6 @@ var flagToKey = map[string]string{
 	"repo-cache-dir":           "repo_cache.dir",
 	"repo-cache-max-age":       "repo_cache.max_age",
 	"workers":                  "count",
-	"active-agent":             "active_agent",
 	"providers":                "providers",
 }
 
@@ -70,7 +69,6 @@ func RegisterFlags(cmd *cobra.Command) {
 	f.Duration("repo-cache-max-age", 0, "max age before repo cache is refreshed")
 
 	f.Int("workers", 0, "number of worker goroutines (maps to count)")
-	f.String("active-agent", "", "active agent name (single-agent mode)")
 	f.StringSlice("providers", nil, "ordered provider chain (comma-separated)")
 }
 

--- a/worker/config/load_test.go
+++ b/worker/config/load_test.go
@@ -19,7 +19,7 @@ func clearWorkerEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"GITHUB_TOKEN", "REDIS_ADDR", "REDIS_PASSWORD",
-		"SECRET_KEY", "ACTIVE_AGENT", "PROVIDERS",
+		"SECRET_KEY", "PROVIDERS",
 	} {
 		t.Setenv(k, "")
 	}


### PR DESCRIPTION
## What this PR does / why we need it

`active_agent` was dead code. In `worker/agent/runner.go:36-49` the two branches (providers and active_agent) were mutually exclusive: whenever `providers` was non-empty, `active_agent` was never read. Users setting both fields were confused about which one had priority — it was always `providers`.

This removes the field entirely (Option A from the issue). 11 files changed, 55 insertions(+), 18 deletions(-) across the worker module and docs.

Dead-code evidence from the issue: `worker/agent/runner.go:45-48` (the `else if cfg.ActiveAgent != ""` branch) was the sole consumer of the field, and it was unreachable whenever `providers` was set. `worker/worker.go` also only reads `cfg.Providers` downstream.

**Migration (Option A — silent ignore + warn log)**

`active_agent:` in an existing `worker.yaml` becomes an unknown koanf key after this change. The pre-existing `warnUnknownKeys()` in `worker/config/load.go` already emits `slog.Warn("未知設定鍵", "key", ...)` for any unknown key — users will see a log line the first time they start the worker, prompting them to migrate. No panic, no startup failure.

Single-agent mode idiom going forward: `providers: [claude]`.

## Changes

| File | Change |
|------|--------|
| `worker/config/config.go` | Delete `ActiveAgent string` field |
| `worker/agent/runner.go` | Delete `else if cfg.ActiveAgent` branch; drop now-redundant `if len > 0` guard |
| `worker/config/env.go` | Delete `ACTIVE_AGENT` env-var mapping |
| `worker/config/flags.go` | Delete `active-agent` flag registration and key mapping |
| `worker/config/config_test.go` | Remove `active_agent: claude` fixture line; add `TestLoadConfig_LegacyActiveAgentIgnored` |
| `worker/config/load_test.go` | Remove `ACTIVE_AGENT` from `clearWorkerEnv` |
| `worker/agent/runner_test.go` | Add `TestNewRunnerFromConfig_EmptyProviders`, `TestNewRunnerFromConfig_SingleProvider` |
| `docs/configuration-worker.md` | Remove `active_agent:` schema line |
| `docs/configuration-worker.en.md` | Remove `active_agent:` schema line |
| `docs/MIGRATION-v2.md` | Annotate `active_agent` row: removed in v2.5, warn log on old yaml |
| `docs/MIGRATION-v2.en.md` | Same in English |

## Tests

New tests added:
- `TestLoadConfig_LegacyActiveAgentIgnored` — yaml with `active_agent: claude` but no `providers:` unmarshals without panic; `Providers` remains empty (the existing `warnUnknownKeys` path handles the warn log)
- `TestNewRunnerFromConfig_EmptyProviders` — empty providers → error from `Run`
- `TestNewRunnerFromConfig_SingleProvider` — `providers: [myagent]` → agent is invoked and output returned

Local test run (WSL2, `-race` requires cgo which is unavailable; CI `-race` is authoritative):
```
ok  github.com/Ivantseng123/agentdock/worker/agent       10.020s
ok  github.com/Ivantseng123/agentdock/worker/config      0.006s
ok  github.com/Ivantseng123/agentdock/worker/integration 0.012s
ok  github.com/Ivantseng123/agentdock/worker/pool        0.009s
ok  github.com/Ivantseng123/agentdock/worker/prompt      0.002s
ok  github.com/Ivantseng123/agentdock/cmd/agentdock      0.014s
ok  github.com/Ivantseng123/agentdock/test               0.207s
all vet passed (all four modules)
```

Note: local `-race` is unavailable (WSL2 without cgo/gcc). CI `test.yml` runs `-race` for all modules and is the authoritative pass signal.

## /simplify addressed

One Must finding adopted:
- Removed redundant `if len(cfg.Providers) > 0` guard in `NewRunnerFromConfig` — with the `else-if` branch gone, iterating an empty slice is already a no-op in Go. Committed as a separate `refactor(worker): drop redundant len guard` commit.

Other findings:
- `"phase"` string literals in `runner.go` use raw strings instead of `shared/logging` constants — pre-existing pattern throughout the codebase, not introduced by this PR; out of scope.
- `os.WriteFile` without error check in tests — matches style of all surrounding pre-existing tests; not a regression.

## Release note

```
Removed `active_agent` config option — use `providers: [<name>]` for single-agent mode.
```

Closes #120