### PR TITLE
fix(workflow): walk marker segments so opencode fence pattern parses

### DIFF
--- a/app/workflow/ask_parser.go
+++ b/app/workflow/ask_parser.go
@@ -14,25 +14,33 @@ type AskResult struct {
 	Confidence string `json:"confidence,omitempty"`
 }
 
-// ParseAskOutput extracts the last ASK_RESULT marker block and unmarshals
-// its JSON body. Rejects empty answers.
+// ParseAskOutput extracts the ASK_RESULT marker block and unmarshals its
+// JSON body. Walks markers last-first so the opencode fence pattern
+// (payload sandwiched between opening and closing markers) is recovered.
+// Rejects empty answers.
 func ParseAskOutput(output string) (AskResult, error) {
 	output = strings.TrimSpace(output)
-	idx := strings.LastIndex(output, askMarker)
-	if idx == -1 {
+	segments := segmentAfterMarker(output, askMarker)
+	if len(segments) == 0 {
 		return AskResult{}, fmt.Errorf("%s marker not found", askMarker)
 	}
-	body := strings.TrimSpace(output[idx+len(askMarker):])
-	if !strings.HasPrefix(body, "{") {
-		return AskResult{}, fmt.Errorf("expected JSON object after marker")
+	var lastErr error
+	for _, seg := range segments {
+		if !strings.HasPrefix(seg, "{") {
+			lastErr = fmt.Errorf("expected JSON object after marker")
+			continue
+		}
+		jsonStr := extractJSON(seg)
+		var r AskResult
+		if err := json.Unmarshal([]byte(jsonStr), &r); err != nil {
+			lastErr = fmt.Errorf("unmarshal: %w", err)
+			continue
+		}
+		if strings.TrimSpace(r.Answer) == "" {
+			lastErr = fmt.Errorf("answer must not be empty")
+			continue
+		}
+		return r, nil
 	}
-	jsonStr := extractJSON(body) // reused from issue_parser.go
-	var r AskResult
-	if err := json.Unmarshal([]byte(jsonStr), &r); err != nil {
-		return AskResult{}, fmt.Errorf("unmarshal: %w", err)
-	}
-	if strings.TrimSpace(r.Answer) == "" {
-		return AskResult{}, fmt.Errorf("answer must not be empty")
-	}
-	return r, nil
+	return AskResult{}, lastErr
 }

--- a/app/workflow/ask_parser_test.go
+++ b/app/workflow/ask_parser_test.go
@@ -50,3 +50,18 @@ func TestParseAskOutput_MultipleMarkers_LastWins(t *testing.T) {
 		t.Errorf("expected last marker to win, got %q", r.Answer)
 	}
 }
+
+// TestParseAskOutput_FenceMarkers guards the opencode fence pattern where
+// the payload sits between an opening and closing marker. Without the
+// fence-aware walk the last marker's segment is empty and parsing errors
+// out before reaching the real payload.
+func TestParseAskOutput_FenceMarkers(t *testing.T) {
+	output := "===ASK_RESULT===\n" + `{"answer":"real answer","confidence":"high"}` + "\n===ASK_RESULT==="
+	r, err := ParseAskOutput(output)
+	if err != nil {
+		t.Fatalf("fence pattern must parse: %v", err)
+	}
+	if r.Answer != "real answer" || r.Confidence != "high" {
+		t.Errorf("got %+v", r)
+	}
+}

--- a/app/workflow/issue_parser.go
+++ b/app/workflow/issue_parser.go
@@ -127,6 +127,31 @@ func markerPositions(s, marker string) []int {
 	}
 }
 
