### PR TITLE
feat(ask): include prior bot answer for multi-turn continuity

### DIFF
--- a/agents/skills/ask-assistant/SKILL.md
+++ b/agents/skills/ask-assistant/SKILL.md
@@ -45,6 +45,8 @@ You receive a prompt with these XML-ish sections:
 - `<thread_context>`: the Slack thread messages leading up to the trigger.
 - `<extra_description>` (optional): the user's clarification from a modal,
   often the sharpest statement of intent.
+- `<prior_answer>` (optional): your own previous substantive reply in this
+  thread — see §2a below for how to use it.
 - A repo may be cloned into your working directory. `<issue_context>`
   lists the channel, reporter, the `<bot>` tag covered above, and —
   if a repo is attached — a `<branch>` field.
@@ -54,6 +56,34 @@ You receive a prompt with these XML-ish sections:
 The user may also @-mention the bot multiple times in the thread
 (triggering retries that got deduped). Ignore the duplicates — answer
 the latest question.
+
+## 2a. Prior answer context (multi-turn continuity)
+
+When `<prior_answer>` is present, treat it as **what you said last
+round, and the user's current question is a follow-up to that**. The
+opt-in happened explicitly — the user clicked "帶上次回覆一起問" —
+so they *want* you to be aware of it.
+
+How to use it:
+
+- **Don't repeat it.** Users already saw your previous answer. Quoting
+  it back verbatim is noise. Reference it briefly if needed
+  ("接續上次提到的 X..."), but the new answer should be net-new content
+  driven by the user's latest message.
+- **Build on or revise.** If your previous answer was missing info and
+  the user supplied it, give the next-step answer. If your previous
+  answer was wrong and the user pointed that out, own it ("上次說
+  錯了，正確應該是...") — don't pretend the first answer never happened.
+- **Don't let prior scope override current scope.** The user may have
+  pivoted. If last turn was about the login flow and this turn is
+  about the checkout flow, answer checkout — prior answer becomes
+  background, not the primary frame.
+- **Same action boundaries apply.** Prior context does not unlock
+  file-writing, issue-creating, or any of §5's forbidden actions.
+
+If `<prior_answer>` is absent, this section doesn't apply — answer
+the question from scratch using `<thread_context>` and
+`<extra_description>` as usual.
 
 ## 3. Classify the question
 

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -268,12 +268,18 @@ func (w *Workflow) HandleDescriptionAction(channelID, value, selectorMsgTS, trig
 	if prev, rewind := rewindModalPhase(pending.Phase); rewind {
 		pending.Phase = prev
 	}
-	if value == "跳過" {
+	// Submit-path values: the click dispatches a Submit directly (no modal
+	// follows) so the selector message and pending entry must be cleaned up
+	// here — nothing downstream will. The only non-submit value is
+	// "補充說明", which falls through to OpenModal (modal cleanup owns that
+	// path). Keep this list in sync with the description-prompt options in
+	// the workflows that use description_action.
+	if value == "跳過" || value == workflow.AskPriorAnswerOptIn {
 		delete(w.pending, selectorMsgTS)
 		w.mu.Unlock()
-		// Drop the prompt rather than leaving a ":fast_forward: 跳過補充說明"
-		// ack — the "分析 codebase 中..." status message that follows is
-		// the user-visible confirmation.
+		// Drop the prompt rather than leaving an ack — the status message
+		// that follows ("分析 codebase 中..." / "思考中...") is the real
+		// user-visible confirmation.
 		_ = w.slack.DeleteMessage(channelID, selectorMsgTS)
 		ctx := context.Background()
 		step, err := w.dispatcher.HandleSelection(ctx, pending, value)

--- a/app/bot/workflow_test.go
+++ b/app/bot/workflow_test.go
@@ -72,6 +72,9 @@ func (s *shimSlack) GetChannelName(cid string) string                           
 func (s *shimSlack) FetchThreadContext(c, ts, tts string, lim int) ([]slackclient.ThreadRawMessage, error) {
 	return nil, nil
 }
+func (s *shimSlack) FetchPriorBotAnswer(c, ts, tts string, lim int) (*slackclient.ThreadRawMessage, error) {
+	return nil, nil
+}
 func (s *shimSlack) DownloadAttachments(msgs []slackclient.ThreadRawMessage, dir string) []slackclient.AttachmentDownload {
 	return nil
 }
@@ -1075,6 +1078,75 @@ func TestHandleDescriptionAction_SkipWhileStuckInModal_RewindsBeforeDispatch(t *
 	}
 	if gotValue != "跳過" {
 		t.Errorf("Selection value = %q, want 跳過", gotValue)
+	}
+}
+
+// TestHandleDescriptionAction_PriorAnswerOptIn_DeletesSelectorAndDispatches
+// is the regression guard for issue #151 follow-up: the "帶上次回覆" opt-in
+// button is a submit-path value (no modal follows), so HandleDescriptionAction
+// must clean up the selector message and the pending entry the same way
+// "跳過" does. Before the fix this value fell through to the modal-path and
+// the selector sat around until the pending timeout swept it up.
+func TestHandleDescriptionAction_PriorAnswerOptIn_DeletesSelectorAndDispatches(t *testing.T) {
+	sl := &shimSlack{}
+	cfg := &config.Config{Channels: map[string]config.ChannelConfig{}}
+	reg := workflow.NewRegistry()
+
+	var gotValue string
+	submitCalled := false
+	fake := &countingSelectionWorkflow{
+		returnFn: func(p *workflow.Pending, value string) workflow.NextStep {
+			gotValue = value
+			return workflow.NextStep{Kind: workflow.NextStepSubmit, Pending: p}
+		},
+	}
+	reg.Register(fake)
+	disp := workflow.NewDispatcher(reg, sl, nil)
+	wf := NewWorkflow(cfg, disp, sl, nil, slog.Default(), nil)
+	wf.SetSubmitHook(func(ctx context.Context, p *workflow.Pending) {
+		submitCalled = true
+	})
+
+	const selectorTS = "desc-sel-prior-answer"
+	// TaskType="issue" matches countingSelectionWorkflow's Type() — the test
+	// is about the handler's value-routing, not which workflow ultimately
+	// runs. The handler behaviour is shared across any workflow using
+	// description_action.
+	p := &workflow.Pending{
+		ChannelID: "C1", ThreadTS: "T1",
+		TaskType:   "issue",
+		Phase:      "ask_description_prompt",
+		SelectorTS: selectorTS,
+	}
+	wf.mu.Lock()
+	wf.pending[selectorTS] = p
+	wf.mu.Unlock()
+
+	wf.HandleDescriptionAction("C1", workflow.AskPriorAnswerOptIn, selectorTS, "")
+
+	deleted := sl.snapshotDeleted()
+	sawDelete := false
+	for _, ts := range deleted {
+		if ts == selectorTS {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Errorf("selector message must be deleted on opt-in click; deleted=%v", deleted)
+	}
+
+	wf.mu.Lock()
+	_, stillPending := wf.pending[selectorTS]
+	wf.mu.Unlock()
+	if stillPending {
+		t.Error("pending entry must be removed on opt-in click")
+	}
+
+	if gotValue != workflow.AskPriorAnswerOptIn {
+		t.Errorf("Selection saw value=%q, want %q", gotValue, workflow.AskPriorAnswerOptIn)
+	}
+	if !submitCalled {
+		t.Error("submit hook must fire on NextStepSubmit")
 	}
 }
 

--- a/app/slack/prior_answer.go
+++ b/app/slack/prior_answer.go
@@ -1,0 +1,188 @@
+package slack
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/metrics"
+	"github.com/slack-go/slack"
+)
+
+// botAnswerMinChars is the minimum text length (in runes) for a bot post
+// to be treated as a substantive answer. Shorter messages are typically
+// acks, status lines, or one-liners that add no signal to multi-turn
+// continuity. 50 is a judgment call — tune via feedback.
+const botAnswerMinChars = 50
+
+// botNonAnswerEmojiPrefixes is the blocklist of leading Slack emoji codes
+// that identify bot posts as UI scaffolding rather than substantive
+// answers. Any bot message whose (trimmed) text starts with one of these
+// is excluded from PriorAnswer.
+//
+// The categories:
+//   - selector prompts: :question: :point_right: :pencil2:
+//   - user-pick acks:   :white_check_mark:
+//   - skip breadcrumbs: :fast_forward: :leftwards_arrow_with_hook:
+//   - status lines:     :mag: :thinking_face:
+//   - error lines:      :warning: :x:
+//   - user-echo quote:  :memo: (Ask's "補充說明" is the user's own words, not
+//                       a bot answer — the modal-derived extra_description
+//                       path already carries that signal)
+var botNonAnswerEmojiPrefixes = []string{
+	":question:",
+	":point_right:",
+	":pencil2:",
+	":white_check_mark:",
+	":fast_forward:",
+	":leftwards_arrow_with_hook:",
+	":mag:",
+	":thinking_face:",
+	":memo:",
+	":warning:",
+	":x:",
+}
+
+// isBotAnswerMessage reports whether a bot-authored Slack message text
+// qualifies as a substantive answer worth replaying to the next turn.
+//
+// Rules:
+//  1. Trim whitespace.
+//  2. Reject if empty.
+//  3. Reject if the text begins with any blocklisted emoji prefix.
+//  4. Reject if shorter than botAnswerMinChars runes (UI noise guard).
+//
+// The predicate is deliberately conservative — false negatives (dropping
+// an ambiguous "好的，馬上處理") are cheaper than false positives
+// (feeding a status line back as "previous answer" and confusing the
+// worker).
+func isBotAnswerMessage(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	for _, prefix := range botNonAnswerEmojiPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return false
+		}
+	}
+	if runeLen(trimmed) < botAnswerMinChars {
+		return false
+	}
+	return true
+}
+
+// runeLen counts Unicode code points. len(s) counts bytes, which
+// underestimates English character count for CJK text that most Slack
+// answers in this workspace are written in.
+func runeLen(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+// filterPriorBotAnswers returns bot-authored messages from the thread
+// that pass isBotAnswerMessage, in the order Slack returned them (usually
+// chronological). Messages at or after triggerTS are excluded. Bot
+// identity is matched against botUserID or botID; at least one must be
+// non-empty for any match to succeed — passing both empty returns nil.
+//
+// Unlike filterThreadMessages (which drops the bot's own posts), this
+// helper is the inverse: it keeps only the bot's posts. Other-bot
+// messages (e.g., GitHub, CI) are not considered — PriorAnswer is
+// about this bot's own conversational memory.
+func filterPriorBotAnswers(messages []slack.Message, triggerTS, botUserID, botID string) []ThreadRawMessage {
+	if botUserID == "" && botID == "" {
+		return nil
+	}
+	var result []ThreadRawMessage
+	for _, m := range messages {
+		if m.Timestamp >= triggerTS {
+			continue
+		}
+		// Identify self-posts. Match either axis because integration quirks
+		// can leave User mismatched while BotID matches, or vice versa.
+		isSelf := false
+		if botUserID != "" && m.User == botUserID {
+			isSelf = true
+		}
+		if botID != "" && m.BotID == botID {
+			isSelf = true
+		}
+		if !isSelf {
+			continue
+		}
+		text := extractMessageText(m)
+		if !isBotAnswerMessage(text) {
+			continue
+		}
+		user := m.User
+		if m.BotID != "" {
+			if name := resolveBotDisplayName(m); name != "" {
+				user = "bot:" + name
+			}
+		}
+		result = append(result, ThreadRawMessage{
+			User:      user,
+			Text:      text,
+			Timestamp: m.Timestamp,
+			Files:     m.Files,
+		})
+	}
+	return result
+}
+
+// FetchPriorBotAnswer reads the thread and returns the most recent
+// qualifying bot-authored answer (by Slack timestamp), or nil when
+// none is found. limit defaults to 50 when <=0 — matching
+// FetchThreadContext's default so a cap-misconfig doesn't diverge
+// silently between the two paths.
+//
+// This exists so the Ask workflow can enable multi-turn continuity
+// without re-fetching thread pages on every job submit: the Ask
+// description-prompt step calls this once to decide whether to show
+// the "帶上次回覆" opt-in button, and caches the result for BuildJob.
+func (c *Client) FetchPriorBotAnswer(channelID, threadTS, triggerTS, botUserID, botID string, limit int) (*ThreadRawMessage, error) {
+	start := time.Now()
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var allMessages []slack.Message
+	cursor := ""
+
+	for {
+		params := &slack.GetConversationRepliesParameters{
+			ChannelID: channelID,
+			Timestamp: threadTS,
+			Cursor:    cursor,
+			Limit:     200,
+		}
+
+		msgs, hasMore, nextCursor, err := c.api.GetConversationReplies(params)
+		if err != nil {
+			metrics.ExternalErrorsTotal.WithLabelValues("slack", "fetch_prior_bot_answer").Inc()
+			return nil, fmt.Errorf("conversations.replies: %w", err)
+		}
+
+		allMessages = append(allMessages, msgs...)
+
+		if !hasMore || len(allMessages) >= limit {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	filtered := filterPriorBotAnswers(allMessages, triggerTS, botUserID, botID)
+	metrics.ExternalDuration.WithLabelValues("slack", "fetch_prior_bot_answer").Observe(time.Since(start).Seconds())
+
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	// Most recent by thread order. Slack returns messages oldest-first,
+	// so the last element is freshest.
+	latest := filtered[len(filtered)-1]
+	return &latest, nil
+}

--- a/app/slack/prior_answer_test.go
+++ b/app/slack/prior_answer_test.go
@@ -1,0 +1,192 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// TestIsBotAnswerMessage_TableRows mirrors the §1 classification table
+// from issue #151 row-by-row. Each case documents which row it comes
+// from so future edits to the predicate trace back to the spec.
+func TestIsBotAnswerMessage_TableRows(t *testing.T) {
+	substantive := strings.Repeat("a", botAnswerMinChars+10)
+
+	cases := []struct {
+		name string
+		text string
+		want bool
+		row  string
+	}{
+		// Row 1: substantive markdown answer → include.
+		{"substantive_long_answer", substantive, true, "substantive answer"},
+		{"substantive_with_mrkdwn_bold", "*簡答*\nYour code sends a malformed request. Check the auth header format — it should be `Bearer <token>`, not `Token <token>`.", true, "substantive answer"},
+
+		// Row 2: uploaded answer file — file-stream content still passes the
+		// text predicate when Slack surfaces it via blocks/attachments. (The
+		// pure no-text file-upload case is filtered at the caller by
+		// extractMessageText returning "".)
+		{"answer_md_content_via_blocks", "## Follow-up on DB migration\n\n" + substantive, true, "uploaded answer"},
+
+		// Row 3: selector prompts — drop.
+		{"selector_attach_repo", ":question: 要附加 Repository 嗎？", false, "selector prompt"},
+		{"selector_which_repo", ":point_right: Which repo?", false, "selector prompt"},
+		{"selector_description", ":pencil2: 要補充說明想讓 agent 做什麼嗎？", false, "selector prompt"},
+
+		// Row 4: user-pick acks — drop.
+		{"ack_user_pick", ":white_check_mark: foo/bar", false, "user-pick ack"},
+
+		// Row 5: skip / back breadcrumbs — drop.
+		{"skip_breadcrumb", ":fast_forward: 跳過補充說明", false, "skip breadcrumb"},
+		{"back_breadcrumb", ":leftwards_arrow_with_hook: 返回 attach 選擇", false, "back breadcrumb"},
+
+		// Row 6: status lines — drop.
+		{"status_analyzing", ":mag: 分析 codebase 中...", false, "status line"},
+		{"status_thinking", ":thinking_face: 思考中...", false, "status line"},
+
+		// Row 7: user's 補充說明 quote — drop. (User verbatim, not a bot
+		// answer; the modal's extra_description already carries this.)
+		{"user_memo_echo", ":memo: 補充說明: fix the login bug please", false, "user-echo"},
+
+		// Extras beyond the table: error lines and short acks.
+		{"failure_x", ":x: 思考失敗：timeout", false, "error line"},
+		{"warning_busy", ":warning: 系統忙碌，請稍後再試", false, "warning line"},
+		{"too_short_plain_text", "收到", false, "below min length"},
+		{"empty_string", "", false, "empty"},
+		{"whitespace_only", "   \n\t ", false, "whitespace only"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isBotAnswerMessage(tc.text)
+			if got != tc.want {
+				t.Errorf("isBotAnswerMessage(%q) = %v, want %v (row: %s)",
+					truncate(tc.text, 60), got, tc.want, tc.row)
+			}
+		})
+	}
+}
+
+// TestIsBotAnswerMessage_MinLengthEdge is the guard for substantive-but-
+// short bot replies just above/below the threshold.
+func TestIsBotAnswerMessage_MinLengthEdge(t *testing.T) {
+	justBelow := strings.Repeat("x", botAnswerMinChars-1)
+	atThreshold := strings.Repeat("x", botAnswerMinChars)
+	if isBotAnswerMessage(justBelow) {
+		t.Errorf("expected false at len=%d (below threshold)", len(justBelow))
+	}
+	if !isBotAnswerMessage(atThreshold) {
+		t.Errorf("expected true at len=%d (at threshold)", len(atThreshold))
+	}
+}
+
+func TestFilterPriorBotAnswers_ReturnsOnlySelfBotPosts(t *testing.T) {
+	long := strings.Repeat("a", botAnswerMinChars+10)
+	messages := []slack.Message{
+		// Human message — must not be counted, even though it's substantive.
+		{Msg: slack.Msg{User: "U001", Text: long, Timestamp: "1000.0"}},
+		// External bot (e.g. GitHub) with substantive content — skip: only
+		// our bot's own answers count as "prior answer".
+		{Msg: slack.Msg{
+			User: "", Text: long, Timestamp: "1001.0",
+			BotID: "B_GH", BotProfile: &slack.BotProfile{Name: "GitHub"},
+		}},
+		// Self via BotID, substantive — keep.
+		{Msg: slack.Msg{
+			User: "UBOT", Text: long, Timestamp: "1002.0",
+			BotID: "B_SELF", BotProfile: &slack.BotProfile{Name: "ai_trigger_issue_bot"},
+		}},
+		// Self via BotID, selector prompt — drop (non-answer).
+		{Msg: slack.Msg{
+			User: "UBOT", Text: ":question: 要附加 Repository 嗎？", Timestamp: "1003.0",
+			BotID: "B_SELF",
+		}},
+		// Self after triggerTS — drop.
+		{Msg: slack.Msg{
+			User: "UBOT", Text: long, Timestamp: "9999.0",
+			BotID: "B_SELF",
+		}},
+	}
+
+	result := filterPriorBotAnswers(messages, "5000.0", "UBOT", "B_SELF")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 qualifying message, got %d", len(result))
+	}
+	if result[0].Timestamp != "1002.0" {
+		t.Errorf("wrong message kept: ts=%q", result[0].Timestamp)
+	}
+	if result[0].User != "bot:ai_trigger_issue_bot" {
+		t.Errorf("bot display name not prefixed: %q", result[0].User)
+	}
+}
+
+func TestFilterPriorBotAnswers_EmptyIdentityReturnsNil(t *testing.T) {
+	// Without a bot identity nothing is a "self" post. Defensive — callers
+	// should always supply at least one identity axis.
+	messages := []slack.Message{
+		{Msg: slack.Msg{User: "UBOT", Text: strings.Repeat("a", 100), Timestamp: "1000.0",
+			BotID: "B_SELF"}},
+	}
+	result := filterPriorBotAnswers(messages, "9999.0", "", "")
+	if result != nil {
+		t.Errorf("expected nil result with empty identity, got %+v", result)
+	}
+}
+
+func TestFilterPriorBotAnswers_UsesBlocksWhenTextEmpty(t *testing.T) {
+	// Messages posted via Block Kit have empty .Text but substantive blocks.
+	long := strings.Repeat("a", botAnswerMinChars+10)
+	blocks := slack.Blocks{BlockSet: []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", long, false, false),
+			nil, nil,
+		),
+	}}
+	messages := []slack.Message{
+		{Msg: slack.Msg{
+			User: "UBOT", Timestamp: "1000.0",
+			BotID:      "B_SELF",
+			BotProfile: &slack.BotProfile{Name: "ai_trigger_issue_bot"},
+			Blocks:     blocks,
+		}},
+	}
+	result := filterPriorBotAnswers(messages, "9999.0", "UBOT", "B_SELF")
+	if len(result) != 1 {
+		t.Fatalf("expected blocks-sourced text to qualify, got %d", len(result))
+	}
+	if !strings.Contains(result[0].Text, long) {
+		t.Errorf("text mismatch: %q", truncate(result[0].Text, 60))
+	}
+}
+
+func TestFilterPriorBotAnswers_ReturnsChronologicalOrder(t *testing.T) {
+	long1 := "answer one " + strings.Repeat("a", botAnswerMinChars)
+	long2 := "answer two " + strings.Repeat("b", botAnswerMinChars)
+	messages := []slack.Message{
+		{Msg: slack.Msg{
+			User: "UBOT", Text: long1, Timestamp: "1000.0",
+			BotID: "B_SELF",
+		}},
+		{Msg: slack.Msg{
+			User: "UBOT", Text: long2, Timestamp: "2000.0",
+			BotID: "B_SELF",
+		}},
+	}
+	result := filterPriorBotAnswers(messages, "9999.0", "UBOT", "B_SELF")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 qualifying, got %d", len(result))
+	}
+	if result[0].Timestamp != "1000.0" || result[1].Timestamp != "2000.0" {
+		t.Errorf("order broken: got ts %q then %q", result[0].Timestamp, result[1].Timestamp)
+	}
+	// Caller (FetchPriorBotAnswer) takes the last element — ts=2000.0.
+}
+
+// truncate is a test helper: trims a long string for readable error output.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/app/slack_adapter_port.go
+++ b/app/slack_adapter_port.go
@@ -84,6 +84,10 @@ func (a *slackAdapterPort) FetchThreadContext(channelID, threadTS, triggerTS str
 	return a.client.FetchThreadContext(channelID, threadTS, triggerTS, a.identity.UserID, a.identity.BotID, limit)
 }
 
