### PR TITLE
fix(ask): drop prior-answer threshold + debug-log raw agent output

### DIFF
--- a/app/slack/prior_answer.go
+++ b/app/slack/prior_answer.go
@@ -11,9 +11,14 @@ import (
 
 // botAnswerMinChars is the minimum text length (in runes) for a bot post
 // to be treated as a substantive answer. Shorter messages are typically
-// acks, status lines, or one-liners that add no signal to multi-turn
-// continuity. 50 is a judgment call — tune via feedback.
-const botAnswerMinChars = 50
+// pure acks ("好"/"收到") that add no signal to multi-turn continuity.
+//
+// Initially set to 50 on the theory that real answers are sentences, but
+// production traces (issue #151 follow-up) showed Niuma routinely emits
+// useful 20–40-rune answers that were being filtered out — so the opt-in
+// button never surfaced. Dropped to 10: still excludes one/two-character
+// acks while letting terse but substantive replies through.
+const botAnswerMinChars = 10
 
 // botNonAnswerEmojiPrefixes is the blocklist of leading Slack emoji codes
 // that identify bot posts as UI scaffolding rather than substantive

--- a/app/slack/prior_answer_test.go
+++ b/app/slack/prior_answer_test.go
@@ -81,6 +81,26 @@ func TestIsBotAnswerMessage_MinLengthEdge(t *testing.T) {
 	}
 }
 
+// TestIsBotAnswerMessage_ShortButSubstantive guards the post-#151 threshold
+// drop. Production traces showed Niuma regularly emits useful 20–40-rune
+// answers (e.g. a sentence like "要設 GH_TOKEN 和 SLACK_TOKEN 才會動。") that
+// the pre-fix threshold (50) was silently filtering out. The opt-in button
+// never surfaced as a result. This test fails if someone re-raises the
+// threshold without also re-checking the Niuma case.
+func TestIsBotAnswerMessage_ShortButSubstantive(t *testing.T) {
+	cases := []string{
+		"要設 GH_TOKEN 和 SLACK_TOKEN 才會動。", // 22 runes
+		"看 app/workflow/ask.go:47",       // 24 runes
+		"這個行為目前是由 config 控制的",              // 14 runes
+	}
+	for _, text := range cases {
+		if !isBotAnswerMessage(text) {
+			t.Errorf("expected substantive short answer %q (%d runes) to qualify; threshold too strict?",
+				text, runeLen(text))
+		}
+	}
+}
+
 func TestFilterPriorBotAnswers_ReturnsOnlySelfBotPosts(t *testing.T) {
 	long := strings.Repeat("a", botAnswerMinChars+10)
 	messages := []slack.Message{

--- a/worker/pool/executor.go
+++ b/worker/pool/executor.go
@@ -151,6 +151,7 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 		return classifyResult(job, startedAt, err, repoPath, ctx, deps.store)
 	}
 	logger.Info("Agent 執行完成", "phase", "完成", "output_len", len(output))
+	logger.Debug("Agent output 內容", "phase", "完成", "output", output)
 
 	// Ship the raw agent output to the app. Parsing and REJECTED/ERROR/parse-failed
 	// classification live in the app-side result listener — worker has no


### PR DESCRIPTION
Two small follow-ups to #151 from observing production traces.

## 1. Prior-answer threshold 50 → 10

**Symptom**: The opt-in "帶上次回覆一起問" button never appeared on the production bot (Niuma), even in threads that clearly had a prior bot answer. User-reported as H3.

**Root cause**: `botAnswerMinChars = 50` was a guess. Actual Niuma answers in the thread traces run ~20–40 runes (short one-sentence replies), so `isBotAnswerMessage` filtered them all out → `FetchPriorBotAnswer` always returned nil → conditional 3rd button never rendered.

**Fix**: Drop the minimum to 10. Still excludes pure acks (`"好"`, `"收到"`, one/two-char emoji reactions), lets the real substance through.

**Regression guard**: `TestIsBotAnswerMessage_ShortButSubstantive` holds Niuma-shaped examples (22 / 24 / 14 runes) so raising the threshold again fails a test immediately.

## 2. Debug-log raw agent output

**Pain point**: While diagnosing a separate "agent output doesn't match the required `===ASK_RESULT===` format" problem, I discovered worker only logs `output_len=N` — there's no way to see what the agent actually emitted without exec'ing into the pod and hunting for opencode's session state (which isn't where you'd expect).

**Fix**: One line. `executor.go` already debug-logs the full prompt next to "Prompt 已組裝"; add the symmetric output log next to "Agent 執行完成". Same DEBUG level, same structured-logging style, only appears in jsonl traces when DEBUG logging is already enabled. Zero production footprint at INFO.

```go
logger.Info("Agent 執行完成", "phase", "完成", "output_len", len(output))
logger.Debug("Agent output 內容", "phase", "完成", "output", output)  // ← new
```

Next time opencode misbehaves, cat `~/logs/*.jsonl` tells you immediately whether it's a prompt-following issue or something downstream.

## Test plan

- [x] `go build ./...` across root / app / worker / shared
- [x] `go test ./...` across all four modules — all green
- [x] `TestIsBotAnswerMessage_ShortButSubstantive` added, passes
- [x] `TestIsBotAnswerMessage_MinLengthEdge` still passes (logic unchanged, constant different)
- [x] `TestImportDirection` still green
- [ ] Production smoke: open a same-thread follow-up Ask after the deploy and verify the 3rd button renders when a short Niuma answer is upstream
- [ ] Production smoke: `cat ~/logs/<today>.jsonl | grep "Agent output 內容"` returns raw output for recent jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)