+// segmentAfterMarker returns non-empty trimmed segments following each
+// occurrence of marker in output, ordered last-marker-first. The final
+// marker's segment comes first so callers that expect the real answer to
+// follow the last marker hit it immediately; empty segments fall through
+// to earlier markers, which is how the opencode "fence" pattern — where
+// payload is wrapped between an opening and closing marker — is recovered.
+func segmentAfterMarker(output, marker string) []string {
+	positions := markerPositions(output, marker)
+	if len(positions) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(positions))
+	for i := len(positions) - 1; i >= 0; i-- {
+		start := positions[i] + len(marker)
+		end := len(output)
+		if i+1 < len(positions) {
+			end = positions[i+1]
+		}
+		if seg := strings.TrimSpace(output[start:end]); seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
+
 // parseResultSegment tries JSON first, then the legacy CREATED:/REJECTED:/ERROR:
 // prefixes. Returns (result, titleErr, matched):
 //   - matched=true, titleErr=nil → caller returns (result, nil).

--- a/app/workflow/pr_review_parser.go
+++ b/app/workflow/pr_review_parser.go
@@ -23,20 +23,24 @@ type ReviewResult struct {
 
 func ParseReviewOutput(output string) (ReviewResult, error) {
 	output = strings.TrimSpace(output)
-	idx := strings.LastIndex(output, reviewMarker)
-	if idx == -1 {
+	segments := segmentAfterMarker(output, reviewMarker)
+	if len(segments) == 0 {
 		return ReviewResult{}, fmt.Errorf("%s marker not found", reviewMarker)
 	}
-	body := strings.TrimSpace(output[idx+len(reviewMarker):])
-	jsonStr := extractJSON(body)
-	var r ReviewResult
-	if err := json.Unmarshal([]byte(jsonStr), &r); err != nil {
-		return ReviewResult{}, fmt.Errorf("unmarshal: %w", err)
+	var lastErr error
+	for _, seg := range segments {
+		jsonStr := extractJSON(seg)
+		var r ReviewResult
+		if err := json.Unmarshal([]byte(jsonStr), &r); err != nil {
+			lastErr = fmt.Errorf("unmarshal: %w", err)
+			continue
+		}
+		switch r.Status {
+		case "POSTED", "SKIPPED", "ERROR":
+			return r, nil
+		default:
+			lastErr = fmt.Errorf("unknown review status %q", r.Status)
+		}
 	}
-	switch r.Status {
-	case "POSTED", "SKIPPED", "ERROR":
-		return r, nil
-	default:
-		return ReviewResult{}, fmt.Errorf("unknown review status %q", r.Status)
-	}
+	return ReviewResult{}, lastErr
 }

--- a/app/workflow/pr_review_parser_test.go
+++ b/app/workflow/pr_review_parser_test.go
@@ -47,3 +47,21 @@ func TestParseReviewOutput_UnknownStatus(t *testing.T) {
 		t.Error("unknown status must error")
 	}
 }
+
+// TestParseReviewOutput_FenceMarkers guards the opencode fence pattern:
+// opencode wraps the JSON payload between an opening and closing marker,
+// which made LastIndex-only parsing see an empty body after the final
+// marker and fail with "unexpected end of JSON input". Payload is copied
+// from the 2026-04-24 prod failure on softleader/jasmine-policy#2925.
+func TestParseReviewOutput_FenceMarkers(t *testing.T) {
+	out := "===REVIEW_RESULT===\n" +
+		`{"status": "POSTED", "summary": "new field ok; unrelated version rollback detected", "comments_posted": 1, "comments_skipped": 3, "severity_summary": "major"}` +
+		"\n===REVIEW_RESULT==="
+	r, err := ParseReviewOutput(out)
+	if err != nil {
+		t.Fatalf("fence pattern must parse: %v", err)
+	}
+	if r.Status != "POSTED" || r.CommentsPosted != 1 || r.CommentsSkipped != 3 || r.Severity != "major" {
+		t.Errorf("got %+v", r)
+	}
+}


### PR DESCRIPTION
## Summary

- `ParseReviewOutput` / `ParseAskOutput` used `LastIndex` on the result marker, which breaks when opencode wraps the JSON payload between an opening and closing marker: the final segment is empty and `json.Unmarshal("")` errors with `unexpected end of JSON input`.
- The Slack-visible symptom was `:x: Review 失敗：parse error: unmarshal: unexpected end of JSON input` even though the PR comment **was** successfully posted (seen on softleader/jasmine-policy#2925, 2026-04-24).
- The issue parser already solved this shape (`issue_parser.go` walks marker positions from the last backwards and skips empty segments). This PR extracts that walk into `segmentAfterMarker` and adopts it in review + ask parsers. Issue parser is left untouched to minimize regression surface.

## Root cause

The opencode agent emits:

```
===REVIEW_RESULT===
{"status":"POSTED", ...}
===REVIEW_RESULT===
```

`LastIndex(...)` picks the closing marker, the slice after it is empty, parser bails.

## Test plan

- [x] New `TestParseReviewOutput_FenceMarkers` reproduces the exact prod-shaped payload (opening marker, real JSON, closing marker) and is red before / green after the fix.
- [x] New `TestParseAskOutput_FenceMarkers` covers the same shape for the Ask skill.
- [x] Pre-existing review/ask tests still pass (including `TestParseAskOutput_MultipleMarkers_LastWins`, which exercises the "agent repeats the marker in a preamble example then writes the real answer later" case — walk-from-last preserves that).
- [x] All four modules (root / app / worker / shared) green via `go test ./...`; import-direction test in root module still passes.
- [x] `go build ./cmd/agentdock` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)