+func (a *slackAdapterPort) FetchPriorBotAnswer(channelID, threadTS, triggerTS string, limit int) (*slackclient.ThreadRawMessage, error) {
+	return a.client.FetchPriorBotAnswer(channelID, threadTS, triggerTS, a.identity.UserID, a.identity.BotID, limit)
+}
+
 func (a *slackAdapterPort) DownloadAttachments(messages []slackclient.ThreadRawMessage, tempDir string) []slackclient.AttachmentDownload {
 	return a.client.DownloadAttachments(messages, tempDir)
 }

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -13,6 +13,12 @@ import (
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
+// AskPriorAnswerOptIn is the button value for the "include previous
+// answer" opt-in on the description prompt. Exported so app/bot's
+// HandleDescriptionAction can recognise it as a submit-path (no modal
+// follows, so the selector message must be deleted on click).
+const AskPriorAnswerOptIn = "帶上次回覆"
+
 // AskWorkflow handles @bot ask queries. Optional attached repo with branch
 // selection (mirrors Issue when channel has branch_select enabled), plus an
 // optional description modal. Result is an agent-produced answer posted as a
@@ -29,6 +35,19 @@ type askState struct {
 	AttachRepo     bool
 	SelectedRepo   string
 	SelectedBranch string
+	// PriorAnswer caches the bot's most recent substantive reply in this
+	// thread (if any), fetched once at descriptionPromptStep time. nil means
+	// either none exists, no fetch yet, or the fetch failed — which we
+	// collapse into "no opt-in affordance".
+	PriorAnswer *queue.ThreadMessage
+	// IncludePriorAnswer is set by the user clicking the opt-in button on
+	// the description prompt. BuildJob honours this to attach PriorAnswer
+	// to the worker's PromptContext.
+	IncludePriorAnswer bool
+	// priorAnswerFetchAttempted guards against double-fetching if
+	// descriptionPromptStep runs twice for the same ask (shouldn't happen
+	// in current flow, but cheap defense against future back-nav changes).
+	priorAnswerFetchAttempted bool
 }
 
 // NewAskWorkflow constructs a workflow instance.
@@ -172,6 +191,12 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 		switch value {
 		case "跳過":
 			return NextStep{Kind: NextStepSubmit, Pending: p}, nil
+		case AskPriorAnswerOptIn:
+			// User wants the bot's last substantive reply fed into this turn.
+			// The cached PriorAnswer was populated at descriptionPromptStep time,
+			// so we only need to flip the opt-in flag and submit.
+			st.IncludePriorAnswer = true
+			return NextStep{Kind: NextStepSubmit, Pending: p}, nil
 		case "補充說明":
 			// Phase must flip before OpenModal so the modal submit routes to
 			// ask_description_modal (HandleDescriptionSubmit no longer rewrites
@@ -264,20 +289,49 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 	}
 }
 
