### PR TITLE
fix: stop agent silent-fail on cwd-external writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Overview, architecture, build/run, tests, and release flow live in `README.md` a
 - **Slack `invalid_blocks`:** do not combine `MsgOptionMetadata` with `MsgOptionBlocks` in the same post — they reject silently together.
 - **Full clone required for branch listing.** Shallow clones can't enumerate branches. `shared/github/repo.go` uses `fetch --all --prune`; keep it that way.
 - **Reporter tag is plain text.** Slack display name ≠ GitHub handle. Never render `@username` into issue bodies.
+- **Worker may run on a user's real machine, not an isolated pod.** Do NOT propose flags / settings that disable agent sandboxing on the host (e.g. `opencode --dangerously-skip-permissions`, `claude --dangerously-skip-permissions`, granting blanket write access). Such flags would let the agent touch `$HOME`, `/etc`, SSH keys, etc. on the operator's box. Solutions for permission/sandbox issues must work in BOTH worker-in-pod and worker-on-laptop deployments — prefer fixing skill/prompt instructions or scoping cwd-relative writes over loosening the agent's host permissions.
 
 ## Product Positioning
 

--- a/agents/skills/github-pr-review/SKILL.md
+++ b/agents/skills/github-pr-review/SKILL.md
@@ -26,11 +26,18 @@ The helper `agentdock pr-review-helper` is on PATH (it is this worker's binary).
 ### 1. Fingerprint the repo
 
 ```bash
-agentdock pr-review-helper fingerprint --pr-url "$PR_URL" > /tmp/fp.json
+agentdock pr-review-helper fingerprint --pr-url "$PR_URL"
 ```
 
-Read `/tmp/fp.json`. It contains `language`, `confidence`, `style_sources`,
-`test_runner`, `framework`, `pr_touched_languages`, `pr_subprojects`.
+The helper prints the fingerprint JSON directly to stdout; parse it from
+there. It contains `language`, `confidence`, `style_sources`, `test_runner`,
+`framework`, `pr_touched_languages`, `pr_subprojects`.
+
+Do NOT redirect to `/tmp/fp.json` or any path outside the current working
+directory — opencode's sandbox treats cwd-external writes as
+`external_directory` asks, and headless `opencode run` auto-rejects them,
+cascade-failing the whole session. If you need the output in a file, write
+it inside cwd (e.g. `./fp.json`).
 
 Why: reviewing generic code without knowing the project's conventions produces
 boilerplate feedback. The fingerprint tells you what rules to apply.

--- a/agents/skills/mantis/README.md
+++ b/agents/skills/mantis/README.md
@@ -66,9 +66,10 @@ node ${your-skills-path}/skills/mantis/scripts/mantis.js get-issue 1234
 # 列出問題
 node ${your-skills-path}/skills/mantis/scripts/mantis.js list-issues --project 5 --filter 50
 
-# 下載附件
+# 下載附件（預設寫到當前 cwd；在 AgentDock worker 下請保持 cwd-relative）
 node ${your-skills-path}/skills/mantis/scripts/mantis.js list-attachments 1234
-node ${your-skills-path}/skills/mantis/scripts/mantis.js download-attachment 1234 <file_id> --output /tmp/screenshot.png
+node ${your-skills-path}/skills/mantis/scripts/mantis.js download-attachment 1234 <file_id>
+node ${your-skills-path}/skills/mantis/scripts/mantis.js download-attachment 1234 <file_id> --output ./screenshot.png
 ```
 
 完整指令說明與 status taxonomy 請參考 [SKILL.md](SKILL.md)；本檔僅保留快速上手與常見流程。

--- a/agents/skills/mantis/SKILL.md
+++ b/agents/skills/mantis/SKILL.md
@@ -160,15 +160,17 @@ node <path-to-skill>/scripts/mantis.js assignment-stats --project <project_id>
 ```bash
 node <path-to-skill>/scripts/mantis.js list-attachments <issue_id>
 node <path-to-skill>/scripts/mantis.js download-attachment <issue_id> <file_id>
-node <path-to-skill>/scripts/mantis.js download-attachment <issue_id> <file_id> --output /tmp/<screenshot_filename>
+node <path-to-skill>/scripts/mantis.js download-attachment <issue_id> <file_id> --output ./screenshot.png
 ```
 
 #### 查看圖片附件流程
 
 1. 先用 `list-attachments` 取得附件清單與 `file_id`
 2. 再用 `download-attachment` 下載附件
+   - 不帶 `--output` 時，預設寫到當前 cwd：`./mantis_<file_id>_<filename>`
+   - 若自行指定 `--output`，**請保留在 cwd 之內**（例如 `./foo.png`）
+   - 禁止輸出到 `/tmp/`、`$HOME`、`~` 等 cwd 之外路徑：AgentDock worker 跑在 opencode 沙箱下，cwd 之外屬 `external_directory`，headless 模式會自動拒絕寫入導致任務靜默失敗
 3. 下載完成後，用 Read 工具讀取圖片或檔案內容
-4. 若在 Windows 環境，注意暫存路徑需改用實際 Windows temp 路徑
 
 ## 常見狀態 ID 對照
 

--- a/agents/skills/mantis/scripts/mantis.js
+++ b/agents/skills/mantis/scripts/mantis.js
@@ -315,8 +315,13 @@ async function cmdDownloadAttachment(args) {
 
   const file = files[0];
   const filename = file.filename || '';
+  // Default to cwd, not os.tmpdir(). In AgentDock worker the cwd is a cloned
+  // git worktree and /tmp is external_directory in the opencode sandbox —
+  // writing there triggers a permission ask that headless `opencode run`
+  // auto-rejects, cascade-failing the whole session. cwd-relative is always
+  // inside the sandbox. Callers can still override via --output.
   const outputPath = parsed.options.output || path.join(
-      os.tmpdir(),
+      process.cwd(),
       filename ? `mantis_${validatedFileId}_${filename}` : `mantis_attachment_${validatedFileId}`,
     );
 

--- a/agents/skills/triage-issue/SKILL.md
+++ b/agents/skills/triage-issue/SKILL.md
@@ -36,8 +36,14 @@ node <skill-path>/mantis/scripts/mantis.js get-issue <N> --full
 
 # 3. Optionally grab screenshots / attachments for visual bugs
 node <skill-path>/mantis/scripts/mantis.js list-attachments <N>
-node <skill-path>/mantis/scripts/mantis.js download-attachment <N> <file_id> --output /tmp/<name>
+node <skill-path>/mantis/scripts/mantis.js download-attachment <N> <file_id>
 ```
+
+`download-attachment` defaults to writing under the current working
+directory (`./mantis_<file_id>_<filename>`). If you pass `--output`, keep
+the path inside cwd (e.g. `--output ./screenshot.png`). Never target
+`/tmp/`, `$HOME`, or other cwd-external paths — opencode's sandbox
+auto-rejects those writes in headless mode.
 
 Incorporate the issue's description, severity, handler, and any
 relevant attachment content (use Read on downloaded images) into

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -137,6 +137,35 @@ func TestPromptConfig_DefaultsPopulated(t *testing.T) {
 	}
 }
 
