### PR TITLE
fix(ask): resolve output_rules contradiction that killed skill structure

### DIFF
--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -178,7 +178,13 @@ The app strips those sections in degraded runs (low files_found / high open_ques
 var (
 	defaultAskOutputRules = []string{
 		"Format the answer in Slack mrkdwn — NOT GitHub markdown. Use *text* (single asterisk) for bold, _text_ for italic, ~text~ for strikethrough, <url|label> for links. Do not use # / ## / ### headings; use *bold* as section labels. Triple-backtick fenced code blocks and single-backtick inline code both render correctly.",
-		"No title, no labels — output the answer content only. Keep it ≤30000 chars.",
+		// Old rule was "No title, no labels — output the answer content only."
+		// That directly contradicted Rule 1 above and SKILL.md §4a, which both
+		// expect *bold* section labels (e.g. *簡答* / *依據*). Agents (correctly)
+		// prioritised this hard-sounding rule and dropped skill structure.
+		// Now: only ban opening heading/title lines, keep the length cap, and
+		// explicitly bless inline *bold* labels so skill structure survives.
+		"Do not open with an H1/H2/H3 heading or standalone title line — start directly with the answer content. *bold* section labels inside the body (e.g. *簡答*, *依據*, *延伸*) are encouraged per the ask-assistant skill. Keep the total answer ≤30000 chars.",
 		"When referring to yourself, use the exact Slack handle from the <bot> tag in <issue_context> (e.g. 'ai_trigger_issue_bot') verbatim. Do NOT invent shorthand like '@bot ask', 'Ask 助理', 'AI 助理', '程式碼助手'. If a sentence doesn't need self-reference, just answer without name-dropping.",
 	}
 	defaultPRReviewOutputRules = []string{


### PR DESCRIPTION
## Summary

`defaultAskOutputRules[0]` says _"use `*bold*` as section labels"_.
`defaultAskOutputRules[1]` says _"No title, no labels"_.
The two rules directly contradict each other. In production traces
after PR #170 fixed skill loading, opencode correctly loaded the
ask-assistant skill AND read §4a's `*簡答*` / `*依據*` / `*延伸*`
structure — then dutifully obeyed Rule #2 and dropped all of it.

Rule #2 conflated two intents:
1. "Don't open with an H1/H2/H3 title line" (keep this — prevents
   GitHub-style headings that Slack renders as plain `#` text).
2. "Don't add a label" (overbroad — kills the `*bold*` section labels
   the skill structure depends on).

## Change

Rewrite Rule #2 to keep (1), drop (2), and explicitly bless inline
`*bold*` labels. Length cap (≤30000 chars) preserved.

```diff
-"No title, no labels — output the answer content only. Keep it ≤30000 chars.",
+"Do not open with an H1/H2/H3 heading or standalone title line — start directly with the answer content. *bold* section labels inside the body (e.g. *簡答*, *依據*, *延伸*) are encouraged per the ask-assistant skill. Keep the total answer ≤30000 chars.",
```

Adds an inline code comment at the definition site so the next
engineer who reads this sees the history of the conflict.

## Why this matches project principles

From memory (`project_skill_vs_output_rules.md`): _"output_rules 是硬
約束；skill 是軟指引。硬規則直接升格到 output_rules"_.
Following that, Rule #2 was correctly acting as a hard constraint —
but it was enforcing the wrong constraint (no labels at all) instead
of the right one (no opening-title heading). The rewrite keeps the
same hierarchy, fixes the content.

## Test plan

- [x] `go build ./...`, `go test ./...` across root / app / worker / shared — all green
- [x] No test was asserting the exact prior-rule text, so no test update needed
- [x] Grep confirms the rule existed at exactly one site (`app/config/defaults.go:181`), so no config.yaml surgery
- [ ] Post-deploy: `@bot ask` → `~/logs/*.jsonl` → raw output should include `*簡答*` / `*依據*` labels when the question is Pure-thread per SKILL.md §4a

## Stacking note

Depends on nothing else being merged first. Orthogonal to #170 (opencode upgrade) — both are needed for the full fix; neither is sufficient alone:
- Without #170: skill still crashes on load, agent never sees §4a.
- Without this: skill loads fine but its structure is actively negated by Rule #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)