-// descriptionPromptStep returns the 補充說明 / 跳過 selector. ActionID
-// mirrors IssueWorkflow's so app.go's description_action route (which owns
-// the modal-trigger-id forwarding) handles the click without Ask needing
-// its own special case.
+// descriptionPromptStep returns the 補充說明 / 跳過 selector, plus an
+// optional 帶上次回覆 opt-in button when the thread already has a
+// substantive bot reply we could hand back to the worker for multi-turn
+// continuity (issue #151). ActionID mirrors IssueWorkflow's so app.go's
+// description_action route (which owns the modal-trigger-id forwarding)
+// handles the click without Ask needing its own special case.
+//
+// The prior-answer fetch happens at most once per ask (priorAnswerFetchAttempted
+// guard) and failures degrade silently to the 2-button UX — the feature
+// is opt-in, so missing it is a non-event.
 func (w *AskWorkflow) descriptionPromptStep(p *Pending) NextStep {
+	st, _ := p.State.(*askState)
+	if st != nil && !st.priorAnswerFetchAttempted {
+		st.priorAnswerFetchAttempted = true
+		if raw, err := w.slack.FetchPriorBotAnswer(p.ChannelID, p.ThreadTS, p.TriggerTS, w.cfg.MaxThreadMessages); err != nil {
+			w.logger.Warn("prior bot answer fetch failed, continuing without opt-in",
+				"phase", "處理中", "error", err)
+		} else if raw != nil {
+			st.PriorAnswer = &queue.ThreadMessage{
+				User:      raw.User,
+				Timestamp: raw.Timestamp,
+				Text:      raw.Text,
+			}
+		}
+	}
+
+	options := []SelectorOption{
+		{Label: "補充說明", Value: "補充說明"},
+		{Label: "跳過", Value: "跳過"},
+	}
+	if st != nil && st.PriorAnswer != nil {
+		options = append(options, SelectorOption{
+			Label: "帶上次回覆一起問",
+			Value: AskPriorAnswerOptIn,
+		})
+	}
+
 	return NextStep{
 		Kind: NextStepSelector,
 		Selector: &SelectorSpec{
 			Prompt:   ":pencil2: 要補充說明想讓 agent 做什麼嗎？",
 			ActionID: "description_action",
-			Options: []SelectorOption{
-				{Label: "補充說明", Value: "補充說明"},
-				{Label: "跳過", Value: "跳過"},
-			},
+			Options:  options,
 		},
 		Pending: p,
 	}
@@ -301,6 +355,11 @@ func (w *AskWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, str
 		cloneURL = cleanCloneURL(st.SelectedRepo)
 	}
 
+	var priorAnswer []queue.ThreadMessage
+	if st.IncludePriorAnswer && st.PriorAnswer != nil {
+		priorAnswer = []queue.ThreadMessage{*st.PriorAnswer}
+	}
+
 	job := &queue.Job{
 		ID:          reqID,
 		RequestID:   reqID,
@@ -322,6 +381,7 @@ func (w *AskWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, str
 			Channel:          p.ChannelName,
 			Reporter:         p.Reporter,
 			AllowWorkerRules: w.cfg.Prompt.IsWorkerRulesAllowed(),
+			PriorAnswer:      priorAnswer,
 			// ThreadMessages, Attachments filled by downstream submit-helper.
 		},
 		// Skills is populated by submitJob via loadSkills(); leaving it unset

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -2,11 +2,13 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/Ivantseng123/agentdock/app/config"
+	slackclient "github.com/Ivantseng123/agentdock/app/slack"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
 
@@ -503,5 +505,162 @@ func TestAskWorkflow_HandleResult_NilStateReturnsError(t *testing.T) {
 	result := &queue.JobResult{JobID: "j1", Status: "completed"}
 	if err := w.HandleResult(context.Background(), nil, result); err == nil {
 		t.Error("expected error on nil state")
+	}
+}
+
+func TestAskWorkflow_DescriptionPrompt_NoPriorAnswer_ShowsTwoButtons(t *testing.T) {
+	// Default fake returns nil PriorBotAnswer → no opt-in button.
+	w, slack := newTestAskWorkflow(t)
+	p := &Pending{Phase: "ask_repo_prompt", State: &askState{Question: "Q"},
+		ChannelID: "C1", ThreadTS: "1.0", TriggerTS: "2.0"}
+	step, err := w.Selection(context.Background(), p, "skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slack.PriorBotAnswerCalls != 1 {
+		t.Errorf("FetchPriorBotAnswer called %d times, want 1", slack.PriorBotAnswerCalls)
+	}
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("expected 2 options (補充說明, 跳過), got %d", len(step.Selector.Options))
+	}
+	for _, o := range step.Selector.Options {
+		if o.Value == AskPriorAnswerOptIn {
+			t.Errorf("opt-in button should be hidden when no prior answer exists")
+		}
+	}
+}
+
+func TestAskWorkflow_DescriptionPrompt_WithPriorAnswer_AddsThirdButton(t *testing.T) {
+	w, slack := newTestAskWorkflow(t)
+	slack.PriorBotAnswer = &slackclient.ThreadRawMessage{
+		User:      "bot:ai_trigger_issue_bot",
+		Timestamp: "1500.0",
+		Text:      strings.Repeat("prior substantive answer ", 5),
+	}
+	p := &Pending{Phase: "ask_repo_prompt", State: &askState{Question: "Q"},
+		ChannelID: "C1", ThreadTS: "1.0", TriggerTS: "2.0"}
+	step, err := w.Selection(context.Background(), p, "skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(step.Selector.Options) != 3 {
+		t.Fatalf("expected 3 options when prior answer exists, got %d", len(step.Selector.Options))
+	}
+	sawOptIn := false
+	for _, o := range step.Selector.Options {
+		if o.Value == AskPriorAnswerOptIn {
+			sawOptIn = true
+		}
+	}
+	if !sawOptIn {
+		t.Error("opt-in button missing despite prior answer being available")
+	}
+	// Prior answer got cached in askState for BuildJob to pick up.
+	st := p.State.(*askState)
+	if st.PriorAnswer == nil || st.PriorAnswer.Text != slack.PriorBotAnswer.Text {
+		t.Errorf("PriorAnswer not cached on askState: %+v", st.PriorAnswer)
+	}
+}
+
+func TestAskWorkflow_DescriptionPrompt_FetchError_DegradesSilently(t *testing.T) {
+	// Slack API failure must NOT break the Ask flow — the opt-in is a
+	// convenience, not a core path. Falls back to 2-button UX.
+	w, slack := newTestAskWorkflow(t)
+	slack.PriorBotAnswerErr = errors.New("rate limit")
+	p := &Pending{Phase: "ask_repo_prompt", State: &askState{Question: "Q"},
+		ChannelID: "C1", ThreadTS: "1.0", TriggerTS: "2.0"}
+	step, err := w.Selection(context.Background(), p, "skip")
+	if err != nil {
+		t.Fatalf("ask flow must not surface fetch error, got: %v", err)
+	}
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("expected 2 options on fetch error, got %d", len(step.Selector.Options))
+	}
+	st := p.State.(*askState)
+	if st.PriorAnswer != nil {
+		t.Errorf("PriorAnswer should remain nil on fetch error, got: %+v", st.PriorAnswer)
+	}
+	if !st.priorAnswerFetchAttempted {
+		t.Error("priorAnswerFetchAttempted should be set even on error, to avoid retry loops")
+	}
+}
+
+func TestAskWorkflow_Selection_OptInPriorAnswerSetsFlagAndSubmits(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	priorMsg := &queue.ThreadMessage{
+		User: "bot:x", Timestamp: "1500.0", Text: "prior answer content",
+	}
+	p := &Pending{
+		Phase: "ask_description_prompt",
+		State: &askState{Question: "Q", PriorAnswer: priorMsg, priorAnswerFetchAttempted: true},
+	}
+	step, err := w.Selection(context.Background(), p, AskPriorAnswerOptIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if step.Kind != NextStepSubmit {
+		t.Errorf("expected NextStepSubmit after opt-in click, got %v", step.Kind)
+	}
+	st := p.State.(*askState)
+	if !st.IncludePriorAnswer {
+		t.Error("IncludePriorAnswer flag should be true after opt-in click")
+	}
+}
+
+func TestAskWorkflow_BuildJob_IncludePriorAnswer_PopulatesPromptContext(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	priorMsg := &queue.ThreadMessage{
+		User: "bot:ai_trigger_issue_bot", Timestamp: "1500.0",
+		Text: "X runs the migration — see migrate.go:42",
+	}
+	p := &Pending{
+		ChannelID: "C1", ThreadTS: "1.0", UserID: "U1",
+		RequestID: "req-prior",
+		State: &askState{
+			Question:           "Q",
+			PriorAnswer:        priorMsg,
+			IncludePriorAnswer: true,
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.PromptContext == nil {
+		t.Fatal("PromptContext nil")
+	}
+	if len(job.PromptContext.PriorAnswer) != 1 {
+		t.Fatalf("expected 1 PriorAnswer, got %d", len(job.PromptContext.PriorAnswer))
+	}
+	if job.PromptContext.PriorAnswer[0].Text != priorMsg.Text {
+		t.Errorf("PriorAnswer.Text = %q, want %q",
+			job.PromptContext.PriorAnswer[0].Text, priorMsg.Text)
+	}
+}
+
+func TestAskWorkflow_BuildJob_NoOptIn_PriorAnswerEmpty(t *testing.T) {
+	// Even when a prior answer was cached, BuildJob must not leak it into
+	// PromptContext unless the user explicitly opted in. Otherwise the
+	// opt-in UX is meaningless.
+	w, _ := newTestAskWorkflow(t)
+	priorMsg := &queue.ThreadMessage{
+		User: "bot:x", Timestamp: "1500.0", Text: "prior answer content",
+	}
+	p := &Pending{
+		ChannelID: "C1", ThreadTS: "1.0", UserID: "U1",
+		RequestID: "req-no-opt",
+		State: &askState{
+			Question:           "Q",
+			PriorAnswer:        priorMsg,
+			IncludePriorAnswer: false,
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(job.PromptContext.PriorAnswer) != 0 {
+		t.Errorf("expected empty PriorAnswer without opt-in, got %d entries",
+			len(job.PromptContext.PriorAnswer))
 	}
 }

--- a/app/workflow/ports.go
+++ b/app/workflow/ports.go
@@ -22,6 +22,12 @@ type SlackPort interface {
 	ResolveUser(userID string) string
 	GetChannelName(channelID string) string
 	FetchThreadContext(channelID, threadTS, triggerTS string, limit int) ([]slackclient.ThreadRawMessage, error)
+	// FetchPriorBotAnswer returns the most recent qualifying bot-authored
+	// answer in the thread, or nil if none qualifies. Used by AskWorkflow
+	// for multi-turn continuity; other workflows don't need it. Returning
+	// nil with nil error is the "no prior answer" case — callers should
+	// treat it as graceful degradation, not an error path.
+	FetchPriorBotAnswer(channelID, threadTS, triggerTS string, limit int) (*slackclient.ThreadRawMessage, error)
 	DownloadAttachments(messages []slackclient.ThreadRawMessage, tempDir string) []slackclient.AttachmentDownload
 	UploadFile(channelID, threadTS, filename, title, content, initialComment string) error
 }

--- a/app/workflow/ports_test.go
+++ b/app/workflow/ports_test.go
@@ -13,6 +13,13 @@ type fakeSlackPort struct {
 	Posted    []string
 	Selectors []string
 	Modal     bool
+
+	// PriorBotAnswer is the canned response for FetchPriorBotAnswer. Tests
+	// that exercise the multi-turn opt-in path set this to a non-nil
+	// ThreadRawMessage so the workflow renders the opt-in button.
+	PriorBotAnswer      *slackclient.ThreadRawMessage
+	PriorBotAnswerErr   error
+	PriorBotAnswerCalls int
 }
 
 func newFakeSlackPort() *fakeSlackPort { return &fakeSlackPort{} }
@@ -59,6 +66,18 @@ func (f *fakeSlackPort) GetChannelName(cid string) string    { return "ch-" + ci
 
 func (f *fakeSlackPort) FetchThreadContext(c, ts, tts string, lim int) ([]slackclient.ThreadRawMessage, error) {
 	return nil, nil
+}
+
+// PriorBotAnswer is the canned response for FetchPriorBotAnswer calls. nil
+// (the default) models "no prior answer in thread" so existing tests behave
+// as before. PriorBotAnswerCalls counts invocations so tests can verify
+// fetch-once semantics in the Ask workflow.
+func (f *fakeSlackPort) FetchPriorBotAnswer(c, ts, tts string, lim int) (*slackclient.ThreadRawMessage, error) {
+	f.PriorBotAnswerCalls++
+	if f.PriorBotAnswerErr != nil {
+		return nil, f.PriorBotAnswerErr
+	}
+	return f.PriorBotAnswer, nil
 }
 
 func (f *fakeSlackPort) DownloadAttachments(msgs []slackclient.ThreadRawMessage, dir string) []slackclient.AttachmentDownload {

--- a/shared/queue/job.go
+++ b/shared/queue/job.go
@@ -69,6 +69,11 @@ type PromptContext struct {
 	ResponseSchema   string          `json:"response_schema,omitempty"`
 	OutputRules      []string        `json:"output_rules"`
 	AllowWorkerRules bool            `json:"allow_worker_rules"`
+	// PriorAnswer carries bot's own previous substantive answers in this
+	// thread so multi-turn Ask conversations don't regress to amnesia.
+	// Slice shape reserves room for multi-turn history; v1 only fills the
+	// most recent qualifying message.
+	PriorAnswer []ThreadMessage `json:"prior_answer,omitempty"`
 }
 
 type JobResult struct {

--- a/worker/prompt/builder.go
+++ b/worker/prompt/builder.go
@@ -41,6 +41,22 @@ func BuildPrompt(ctx queue.PromptContext, extraRules []string, attachments []Att
 		fmt.Fprintf(&b, "<extra_description>%s</extra_description>\n\n", xmlEscape(ctx.ExtraDescription))
 	}
 
+	// <prior_answer> — Ask multi-turn continuity. Carries the bot's own
+	// previous substantive replies in this thread so the agent can build on
+	// rather than repeat them. Rendered only when PriorAnswer is non-empty;
+	// issue / pr_review workflows leave it empty, so those prompts are
+	// unchanged.
+	if len(ctx.PriorAnswer) > 0 {
+		b.WriteString("<prior_answer>\n")
+		for _, m := range ctx.PriorAnswer {
+			fmt.Fprintf(&b,
+				"  <message user=\"%s\" ts=\"%s\">%s</message>\n",
+				xmlEscape(m.User), xmlEscape(m.Timestamp), xmlEscape(m.Text),
+			)
+		}
+		b.WriteString("</prior_answer>\n\n")
+	}
+
 	// <issue_context> — channel, reporter, optional bot identity, optional branch.
 	b.WriteString("<issue_context>\n")
 	fmt.Fprintf(&b, "  <channel>%s</channel>\n", xmlEscape(ctx.Channel))

--- a/worker/prompt/builder_test.go
+++ b/worker/prompt/builder_test.go
@@ -298,6 +298,90 @@ func TestBuildPrompt_Attachments_UnknownTypeSelfClosing(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_PriorAnswer_RenderedWhenPresent(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{
+			{User: "Alice", Timestamp: "1000.0", Text: "what does X do?"},
+		},
+		PriorAnswer: []queue.ThreadMessage{
+			{User: "bot:ai_trigger_issue_bot", Timestamp: "1500.0", Text: "X runs the migration — see migrate.go:42"},
+		},
+		Channel:  "c",
+		Reporter: "r",
+		Goal:     "g",
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if !strings.Contains(got, "<prior_answer>") {
+		t.Fatalf("missing <prior_answer> section in:\n%s", got)
+	}
+	if !strings.Contains(got, `<message user="bot:ai_trigger_issue_bot" ts="1500.0">X runs the migration — see migrate.go:42</message>`) {
+		t.Errorf("prior answer message not rendered verbatim in:\n%s", got)
+	}
+}
+
+func TestBuildPrompt_PriorAnswer_OmittedWhenEmpty(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		Channel:        "c",
+		Reporter:       "r",
+		Goal:           "g",
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if strings.Contains(got, "<prior_answer>") {
+		t.Errorf("expected no <prior_answer> when empty, got:\n%s", got)
+	}
+}
+
+func TestBuildPrompt_PriorAnswer_OrderingBetweenExtraAndIssueContext(t *testing.T) {
+	// prior_answer lives between extra_description and issue_context so
+	// the agent sees: user's clarification → what you said last time → where
+	// the conversation is happening. Any reordering would weaken that flow.
+	ctx := queue.PromptContext{
+		ThreadMessages:   []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		ExtraDescription: "follow up on the migration",
+		PriorAnswer: []queue.ThreadMessage{
+			{User: "bot:x", Timestamp: "1500.0", Text: "prior answer body long enough to pass the filter check"},
+		},
+		Channel:  "c",
+		Reporter: "r",
+		Goal:     "g",
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	extraIdx := strings.Index(got, "<extra_description>")
+	priorIdx := strings.Index(got, "<prior_answer>")
+	issueIdx := strings.Index(got, "<issue_context>")
+	if extraIdx == -1 || priorIdx == -1 || issueIdx == -1 {
+		t.Fatalf("missing sections: extra=%d prior=%d issue=%d", extraIdx, priorIdx, issueIdx)
+	}
+	if !(extraIdx < priorIdx && priorIdx < issueIdx) {
+		t.Errorf("expected extra < prior < issue, got extra=%d prior=%d issue=%d",
+			extraIdx, priorIdx, issueIdx)
+	}
+}
+
+func TestBuildPrompt_PriorAnswer_XMLEscaping(t *testing.T) {
+	// Prior answers often contain code snippets / stack traces with angle
+	// brackets. Guard that they still go through xmlEscape like other
+	// message text, to prevent them from derailing the XML-ish structure.
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		PriorAnswer: []queue.ThreadMessage{
+			{User: "bot:x", Timestamp: "1.0", Text: `see <Button onClick="fn"> & the spec`},
+		},
+		Goal: "g",
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if strings.Contains(got, `<Button`) {
+		t.Errorf("unescaped <Button in prior_answer:\n%s", got)
+	}
+	if !strings.Contains(got, `&lt;Button`) {
+		t.Errorf("expected escaped <Button, got:\n%s", got)
+	}
+	if !strings.Contains(got, `&amp;`) {
+		t.Errorf("expected escaped & in prior_answer, got:\n%s", got)
+	}
+}
+
 func TestBuildPrompt_OutputRulesArray_MultipleRendered(t *testing.T) {
 	ctx := queue.PromptContext{
 		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},


### PR DESCRIPTION
Closes #151.

## Summary

- Ask workers now (optionally) receive the bot's most recent substantive reply in the same thread as `<prior_answer>`, unblocking follow-up questions that used to hit a stateless agent with amnesia.
- Opt-in only: the description prompt grows a third button `[帶上次回覆一起問]` that appears only when a qualifying prior bot message exists in the thread. Default UX stays at two buttons; no surprise context.
- Non-Ask workflows (Issue, PR Review) are unchanged — they never populate `PromptContext.PriorAnswer`, so their prompt strings stay byte-identical.

## How the design questions from #151 landed

- **Filtering** — `isBotAnswerMessage` excludes selector prompts (`:question:`, `:point_right:`, `:pencil2:`), acks (`:white_check_mark:`), breadcrumbs (`:fast_forward:`, `:leftwards_arrow_with_hook:`), status (`:mag:`, `:thinking_face:`), errors (`:x:`, `:warning:`), and the `:memo: 補充說明` user-echo. Plus a 50-rune minimum to reject one-liners. Only the most recent qualifying message is kept.
- **UX** — Opt-in button, **conditional** on a qualifying prior answer being detected (an extra `conversations.replies` call at description-prompt time, ≤1 per Ask).
- **Prompt shape** — Inline `<prior_answer>` XML block between `<extra_description>` and `<issue_context>`. `agents/skills/ask-assistant/SKILL.md` §2a tells the agent to build on / revise the prior answer, not quote it back.

## Bug caught during local testing

`app/bot/workflow.go`'s `HandleDescriptionAction` only treated `"跳過"` as a submit-path — the new opt-in value fell through the modal-path cleanup and the selector message sat until the pending timeout swept it. Fixed by recognising `workflow.AskPriorAnswerOptIn` alongside `"跳過"`. Regression test in `TestHandleDescriptionAction_PriorAnswerOptIn_DeletesSelectorAndDispatches`.

## Non-goals (per #151)

- Multi-turn history beyond one prior message. `PriorAnswer` is a slice so the worker prompt format doesn't churn when this is revisited.
- Bot answers uploaded as `answer.md` files (long-form path). The file body isn't surfaced in `message.text`, so v1 silently ignores them — documented in code.
- Cross-thread memory.
- Global `filterThreadMessages` rewrite. A dedicated `FetchPriorBotAnswer` helper keeps Issue / PR Review paths untouched.

## Test plan

- [x] Unit: `isBotAnswerMessage` against every row of the §1 classification table in #151
- [x] Unit: filter returns only self-bot posts, respects `triggerTS` cutoff, handles blocks-only messages
- [x] Unit: `<prior_answer>` rendered when populated, omitted otherwise, ordered between extra_description and issue_context, XML-escaped
- [x] Unit: Ask workflow fetch-once, conditional third button, graceful degradation on fetch error
- [x] Unit: BuildJob populates `PriorAnswer` only when the opt-in flag is set
- [x] Unit: `HandleDescriptionAction` cleans up selector + pending on opt-in value
- [x] `go build ./...`, `go vet ./...`, `go test ./...` green across root / app / worker / shared
- [x] `TestImportDirection` green (app ✗ worker, worker ✗ app, shared ✗ app|worker)
- [x] Local Slack smoke test: 2-button flow still works; 3-button flow renders when prior answer exists; opt-in click cleanly transitions to `思考中...` (selector message deleted)
- [ ] Remaining: Niuma / production smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)