### PR TITLE
docs(slack-setup): document files:write scope for answer uploads

### DIFF
--- a/docs/slack-setup.en.md
+++ b/docs/slack-setup.en.md
@@ -8,6 +8,7 @@ Bot Token Scopes:
 - `chat:write`, `channels:read`, `channels:history`, `users:read`, `commands`
 - Private channels: `groups:history`, `groups:read`
 - Attachment downloads: `files:read`
+- Attachment uploads: `files:write` (long `@bot ask` answers are posted as an `answer.md` file)
 
 Event Subscriptions:
 - `app_mention`
@@ -66,6 +67,7 @@ oauth_config:
       - chat:write
       - commands
       - files:read
+      - files:write
       - users:read
 
 settings:

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -8,6 +8,7 @@ Bot Token Scopes：
 - `chat:write`, `channels:read`, `channels:history`, `users:read`, `commands`
 - 私人頻道：`groups:history`, `groups:read`
 - 附件下載：`files:read`
+- 附件上傳：`files:write`（`@bot ask` 長答案以 `answer.md` 附檔回覆）
 
 Event Subscriptions：
 - `app_mention`
@@ -66,6 +67,7 @@ oauth_config:
       - chat:write
       - commands
       - files:read
+      - files:write
       - users:read
 
 settings:


### PR DESCRIPTION
## Summary
- Add `files:write` to both the Scopes bullet list and the YAML manifest in `docs/slack-setup.md` + `docs/slack-setup.en.md`
- The bot already uploads long `@bot ask` answers as `answer.md` (see `app/workflow/ask.go` post → UploadFile), so fresh installs following the setup guide were missing the scope and silently degrading to inline-truncation

## Test plan
- [ ] Review the rendered markdown on GitHub (both zh + en)
- [ ] Apply the updated manifest to a dev Slack app, confirm `files:write` is granted
- [ ] Trigger a long `@bot ask` and verify `answer.md` uploads instead of falling back to truncated inline text

🤖 Generated with [Claude Code](https://claude.com/claude-code)