### PR TITLE
fix(image): upgrade opencode 1.4.3 → 1.4.11 to fix skill loading

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -11,7 +11,11 @@ RUN apk add --no-cache git ca-certificates curl
 # Agent CLIs
 RUN npm install -g @anthropic-ai/claude-code @openai/codex
 
-ARG OPENCODE_VERSION=1.4.3
+# opencode 1.4.10+ uses an embedded WASM ripgrep backend, which eliminates the
+# "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
+# version downloaded a platform ripgrep binary at startup and failed to
+# extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
+ARG OPENCODE_VERSION=1.4.11
 RUN curl -sL https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-musl.tar.gz | \
     tar xzf - -C /usr/local/bin opencode
 


### PR DESCRIPTION
## Summary

Production traces surfaced `RipgrepExtractionFailedError` on every `@bot ask` skill tool call. Root cause is in opencode 1.4.3's pre-WASM architecture, which downloads a platform ripgrep binary at container startup and fails to extract it inside our alpine runtime. Downstream, the agent's `Effect.orDie`-wrapped skill tool crashes → agent gives up on `ask-assistant` and answers from the bare prompt body → output ignores SKILL.md §4a (`*簡答*` / `*依據*` / `*延伸*` structure).

Upstream fix lives in opencode v1.4.10+ which shipped the embedded WASM backend — ripgrep no longer needs to be downloaded or extracted.

## Evidence trail

- Error string `RipgrepExtractionFailedError` is defined as a `NamedError` in the pre-WASM `packages/opencode/src/ripgrep/index.ts`, thrown when `tar`/`unzip` on the downloaded archive returns non-zero.
- `git log --all -S "RipgrepExtractionFailedError"` in the opencode repo shows only three commits touch the string; the WASM rewrite (`d6840868d`) removes the entire `src/ripgrep/` directory.
- `git tag --contains d6840868d` → first release is **v1.4.10**. v1.4.3 (current) is pre-WASM.
- Companion build fix `5b60e51c9 fix(opencode): resolve ripgrep worker path in builds (#22436)` is in **v1.4.11**.
- `curl -I https://github.com/anomalyco/opencode/releases/download/v1.4.11/opencode-linux-x64-musl.tar.gz` → `200 OK` — the musl asset our Dockerfile expects exists.

## Changes

```diff
-ARG OPENCODE_VERSION=1.4.3
+# opencode 1.4.10+ uses an embedded WASM ripgrep backend, which eliminates the
+# "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
+# version downloaded a platform ripgrep binary at startup and failed to
+# extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
+ARG OPENCODE_VERSION=1.4.11
```

One-line functional change + comment documenting the why. No Go code change.

## Release flow

This commit is Dockerfile-only, so merging here will:
1. Trigger release-please to open a chore bump PR.
2. When that release PR merges and tags (e.g. v2.6.1 or v2.7.0), `release.yml` fires `goreleaser`, which rebuilds both arch images and pushes to `ghcr.io/ivantseng123/agentdock:<ver>` + manifest tags (`:2`, `:2.6`, `:latest`).
3. The worker pods in `ai-tools` pull `:2` and will pick up the new image on next restart.

## Test plan

- [x] Verified the v1.4.11 musl asset is reachable (HEAD 200).
- [x] Traced the error class to opencode's pre-WASM `ripgrep/index.ts`.
- [x] Confirmed WASM backend + worker-path fixes both land in v1.4.11.
- [ ] Post-deploy: re-trigger `@bot ask` in a same-thread follow-up; `~/logs/*.jsonl` should no longer show `RipgrepExtractionFailedError`, and agent output should follow SKILL.md §4a structure.
- [ ] Post-deploy: combined with #169's threshold drop + debug log, the "帶上次回覆一起問" button should surface on short Niuma answers, and we can verify the full prompt round-trip from the jsonl trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)