+// TestPromptConfig_CwdOnlyRuleInAllWorkflows pins the sandbox guard to all
+// three workflows. Removing it from any workflow re-opens the silent-failure
+// class where the LLM redirects bash output to /tmp/* in a worktree-cwd job
+// and headless `opencode run` cascade-collapses the session. See defaults.go
+// cwdOnlySandboxRule and worker/agent/runner.go for the post-mortem context.
+func TestPromptConfig_CwdOnlyRuleInAllWorkflows(t *testing.T) {
+	cfg := &Config{}
+	ApplyDefaults(cfg)
+
+	cases := map[string][]string{
+		"Issue":    cfg.Prompt.Issue.OutputRules,
+		"Ask":      cfg.Prompt.Ask.OutputRules,
+		"PRReview": cfg.Prompt.PRReview.OutputRules,
+	}
+	for name, rules := range cases {
+		var found bool
+		for _, r := range rules {
+			if strings.Contains(r, "outside cwd") && strings.Contains(r, "/tmp/") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s.OutputRules missing cwdOnlySandboxRule (got %d rules, none mention 'outside cwd' + '/tmp/')",
+				name, len(rules))
+		}
+	}
+}
+
 func TestPromptConfig_ResponseSchemaDefaults(t *testing.T) {
 	cfg := &Config{}
 	ApplyDefaults(cfg)

--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -175,6 +175,16 @@ BODY STRUCTURE (load-bearing): When status is CREATED, the "body" JSON string MU
 The app strips those sections in degraded runs (low files_found / high open_questions). Without them, low-confidence analysis leaks into the published GitHub issue.`
 )
 
+// cwdOnlySandboxRule is shared across all three workflows. It guards against
+// the silent-failure class where the LLM (or a SKILL example) writes to
+// /tmp/* or other cwd-external paths in a worktree-cwd job. opencode's
+// sandbox treats those as external_directory asks; headless `opencode run`
+// auto-rejects them and the reject cascade-fails the whole session, so the
+// task exits 0 with no result marker. Two pr_review failures on 2026-04-24
+// matched this exact pattern. See worker/agent/runner.go for the post-mortem
+// detection log added at the same time.
+const cwdOnlySandboxRule = "All temporary files and shell redirections MUST be written inside the current working directory (e.g. `./fp.json`, `./screenshot.png`). Never write to `/tmp/`, `/var/`, `$HOME`, `~`, or any other path outside cwd — opencode's sandbox treats those as external_directory and headless `opencode run` auto-rejects the write, silently failing the task with no result marker."
+
 var (
 	defaultAskOutputRules = []string{
 		"Format the answer in Slack mrkdwn — NOT GitHub markdown. Use *text* (single asterisk) for bold, _text_ for italic, ~text~ for strikethrough, <url|label> for links. Do not use # / ## / ### headings; use *bold* as section labels. Triple-backtick fenced code blocks and single-backtick inline code both render correctly.",
@@ -186,10 +196,21 @@ var (
 		// explicitly bless inline *bold* labels so skill structure survives.
 		"Do not open with an H1/H2/H3 heading or standalone title line — start directly with the answer content. *bold* section labels inside the body (e.g. *簡答*, *依據*, *延伸*) are encouraged per the ask-assistant skill. Keep the total answer ≤30000 chars.",
 		"When referring to yourself, use the exact Slack handle from the <bot> tag in <issue_context> (e.g. 'ai_trigger_issue_bot') verbatim. Do NOT invent shorthand like '@bot ask', 'Ask 助理', 'AI 助理', '程式碼助手'. If a sentence doesn't need self-reference, just answer without name-dropping.",
+		cwdOnlySandboxRule,
 	}
 	defaultPRReviewOutputRules = []string{
 		"Focus on correctness, security, style",
 		"Summary ≤ 2000 chars",
+		cwdOnlySandboxRule,
+	}
+	// Issue.OutputRules used to be intentionally empty — formatting rules live
+	// in the triage-issue skill's SKILL.md body template, machine schema lives
+	// in Issue.ResponseSchema. The cwd-only rule is the one exception: it's a
+	// sandbox guard that applies regardless of the skill in use, so it's
+	// promoted from skill text to a hard output_rule per the project convention
+	// "硬規則直接升格到 output_rules".
+	defaultIssueOutputRules = []string{
+		cwdOnlySandboxRule,
 	}
 )
 
@@ -227,11 +248,13 @@ func applyPromptDefaults(p *PromptConfig) {
 	if len(p.PRReview.OutputRules) == 0 {
 		p.PRReview.OutputRules = defaultPRReviewOutputRules
 	}
-	// Issue.OutputRules is intentionally left empty — formatting rules for
-	// triage output live in the triage-issue skill's SKILL.md body template,
-	// not here. The machine-readable contract (CREATED/REJECTED/ERROR
-	// shapes) now lives in Issue.ResponseSchema instead of being implicit
-	// in the skill.
+	if len(p.Issue.OutputRules) == 0 {
+		p.Issue.OutputRules = defaultIssueOutputRules
+	}
+	// Issue.OutputRules formerly stayed empty — formatting lives in the
+	// triage-issue SKILL.md, machine schema lives in Issue.ResponseSchema.
+	// It now carries exactly one entry: the cwdOnlySandboxRule sandbox
+	// guard, promoted from skill text per "硬規則直接升格到 output_rules".
 
 	// Preserve prior AllowWorkerRules default (pointer to true).
 	if p.AllowWorkerRules == nil {

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -188,7 +188,19 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 		}
 		return strings.TrimSpace(string(data)), nil
 	}
-	return strings.TrimSpace(output), nil
+	// Exit 0 + empty stdout is silent failure (e.g. opencode run auto-rejecting
+	// a permission ask and cascade-collapsing the session). Surface stderr tail
+	// so the next time this happens, log alone is enough to diagnose without
+	// kubectl exec'ing into the worker.
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		stderrTail := strings.TrimSpace(stderr.String())
+		if len(stderrTail) > 2000 {
+			stderrTail = "…" + stderrTail[len(stderrTail)-2000:]
+		}
+		logger.Warn("Agent exit 0 但 stdout 空", "phase", "失敗", "command", agent.Command, "stderr_tail", stderrTail)
+	}
+	return trimmed, nil
 }
 
 // readOutput routes stdout through the appropriate reader based on stream config.


### PR DESCRIPTION
## Summary

Two recent pr_review jobs silently failed (exit 0, empty stdout, no `===REVIEW_RESULT===`). Root cause: SKILL examples and the LLM redirect output to `/tmp/*` in worktree-cwd jobs → opencode treats `/tmp/*` as `external_directory` → headless `opencode run` auto-rejects → reject **cascade-fails** the whole session (verified against opencode source `permission/index.ts:229-246` and `cli/cmd/run.ts:540-559`).

Hardening at four layers so this class of failure is closed regardless of whether worker runs in a pod or on someone's laptop:

- **Detection** (`worker/agent/runner.go`): exit 0 + empty stdout now logs the stderr tail. Next time something silently fails, the log alone diagnoses it — no kubectl exec needed.
- **Root fix** (`agents/skills/mantis/scripts/mantis.js`): `download-attachment` fallback `os.tmpdir()` → `process.cwd()`. Calling without `--output` is now safe in the sandbox.
- **Docs** (4 SKILL/README files): drop all `/tmp/` write examples; show cwd-relative paths and explain why.
- **Hard rule** (`app/config/defaults.go`): `cwdOnlySandboxRule` const promoted into Issue / Ask / PRReview `output_rules`. Test pins it. Catches LLM fall-back to `/tmp/*` even when SKILL doesn't teach it (e.g. the second failure where the LLM invented `> /tmp/pr_diff.txt`).

`CLAUDE.md` Landmines: documents that worker may run on a user's real machine, so flags like `--dangerously-skip-permissions` are off-limits — the chosen path must be safe in both deployments.

## Test plan

- [x] `go test ./test/` — import direction
- [x] `go test ./worker/...` — worker pkgs
- [x] `go test ./app/config/` — new `TestPromptConfig_CwdOnlyRuleInAllWorkflows`
- [x] `node -c agents/skills/mantis/scripts/mantis.js` — syntax
- [ ] Trigger `@bot review <PR URL>` against this branch's worker once deployed; confirm no silent fail
- [ ] Trigger `@bot issue` with a Mantis URL; confirm `download-attachment` writes inside cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)