### PR TITLE
feat(workflow): extend Ask fallback to cover all parse failures

### DIFF
--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -448,17 +448,19 @@ func (w *AskWorkflow) HandleResult(ctx context.Context, state *queue.JobState, r
 		}
 		w.logger.Warn("ask parse failed", "phase", "失敗", "output", truncated, "err", err)
 		metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "parse_failed").Inc()
-		// Intentionally keep r.Status="completed" — Ask is best-effort with no
-		// retry lane, so letting the listener clear dedup on this path is
-		// correct. IssueWorkflow flips to "failed" to gate its retry button.
-		return w.post(job, fmt.Sprintf(":x: 解析失敗：%v", err))
+		// err != nil only when stdout fails the syntactic gate (truly empty
+		// or below askFallbackMinLength). Every other parse-failure shape now
+		// routes through fallback with a fallback_* ResultSource. Ask remains
+		// best-effort with no retry lane; r.Status stays "completed" so the
+		// listener clears dedup. Spec 2026-04-26-ask-fallback-extension §HandleResult.
+		return w.post(job, ":x: Agent 沒有產生任何答案")
 	}
 
 	answer := parsed.Answer
 	status := "success"
-	if parsed.ResultSource == ResultSourceRawFallback {
+	if parsed.ResultSource != ResultSourceSchema {
 		answer = askFallbackBanner + answer
-		status = "fallback_raw"
+		status = parsed.ResultSource
 	}
 
 	if len(answer) > askMaxChars {

--- a/app/workflow/ask_parser.go
+++ b/app/workflow/ask_parser.go
@@ -9,17 +9,21 @@ import (
 
 const askMarker = "===ASK_RESULT==="
 
-// ResultSource flags transport-quality of an AskResult. Spec §AskResult
-// Metadata explains why this is a separate field rather than overloading
-// Confidence.
+// ResultSource flags transport-quality of an AskResult. Schema is the
+// happy path; any fallback_* value indicates the parser had to recover
+// from an agent that didn't follow the schema. Spec
+// 2026-04-26-ask-fallback-extension-design.md §Failure Categories.
 const (
-	ResultSourceSchema      = "schema"
-	ResultSourceRawFallback = "raw_fallback"
+	ResultSourceSchema                 = "schema"
+	ResultSourceFallbackMarkerMissing  = "fallback_marker_missing"
+	ResultSourceFallbackSegmentsNoJSON = "fallback_segments_no_json"
+	ResultSourceFallbackUnmarshal      = "fallback_unmarshal"
+	ResultSourceFallbackEmptyAnswer    = "fallback_empty_answer"
 )
 
-// askFallbackMinLength is the minimum rune count below which raw stdout is
-// rejected as a fallback answer. Syntactic gate only; no content
-// classification. Spec §Syntactic Check.
+// askFallbackMinLength is the minimum rune count below which raw stdout
+// is rejected as a fallback answer. Syntactic gate only; no content
+// classification.
 const askFallbackMinLength = 10
 
 // AskResult is the parsed ===ASK_RESULT=== JSON, plus a transport-quality
@@ -31,49 +35,51 @@ type AskResult struct {
 }
 
 // ParseAskOutput extracts the ASK_RESULT marker block and unmarshals its
-// JSON body. Walks markers last-first so the opencode fence pattern
-// (payload sandwiched between opening and closing markers) is recovered.
-// Rejects empty answers.
-//
-// On marker-missing-entirely + raw output passing the syntactic gate,
-// returns the raw output as the answer with
-// ResultSource="raw_fallback". Marker-present failures (malformed JSON,
-// empty answer) intentionally do NOT fall back; spec §Design Decisions
-// Resolved #2.
+// JSON body. Returns error only when stdout fails the syntactic gate
+// (truly empty / below min length); every other failure shape (marker
+// missing, segments without JSON, unmarshal failure, empty answer)
+// returns success with the corresponding fallback_* ResultSource so the
+// handler can prepend a transparency banner. Reverses §Design Decisions
+// #2 of 2026-04-25-workflow-output-boundary-design.md.
 func ParseAskOutput(output string) (AskResult, error) {
 	output = strings.TrimSpace(output)
 	segments := segmentAfterMarker(output, askMarker)
 	if len(segments) == 0 {
-		if looksLikePlainAnswer(output) {
-			return AskResult{Answer: output, ResultSource: ResultSourceRawFallback}, nil
-		}
-		return AskResult{}, fmt.Errorf("%s marker not found", askMarker)
+		return fallbackOrFail(output, ResultSourceFallbackMarkerMissing)
 	}
-	var lastErr error
+	lastReason := ResultSourceFallbackSegmentsNoJSON
 	for _, seg := range segments {
 		if !strings.HasPrefix(seg, "{") {
-			lastErr = fmt.Errorf("expected JSON object after marker")
 			continue
 		}
 		jsonStr := extractJSON(seg)
 		var r AskResult
 		if err := json.Unmarshal([]byte(jsonStr), &r); err != nil {
-			lastErr = fmt.Errorf("unmarshal: %w", err)
+			lastReason = ResultSourceFallbackUnmarshal
 			continue
 		}
 		if strings.TrimSpace(r.Answer) == "" {
-			lastErr = fmt.Errorf("answer must not be empty")
+			lastReason = ResultSourceFallbackEmptyAnswer
 			continue
 		}
 		r.ResultSource = ResultSourceSchema
 		return r, nil
 	}
-	return AskResult{}, lastErr
+	return fallbackOrFail(output, lastReason)
 }
 
-// looksLikePlainAnswer is the syntactic gate for the missing-marker
-// fallback. Not a content classifier — the handler layer attaches a
-// transparency banner regardless.
+// fallbackOrFail packages raw stdout as a fallback Answer when the
+// syntactic gate passes; otherwise reports the parse failure for the
+// caller to surface as ":x: Agent 沒有產生任何答案".
+func fallbackOrFail(output, reason string) (AskResult, error) {
+	if looksLikePlainAnswer(output) {
+		return AskResult{Answer: output, ResultSource: reason}, nil
+	}
+	return AskResult{}, fmt.Errorf("ask output empty or below min length")
+}
+
+// looksLikePlainAnswer is the syntactic gate for fallback. Not a content
+// classifier — the handler attaches a transparency banner regardless.
 func looksLikePlainAnswer(s string) bool {
 	return utf8.RuneCountInString(strings.TrimSpace(s)) >= askFallbackMinLength
 }

--- a/app/workflow/ask_parser_test.go
+++ b/app/workflow/ask_parser_test.go
@@ -22,11 +22,10 @@ func TestParseAskOutput_Valid(t *testing.T) {
 	}
 }
 
-// TestParseAskOutput_MarkerMissing_FallbackToRaw exercises the missing-marker
-// fallback: when the agent omits the ===ASK_RESULT=== wrapper but its raw
-// stdout passes the syntactic gate, the parser surfaces stdout verbatim as
-// the answer with ResultSource="raw_fallback". Spec §Ask Fallback Policy.
-func TestParseAskOutput_MarkerMissing_FallbackToRaw(t *testing.T) {
+// TestParseAskOutput_MarkerMissing_FallbackToMarkerMissing exercises the
+// missing-marker fallback: agent omits the ===ASK_RESULT=== wrapper but
+// raw stdout passes the syntactic gate. Spec §Failure Categories.
+func TestParseAskOutput_MarkerMissing_FallbackToMarkerMissing(t *testing.T) {
 	output := "Here is the answer to your question."
 	r, err := ParseAskOutput(output)
 	if err != nil {
@@ -35,8 +34,8 @@ func TestParseAskOutput_MarkerMissing_FallbackToRaw(t *testing.T) {
 	if r.Answer != output {
 		t.Errorf("Answer = %q, want %q", r.Answer, output)
 	}
-	if r.ResultSource != ResultSourceRawFallback {
-		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceRawFallback)
+	if r.ResultSource != ResultSourceFallbackMarkerMissing {
+		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceFallbackMarkerMissing)
 	}
 }
 
@@ -58,20 +57,74 @@ func TestParseAskOutput_MarkerMissing_TooShortFails(t *testing.T) {
 	}
 }
 
-func TestParseAskOutput_EmptyAnswer(t *testing.T) {
+// TestParseAskOutput_EmptyAnswer_FallsBackToEmptyAnswer covers the case
+// where the JSON parses but the answer field is empty. Under the
+// extended fallback, we surface the raw stdout (incl. the empty-answer
+// JSON) so the user can see what the agent actually returned.
+func TestParseAskOutput_EmptyAnswer_FallsBackToEmptyAnswer(t *testing.T) {
 	output := "===ASK_RESULT===\n" + `{"answer":""}`
-	if _, err := ParseAskOutput(output); err == nil {
-		t.Error("expected error when answer empty")
+	r, err := ParseAskOutput(output)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if r.ResultSource != ResultSourceFallbackEmptyAnswer {
+		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceFallbackEmptyAnswer)
+	}
+	if !strings.Contains(r.Answer, "===ASK_RESULT===") {
+		t.Errorf("fallback Answer should be the raw stdout; got %q", r.Answer)
 	}
 }
 
-// TestParseAskOutput_MalformedJSON confirms marker-present-but-unparseable
-// JSON still fails closed. Fallback is intentionally limited to
-// missing-marker; spec §Design Decisions Resolved #2.
-func TestParseAskOutput_MalformedJSON(t *testing.T) {
+// TestParseAskOutput_MalformedJSON_FallsBackToUnmarshal pins the
+// marker-present-but-unparseable case. Old behaviour failed closed; new
+// contract surfaces the raw stdout with fallback_unmarshal so the user
+// still sees the output.
+func TestParseAskOutput_MalformedJSON_FallsBackToUnmarshal(t *testing.T) {
 	output := "===ASK_RESULT===\n{not json"
-	if _, err := ParseAskOutput(output); err == nil {
-		t.Error("expected error on malformed JSON; fallback must not cover this case")
+	r, err := ParseAskOutput(output)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if r.ResultSource != ResultSourceFallbackUnmarshal {
+		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceFallbackUnmarshal)
+	}
+	if r.Answer != output {
+		t.Errorf("fallback Answer should equal raw stdout; got %q", r.Answer)
+	}
+}
+
+// TestParseAskOutput_MarkerInStringValue_FallsBackToUnmarshal covers the
+// 2026-04-25 incident shape where the agent emits a marker followed by
+// JSON whose string value also contains the marker keyword. extractJSON
+// is brace-counting + string-aware, but segmentAfterMarker still splits
+// on every marker occurrence, leaving the JSON segment truncated. New
+// contract: that truncation routes to fallback_unmarshal instead of
+// failing closed. Spec §Failure Categories lists this as one of the
+// patterns the unmarshal fallback covers.
+func TestParseAskOutput_MarkerInStringValue_FallsBackToUnmarshal(t *testing.T) {
+	output := "===ASK_RESULT===\n" + `{"answer": "Schema reference: ===ASK_RESULT=== marker is required."}`
+	r, err := ParseAskOutput(output)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if r.ResultSource != ResultSourceFallbackUnmarshal {
+		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceFallbackUnmarshal)
+	}
+}
+
+// TestParseAskOutput_MarkerInBodyNoJSON_FallsBackToSegmentsNoJSON pins the
+// 2026-04-26 incident where the agent answered in markdown that字面引用
+// the marker keyword in body text without ever emitting a JSON object.
+// Old behaviour returned "expected JSON object after marker" → :x: 解析失敗.
+// New contract: fallback_segments_no_json with the markdown surfaced.
+func TestParseAskOutput_MarkerInBodyNoJSON_FallsBackToSegmentsNoJSON(t *testing.T) {
+	output := "*簡答*\n答案。結尾附上 `===ASK_RESULT===` JSON 區塊。\n\n*依據*\n以 `===ASK_RESULT===` 結尾。"
+	r, err := ParseAskOutput(output)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if r.ResultSource != ResultSourceFallbackSegmentsNoJSON {
+		t.Errorf("ResultSource = %q, want %q", r.ResultSource, ResultSourceFallbackSegmentsNoJSON)
 	}
 }
 

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -716,23 +716,78 @@ func TestAskWorkflow_BuildJob_NoOptIn_PriorAnswerEmpty(t *testing.T) {
 	}
 }
 
-// TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric covers the
-// missing-marker fallback path: when ParseAskOutput returns a raw_fallback
-// AskResult, HandleResult must prepend the transparency banner to the
-// posted answer and increment the fallback_raw metric. Spec §Slack
-// Rendering and §Observability.
+// TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric exercises
+// the four fallback paths (marker missing / segments without JSON /
+// unmarshal failure / empty answer): each must prepend the transparency
+// banner and increment the matching fallback_* metric label. Spec
+// 2026-04-26-ask-fallback-extension §HandleResult, §Metrics.
 func TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric(t *testing.T) {
-	before := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "fallback_raw"))
+	cases := []struct {
+		name      string
+		rawOutput string
+		wantLabel string
+	}{
+		{
+			name:      "marker_missing",
+			rawOutput: "Plain answer with enough length to clear the syntactic gate.",
+			wantLabel: "fallback_marker_missing",
+		},
+		{
+			name:      "segments_no_json",
+			rawOutput: "===ASK_RESULT===\nThis body never produced a JSON object even though the marker appeared.",
+			wantLabel: "fallback_segments_no_json",
+		},
+		{
+			name:      "unmarshal",
+			rawOutput: "===ASK_RESULT===\n{not valid json at all}",
+			wantLabel: "fallback_unmarshal",
+		},
+		{
+			name:      "empty_answer",
+			rawOutput: "===ASK_RESULT===\n{\"answer\":\"\"}",
+			wantLabel: "fallback_empty_answer",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", tc.wantLabel))
+
+			w, slack := newTestAskWorkflow(t)
+			job := &queue.Job{ID: "j1", ChannelID: "C1", ThreadTS: "1.0", StatusMsgTS: "s-ts", TaskType: "ask"}
+			state := &queue.JobState{Job: job}
+			result := &queue.JobResult{JobID: "j1", Status: "completed", RawOutput: tc.rawOutput}
+			if err := w.HandleResult(context.Background(), state, result); err != nil {
+				t.Fatal(err)
+			}
+
+			if len(slack.Posted) == 0 {
+				t.Fatal("nothing posted")
+			}
+			last := slack.Posted[len(slack.Posted)-1]
+			if !strings.HasPrefix(last, ":warning: 請驗證輸出答案,AGENT 並未遵守輸出格式") {
+				t.Errorf("fallback path must prepend warning banner; posted: %q", last)
+			}
+
+			after := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", tc.wantLabel))
+			if after-before != 1 {
+				t.Errorf("%s counter delta = %v, want 1", tc.wantLabel, after-before)
+			}
+		})
+	}
+}
+
+// TestAskWorkflow_HandleResult_TrueEmpty_PostsAgentNoAnswer pins the new
+// error-branch wording. Stdout that fails the syntactic gate (truly empty
+// or below askFallbackMinLength) is the only path that still posts an
+// :x: failure; everything else falls through to fallback. Spec
+// 2026-04-26-ask-fallback-extension §HandleResult.
+func TestAskWorkflow_HandleResult_TrueEmpty_PostsAgentNoAnswer(t *testing.T) {
+	before := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "parse_failed"))
 
 	w, slack := newTestAskWorkflow(t)
 	job := &queue.Job{ID: "j1", ChannelID: "C1", ThreadTS: "1.0", StatusMsgTS: "s-ts", TaskType: "ask"}
 	state := &queue.JobState{Job: job}
-	// No marker, plain text long enough to clear the syntactic gate.
-	const rawAnswer = "Plain answer with enough length to clear the syntactic gate."
-	result := &queue.JobResult{
-		JobID: "j1", Status: "completed",
-		RawOutput: rawAnswer,
-	}
+	result := &queue.JobResult{JobID: "j1", Status: "completed", RawOutput: "  \n  "}
 	if err := w.HandleResult(context.Background(), state, result); err != nil {
 		t.Fatal(err)
 	}
@@ -741,16 +796,13 @@ func TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric(t *testing.
 		t.Fatal("nothing posted")
 	}
 	last := slack.Posted[len(slack.Posted)-1]
-	if !strings.HasPrefix(last, ":warning: 請驗證輸出答案,AGENT 並未遵守輸出格式") {
-		t.Errorf("fallback path must prepend warning banner; posted: %q", last)
-	}
-	if !strings.Contains(last, rawAnswer) {
-		t.Errorf("fallback path must include raw answer body; posted: %q", last)
+	if last != ":x: Agent 沒有產生任何答案" {
+		t.Errorf("true-empty stdout must post the new wording; posted: %q", last)
 	}
 
-	after := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "fallback_raw"))
+	after := testutil.ToFloat64(metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "parse_failed"))
 	if after-before != 1 {
-		t.Errorf("fallback_raw counter delta = %v, want 1", after-before)
+		t.Errorf("parse_failed counter delta = %v, want 1", after-before)
 	}
 }
 

--- a/app/workflow/redact_log_test.go
+++ b/app/workflow/redact_log_test.go
@@ -77,18 +77,21 @@ func TestIssueHandleResult_ParseFail_NoSecret_Unchanged(t *testing.T) {
 // ── AskWorkflow ───────────────────────────────────────────────────────────────
 
 func TestAskHandleResult_ParseFail_RedactsSecret(t *testing.T) {
-	const fakeSecret = "supersecret-ask-xyz789"
+	// Under the 2026-04-26 fallback extension, ask's parse-fail log only
+	// fires for stdout that fails the syntactic gate (truly empty / below
+	// askFallbackMinLength = 10 runes). Driver therefore uses a short raw
+	// output that equals the secret. The secret length must be >= the
+	// shared/logging minRedactLength (6 bytes) AND the whole stdout must
+	// remain under 10 runes; "ASKXYZ" (6 bytes) satisfies both.
+	const fakeSecret = "ASKXYZ"
 	cfg := cfgWithSecret(fakeSecret)
 	var buf bytes.Buffer
 	w := NewAskWorkflow(cfg, newFakeSlackPort(), nil, captureLogger(&buf))
 
 	state := &queue.JobState{Job: &queue.Job{TaskType: "ask"}}
 	result := &queue.JobResult{
-		Status: "completed",
-		// Marker present + malformed JSON triggers the strict parse-fail path
-		// (the missing-marker fallback intentionally does not cover this case;
-		// spec §Design Decisions Resolved #2).
-		RawOutput: "===ASK_RESULT===\nbad json with token " + fakeSecret + " inside",
+		Status:    "completed",
+		RawOutput: fakeSecret,
 	}
 	_ = w.HandleResult(context.Background(), state, result)
 
@@ -102,13 +105,13 @@ func TestAskHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 }
 
 func TestAskHandleResult_ParseFail_NoSecret_Unchanged(t *testing.T) {
-	cfg := cfgWithSecret("supersecret-ask-xyz789")
+	cfg := cfgWithSecret("ASKXYZ")
 	var buf bytes.Buffer
 	w := NewAskWorkflow(cfg, newFakeSlackPort(), nil, captureLogger(&buf))
 
-	// No newline so the slog text handler does not escape it; the assertion
-	// uses substring containment on the rendered log line.
-	const harmlessOutput = "===ASK_RESULT=== not valid json at all"
+	// Short stdout with no secret. Same gate constraint as the redaction test
+	// above: the parse-fail path is now reserved for sub-min-length stdout.
+	const harmlessOutput = "harmless"
 	state := &queue.JobState{Job: &queue.Job{TaskType: "ask"}}
 	result := &queue.JobResult{
 		Status:    "completed",

--- a/docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md
+++ b/docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md
@@ -3,6 +3,7 @@
 **Date:** 2026-04-25
 **Status:** Draft (revised after design grill)
 **Issue:** TBD
+**Reversed in part by:** [`2026-04-26-ask-fallback-extension-design.md`](./2026-04-26-ask-fallback-extension-design.md) — §Ask Fallback Policy → Trigger Condition #2, §Acceptance Criteria #3, and §Design Decisions Resolved #2 are no longer in force. Ask fallback now covers all parse-failure shapes, with categorised metric labels for observability.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md
+++ b/docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md
@@ -1,0 +1,185 @@
+# Ask Fallback Extension: Categorised Failure Recovery
+
+**Date:** 2026-04-26
+**Status:** Draft
+**Issue:** TBD
+**Supersedes:** §Ask Fallback Policy, §Acceptance Criteria #3, and §Design Decisions Resolved #2 of `2026-04-25-workflow-output-boundary-design.md`
+
+## Problem
+
+The previous spec ratified a narrow Ask fallback trigger: missing-marker only. Marker-present-but-JSON-broken cases were intentionally left to fail closed.
+
+That decision held until the next failure shape arrived. On 2026-04-26 (~03:33 UTC), an Ask job emitted a markdown answer that included three literal references to `===ASK_RESULT===` in the body and no JSON object. `segmentAfterMarker` produced three segments, none JSON-shaped, parser returned `expected JSON object after marker`, user saw `:x: 解析失敗`.
+
+This is the fourth distinct parser-side incident in two weeks:
+
+| PR / branch | Failure shape | Fix style |
+| --- | --- | --- |
+| #121 | doubled `===TRIAGE_RESULT===` markers | parser patch |
+| #165 | opencode fence pattern around marker | parser patch |
+| #205 | marker entirely missing | fallback (narrow) |
+| `fix/ask-parser-marker-in-string` (open) | marker referenced inside JSON string value | parser patch |
+| 2026-04-26 incident | marker referenced inside markdown body, no JSON | none yet |
+
+Pattern: LLM output is stochastic; a deterministic parser cannot achieve 100% coverage by case-specific patching. Each patch resolves its case; the next case shows up the next week. Engineering cost per patch is days; user cost per uncovered case is `:x: 解析失敗`.
+
+## Premise Reversal
+
+`2026-04-25-workflow-output-boundary-design.md` §Design Decisions #2 closed:
+
+> Ask fallback surface — missing-marker only. Malformed-JSON cases stay strict because the raw stdout in those cases typically contains JSON debris that would confuse the user.
+
+The "JSON debris" rationale was inferred from one incident shape and does not generalise. The 2026-04-26 case has no JSON debris at all — the body is clean markdown. More fundamentally, the original decision optimised for "schema integrity as a contract" and produced "user sees `:x:` while the agent's answer is sitting right there in stdout".
+
+The reversal: every parse failure that pairs with a non-empty syntactic check passes through fallback. The specific failure mode is carried in metrics labels for operator observability, not in user-facing wording.
+
+## Goals
+
+1. Eliminate user-visible `:x: 解析失敗` for the Ask workflow whenever the agent produced substantive stdout.
+2. Stop accumulating parser-side patches per new failure shape.
+3. Preserve operator observability into agent format-compliance degradation via categorised metrics.
+4. Issue and PR Review strictness is untouched. Their success contracts still require successful side effects.
+
+## Non-Goals
+
+- Changing the Ask schema. `===ASK_RESULT===` + JSON is still the contract agents are prompted to follow.
+- Removing `looksLikePlainAnswer`. The minimum-length floor still rejects truly empty stdout.
+- Changing Issue or PR Review behavior.
+- Introducing a second LLM as parser-of-last-resort.
+
+## Design
+
+### Failure Categories
+
+`AskResult.ResultSource` extends from `{schema, raw_fallback}` to a finer set:
+
+| ResultSource | Trigger |
+| --- | --- |
+| `schema` | marker present, segment is JSON, unmarshals, `answer` non-empty |
+| `fallback_marker_missing` | marker not in stdout (PR #205's case) |
+| `fallback_segments_no_json` | marker(s) present, no segment starts with `{` (2026-04-26 case) |
+| `fallback_unmarshal` | segment starts with `{`, but `json.Unmarshal` failed (covers in-string marker, doubled markers, fence patterns) |
+| `fallback_empty_answer` | JSON valid, `answer` field empty/whitespace |
+
+### Parser Contract
+
+`ParseAskOutput` returns `(AskResult, error)` where:
+
+- `error == nil` for the schema path **and** any fallback path that passes `looksLikePlainAnswer`.
+- `error != nil` only when stdout fails the syntactic gate (truly empty / near-empty).
+
+Sketch:
+
+```go
+func ParseAskOutput(output string) (AskResult, error) {
+    output = strings.TrimSpace(output)
+    segments := segmentAfterMarker(output, askMarker)
+    if len(segments) == 0 {
+        return fallbackOrFail(output, ResultSourceFallbackMarkerMissing)
+    }
+    lastReason := ResultSourceFallbackSegmentsNoJSON
+    for _, seg := range segments {
+        if !strings.HasPrefix(seg, "{") {
+            continue
+        }
+        var r AskResult
+        if err := json.Unmarshal([]byte(extractJSON(seg)), &r); err != nil {
+            lastReason = ResultSourceFallbackUnmarshal
+            continue
+        }
+        if strings.TrimSpace(r.Answer) == "" {
+            lastReason = ResultSourceFallbackEmptyAnswer
+            continue
+        }
+        r.ResultSource = ResultSourceSchema
+        return r, nil
+    }
+    return fallbackOrFail(output, lastReason)
+}
+
+func fallbackOrFail(output, reason string) (AskResult, error) {
+    if looksLikePlainAnswer(output) {
+        return AskResult{Answer: output, ResultSource: reason}, nil
+    }
+    return AskResult{}, fmt.Errorf("ask output empty or below min length")
+}
+```
+
+### HandleResult
+
+`app/workflow/ask.go:443-470` — the `if err != nil` branch shrinks; the `:x: 解析失敗` post-and-return is deleted. Replacement:
+
+```go
+parsed, err := ParseAskOutput(r.RawOutput)
+if err != nil {
+    metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "parse_failed").Inc()
+    return w.post(job, ":x: Agent 沒有產生任何答案")
+}
+
+answer := parsed.Answer
+if parsed.ResultSource != ResultSourceSchema {
+    answer = askFallbackBanner + answer
+}
+metrics.WorkflowCompletionsTotal.WithLabelValues("ask", parsed.ResultSource).Inc()
+return w.post(job, answer)
+```
+
+### Banner
+
+The existing banner is unchanged and does not vary by `ResultSource`:
+
+```
+:warning: 請驗證輸出答案,AGENT 並未遵守輸出格式
+
+<answer body>
+```
+
+User only needs "schema violated, verify before acting"; the precise failure mode stays operator-facing.
+
+### Metrics
+
+`WorkflowCompletionsTotal{workflow="ask", status=...}` label values:
+
+- `success` — schema path (kept as-is for dashboard backwards compatibility)
+- `fallback_marker_missing` — replaces the previous `fallback_raw` label
+- `fallback_segments_no_json` — new
+- `fallback_unmarshal` — new
+- `fallback_empty_answer` — new
+- `parse_failed` — now reserved for true-empty stdout (was the catch-all)
+
+A spike in any specific `fallback_*` label tells ops which failure shape is regressing. Old `fallback_raw` is dropped — the migration is one CHANGELOG line. Pre-launch project, no production dashboards to migrate beyond personal Grafana.
+
+## Acceptance Criteria
+
+1. Ask jobs whose stdout fails any parsing path but passes `looksLikePlainAnswer` post the answer with `askFallbackBanner` prepended. No `:x: 解析失敗` user-visible message.
+2. Ask jobs whose stdout fails `looksLikePlainAnswer` post `:x: Agent 沒有產生任何答案` and increment `parse_failed`.
+3. Each of the four `fallback_*` metric labels increments exactly under its trigger condition (unit-test enforced).
+4. Issue and PR Review behavior is unchanged.
+5. Branch `fix/ask-parser-marker-in-string` is closed without merging — its in-string marker case becomes a graceful `fallback_unmarshal` outcome under the new contract, so the parser-side patch is no longer required.
+
+## What This Spec Refuses to Do
+
+Recorded so future-me doesn't re-litigate:
+
+- **Per-case parser patches.** The whole point of this spec is that case-specific patching is unsustainable. Future "add another `markerPositions` rule" proposals should be rejected; reinforce the prompt or accept the fallback.
+- **LLM-as-parser.** Second API call, second failure mode, second cost line. The deterministic parser already covers happy path; the new fallback covers everything else cheaply.
+
+## Rollout
+
+1. Land parser + HandleResult changes behind no flag (pre-launch, no users to gate).
+2. Update CHANGELOG: `fallback_raw` label removed, `fallback_*` enumeration added.
+3. Close `fix/ask-parser-marker-in-string` branch without merging.
+4. (Optional) Reinforce prompt to discourage literal marker references in answer body — treated as a quality improvement, not a parser correctness requirement. Fallback absorbs the failure regardless.
+
+## Design Decisions Reversed
+
+Vs. `2026-04-25-workflow-output-boundary-design.md`:
+
+- §Design Decisions #2 (Ask fallback surface — missing-marker only) — **reversed**. All parse failures with non-empty stdout now fall back.
+- §Acceptance Criteria #3 (marker present + malformed JSON still fails closed) — **reversed**. Such jobs now fall back with `ResultSource = fallback_unmarshal`.
+- §Ask Fallback Policy → Trigger Condition #2 (missing marker only) — **reversed**, see §Failure Categories above.
+
+## Open Questions
+
+- **Banner per category?** Current decision: no. Single banner. User reads answer and decides; operators read metrics. Revisit if user feedback says the warning is too vague.
+- **Rename `success` label to `schema`?** Current decision: keep `success` to avoid breaking the one personal dashboard. Trade-off: label name is opinionated. Revisit if it confuses anyone.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,148 +1,165 @@
-# Plan: Workflow Output Boundary — Ask Raw Fallback
+# Implementation Plan: Ask Fallback Extension (Categorised Failure Recovery)
 
-**Spec:** `docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md`
-**Date:** 2026-04-25
-**Branch suggestion:** `feat/ask-raw-fallback`
+**Spec:** `docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md`
+**Date:** 2026-04-26
+**Branch suggestion:** `feat/ask-fallback-extension` (NOT continued from `fix/ask-parser-marker-in-string`)
 
-## Scope
+## Overview
 
-Implement the Ask missing-marker fallback. Worker code is unchanged. All work
-lives in `app/workflow/`.
+Extend Ask parser fallback to cover **all** parse-failure shapes (not just missing-marker), with categorised metric labels (`fallback_marker_missing` / `fallback_segments_no_json` / `fallback_unmarshal` / `fallback_empty_answer`) for operator observability. Reverses §Design Decisions #2 + §Acceptance Criteria #3 of `2026-04-25-workflow-output-boundary-design.md`.
 
-In scope:
-- `AskResult.ResultSource` field
-- `ParseAskOutput` missing-marker fallback path with syntactic check
-- `HandleResult` prepends warning banner + emits `fallback_raw` metric
+User-visible outcome: `:x: 解析失敗` no longer surfaces when stdout has substantive content. Only truly-empty stdout produces `:x: Agent 沒有產生任何答案`.
 
-Out of scope (rejected during design grill, see spec §Design Decisions Resolved):
-- Malformed-JSON fallback
-- Worker-side hint
-- Generic stdout sanitizer
-- Issue / PR Review failure-message UX cleanup (separate follow-up)
+## Architecture Decisions
 
-## Dependency graph
+1. **Branch from `main`, not from `fix/ask-parser-marker-in-string`.** The pending branch's string-aware `markerPositions` patch becomes redundant — its in-string marker case now falls through to `fallback_unmarshal` gracefully under the new contract. Keeping the patch contradicts spec §What This Spec Refuses to Do (per-case parser patches).
+2. **Single banner, not per-category.** Banner is a transparency signal; users read the answer + warning, operators read metric breakdown. Spec §Banner.
+3. **Keep `success` label for schema path.** Backwards-compat for the existing personal Grafana dashboard. Spec §Open Questions.
+4. **Drop `fallback_raw` label entirely.** Replaced by the four `fallback_*` labels. Pre-launch project, no production dashboard migration burden.
+5. **`fix/ask-parser-marker-in-string` is closed without merge** per spec §Acceptance Criteria #5. Local-only branch (no remote, no PR), so deletion is `git branch -D` — destructive, requires user confirmation.
+
+## Dependency Graph
 
 ```
-Task 1 (parser) ─→ Task 2 (handler) ─→ Task 3 (e2e verification)
+Task 1 (parser: ResultSource enum + ParseAskOutput contract)
+    └─ Task 2 (handler: simplify HandleResult + route ResultSource → metric label)
+            └─ Task 3 (cleanup: annotate old spec + CHANGELOG + close stale branch)
 ```
 
-Task 2 needs the `ResultSource` field added in Task 1. Task 3 is verification
-only — no code changes.
+Task 2 depends on Task 1 because the new label values must exist before HandleResult routes them. Task 3 is documentation + housekeeping; depends on Task 2 only because CHANGELOG references the merged behavior.
 
-## Tasks
+## Task List
 
-### Task 1 — AskResult.ResultSource + parser fallback path
+### Phase 1: Parser
 
-**Files:**
+#### Task 1 — Extend ResultSource enum + ParseAskOutput contract change
+
+**Description:** Replace `ResultSourceRawFallback` with four categorised constants. Refactor `ParseAskOutput` so every parse-failure shape (marker missing, segments no JSON, unmarshal failed, empty answer) routes through a single `fallbackOrFail` helper that gates on `looksLikePlainAnswer`. Only true-empty stdout returns an error.
+
+**Acceptance criteria:**
+- [ ] Constants: `ResultSourceSchema`, `ResultSourceFallbackMarkerMissing`, `ResultSourceFallbackSegmentsNoJSON`, `ResultSourceFallbackUnmarshal`, `ResultSourceFallbackEmptyAnswer`. Old `ResultSourceRawFallback` removed.
+- [ ] `ParseAskOutput` returns `error == nil` whenever `looksLikePlainAnswer(output) == true`, regardless of which parsing path failed.
+- [ ] `ParseAskOutput` returns `error != nil` only when `looksLikePlainAnswer` rejects (truly empty / below min length).
+- [ ] Each fallback path sets the correct `ResultSource` value (the four `fallback_*` constants).
+- [ ] Schema-path success continues to set `ResultSource = ResultSourceSchema`.
+
+**Verification:**
+- [ ] `go test ./app/workflow -run TestParseAskOutput -v` green
+- [ ] `go vet ./app/...` clean
+- [ ] Test cases (added or updated):
+  - schema happy path → `ResultSourceSchema`
+  - marker missing + plain text → `ResultSourceFallbackMarkerMissing`
+  - marker present + body has no `{` segment (2026-04-26 case) → `ResultSourceFallbackSegmentsNoJSON`
+  - marker present + JSON-shaped segment but unmarshal fails (in-string marker / fence / doubled marker) → `ResultSourceFallbackUnmarshal`
+  - marker present + JSON valid + `answer` empty → `ResultSourceFallbackEmptyAnswer` (rest of body fills the fallback Answer)
+  - empty / whitespace-only / sub-min-length stdout → `error != nil`
+- [ ] Existing `TestParseAskOutput_MalformedJSON` semantic flips: now expects fallback success (rename test accordingly).
+- [ ] Existing `TestParseAskOutput_EmptyAnswer` semantic flips: now expects fallback success.
+- [ ] Existing `TestParseAskOutput_MarkerInsideAnswer` (from `fix/ask-parser-marker-in-string`) is **not** ported — that branch is closed; behavior is covered by the new `fallback_unmarshal` test.
+
+**Dependencies:** None.
+
+**Files likely touched:**
 - `app/workflow/ask_parser.go`
 - `app/workflow/ask_parser_test.go`
 
-**Changes:**
-1. Add `ResultSource string` to `AskResult` (struct tag `json:"-"` so it
-   never round-trips into the agent's JSON contract).
-2. In `ParseAskOutput`:
-   - Schema-path success → set `ResultSource = "schema"` before return.
-   - On marker-not-found error → run syntactic check on the trimmed output.
-     Pass: return `AskResult{Answer: trimmed, ResultSource: "raw_fallback"}, nil`.
-     Fail: return existing `marker not found` error.
-   - Marker present but JSON malformed / missing object / empty answer →
-     keep existing error path (deliberately not covered).
-3. Syntactic check (private helper, e.g. `looksLikePlainAnswer`):
-   - non-empty after `strings.TrimSpace`
-   - meets minimum length threshold (suggested ≥ 10 visible chars; finalize
-     at code review)
-   - intentionally **no** keyword blocklist
+**Estimated scope:** S (2 files)
+
+---
+
+### Checkpoint: After Task 1
+
+- [ ] Parser tests green; `ResultSource` enum extended; `ParseAskOutput` contract is "error iff syntactic gate fails".
+- [ ] Diff to `ask_parser.go` is contained (one helper added, one constant block edited, one function refactored). No drive-by edits.
+- [ ] Confirm with human: are the four `fallback_*` label spellings final? They become metric label values that are awkward to rename later.
+
+---
+
+### Phase 2: Handler
+
+#### Task 2 — HandleResult: drop `:x: 解析失敗`, route ResultSource to metric label
+
+**Description:** Simplify `HandleResult` so the `if err != nil` branch only handles truly-empty stdout (post `:x: Agent 沒有產生任何答案`). On parser success, prepend the existing `askFallbackBanner` whenever `parsed.ResultSource != ResultSourceSchema`, and emit `WorkflowCompletionsTotal{workflow="ask", status=parsed.ResultSource}` (or `"success"` when schema). Banner does not vary by category.
 
 **Acceptance criteria:**
-- Schema path returns `ResultSource = "schema"` and existing tests pass.
-- Missing-marker + valid plain text → `ResultSource = "raw_fallback"`, no error.
-- Missing-marker + empty stdout → error.
-- Missing-marker + whitespace-only stdout → error.
-- Missing-marker + below-threshold-length stdout → error.
-- Marker present + malformed JSON → unchanged error (no fallback).
-- `Confidence` field semantics unchanged (still model-provided).
+- [ ] `:x: 解析失敗：%v` post-and-return removed from `app/workflow/ask.go`.
+- [ ] New error-branch wording: `:x: Agent 沒有產生任何答案` (no leak of internal error string).
+- [ ] Schema path: no banner, metric label `success`.
+- [ ] Any `fallback_*` path: banner prepended, metric label = the `ResultSource` value.
+- [ ] Banner prepended **before** the `askMaxChars` truncation check (preserves PR #205 ordering).
+- [ ] `r.Status="completed"` left unchanged on the empty-output error path (Ask still has no retry lane; preserve PR #205 comment intent).
 
 **Verification:**
-```sh
-go test ./app/workflow -run TestParseAskOutput -v
-go vet ./...
-```
+- [ ] `go test ./app/workflow -run TestAskWorkflow_HandleResult -v` green
+- [ ] `go build ./cmd/agentdock` succeeds
+- [ ] Test cases (updated):
+  - schema path → no banner, `success` metric +1
+  - each of 4 fallback paths → banner present, correct `fallback_*` metric +1
+  - true-empty stdout → posts `:x: Agent 沒有產生任何答案`, `parse_failed` metric +1
+- [ ] Existing `TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric` is renamed/split into per-category tests; the old `fallback_raw` label is no longer asserted.
 
-### Task 2 — Handler banner + metric label
+**Dependencies:** Task 1.
 
-**Files:**
+**Files likely touched:**
 - `app/workflow/ask.go`
 - `app/workflow/ask_test.go`
 
-**Changes:**
-1. In `AskWorkflow.HandleResult`, after `ParseAskOutput` succeeds:
-   - If `parsed.ResultSource == "raw_fallback"`:
-     - Prepend banner `":warning: 請驗證輸出答案,AGENT 並未遵守輸出格式\n\n"`
-       to `answer`.
-     - Increment `metrics.WorkflowCompletionsTotal.WithLabelValues("ask", "fallback_raw")`.
-   - Else:
-     - Behave as today (`success` metric).
-2. Banner is prepended **before** the `askMaxChars` truncation so a very long
-   fallback answer still ships with the warning intact.
+**Estimated scope:** S (2 files)
+
+---
+
+### Checkpoint: After Task 2
+
+- [ ] Handler tests green; metric labels exactly match the four `fallback_*` constants + `success` + `parse_failed`.
+- [ ] `go test ./...` green across modules.
+- [ ] `go test ./test/...` green (import direction).
+- [ ] Confirm with human: empty-stdout wording (`:x: Agent 沒有產生任何答案`) is acceptable, or revise.
+
+---
+
+### Phase 3: Cleanup
+
+#### Task 3 — Annotate old spec, update CHANGELOG, close stale branch
+
+**Description:** Mark the reversed sections in `2026-04-25-workflow-output-boundary-design.md` so future readers find the reversal. Add a CHANGELOG entry for the metric label rename (`fallback_raw` removed, four `fallback_*` added). Confirm with user before deleting local branch `fix/ask-parser-marker-in-string` (destructive; no remote, no PR, but commit `2c4a2db` lives only there).
 
 **Acceptance criteria:**
-- Schema path: posted text equals `parsed.Answer`, no banner, `success`
-  metric increments.
-- Fallback path: posted text begins with the banner, `fallback_raw` metric
-  increments.
-- Existing `parse_failed` path (truly empty / non-fallback-eligible) still
-  posts `:x: 解析失敗:%v` and increments `parse_failed` metric.
-- Long fallback answers: banner + truncated body, banner is not lost to
-  truncation.
+- [ ] `2026-04-25-workflow-output-boundary-design.md` gains a top-of-file note: `**Reversed in part by:** docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md (§Design Decisions #2, §Acceptance Criteria #3, §Ask Fallback Policy → Trigger Condition #2)`.
+- [ ] CHANGELOG entry under appropriate section: `Ask metric label fallback_raw removed; replaced by fallback_marker_missing, fallback_segments_no_json, fallback_unmarshal, fallback_empty_answer.`
+- [ ] User confirms before any `git branch -D fix/ask-parser-marker-in-string` is run. If user prefers to keep the branch locally for reference, that's fine — close-by-deletion is not strictly required for the spec acceptance, only that the branch is not merged.
 
 **Verification:**
-```sh
-go test ./app/workflow -run TestAskWorkflow_HandleResult -v
-go build ./...
-```
+- [ ] `grep -n "Reversed" docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md` finds the new note.
+- [ ] CHANGELOG diff shows the metric label migration entry.
+- [ ] `git branch --list fix/ask-parser-marker-in-string` outcome matches user's decision (deleted or retained).
 
-### Task 3 — End-to-end verification
+**Dependencies:** Task 2.
 
-**Changes:** none (verification only)
+**Files likely touched:**
+- `docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md`
+- `CHANGELOG.md` (path TBD — confirm existing CHANGELOG location)
 
-**Acceptance criteria:**
-- `go test ./...` green across all modules.
-- `go test ./test/...` green (covers `import_direction_test.go`).
-- `go build ./cmd/agentdock` succeeds.
-- Manual sanity: synthesise a `JobResult` whose `RawOutput` is plain text
-  without the marker, run through `AskWorkflow.HandleResult` (or a unit-test
-  harness that exercises it) and confirm the banner + answer render.
+**Estimated scope:** XS (2 files + git op)
 
-**Verification:**
-```sh
-go test ./...
-go build ./cmd/agentdock
-```
+---
 
-## Checkpoints
+### Checkpoint: After Task 3 (Complete)
 
-- **After Task 1:** parser tests green, handler unchanged. Pause to confirm
-  threshold value and the constant naming for `ResultSource` values
-  (`"schema"` / `"raw_fallback"`).
-- **After Task 2:** handler tests green, metric observable. Pause to decide
-  whether the banner wording needs UX review with stakeholders before merge.
-- **After Task 3:** ready for PR. CI must pass, no worker code touched.
+- [ ] All acceptance criteria from spec §Acceptance Criteria met.
+- [ ] PR opened on `feat/ask-fallback-extension` from `main`. Per memory `feedback_merge_authorization`, stop after opening PR; user verifies CI before merge.
+- [ ] Image rebuild + k8s redeploy is downstream and is **not** part of this plan — covered by existing release-please flow.
 
-## Risks
+## Risks and Mitigations
 
-- **Banner wording UX:** team may judge the wording too aggressive or too
-  permissive. Mitigation: revisit at Task 2 checkpoint; wording is a
-  one-line change.
-- **Threshold mis-calibration:** too low leaks garbage stdout, too high
-  rejects legitimate one-line answers. Mitigation: observe `fallback_raw`
-  rate after rollout; adjust via follow-up PR.
-- **Metric label collision:** confirm `fallback_raw` is not already a
-  registered status value in `shared/metrics`.
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Renaming metric labels breaks user's personal Grafana panels | Low (pre-launch, single dashboard) | Explicit CHANGELOG note. User updates dashboard at deploy time. |
+| `looksLikePlainAnswer` minimum-length (10 runes) lets through obviously-broken stdout (e.g. `null null null`) | Low | Banner warns user. If false-positive rate is noisy in practice, revisit threshold separately — out of scope for this plan. |
+| Closing `fix/ask-parser-marker-in-string` loses commit `2c4a2db` | Low | Commit lives in reflog for 90 days; the test it added is documented in spec §Failure Categories as the `fallback_unmarshal` reference case. Branch is local-only with no PR, so no one else depends on it. |
+| Future incident proposes "add another `markerPositions` rule" | Medium | Spec §What This Spec Refuses to Do is explicit. Reject and reinforce prompt instead. |
 
-## Follow-ups (not part of this plan)
+## Open Questions
 
-- Sanitize `issue.go:316,323` raw `errMsg` exposure (separate UX PR).
-- Review `===ASK_RESULT===` prompt emphasis, gated by `fallback_raw` metric
-  trend (spec §Rollout step 4).
-- Revisit model selection if fallback frequency stays operationally noisy
-  (spec §Rollout step 5).
+- **Banner per category?** Default: no. Single banner `:warning: 請驗證輸出答案,AGENT 並未遵守輸出格式`. Revisit if user feedback says it's too vague.
+- **Rename `success` label to `schema`?** Default: keep `success` for backwards-compat with existing dashboard.
+- **CHANGELOG file path?** Confirm at Task 3 — release-please usually maintains it; if managed by automation, the entry may go in a different file (e.g. release-notes draft).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,43 +1,90 @@
-# Todo: Workflow Output Boundary — Ask Raw Fallback
+# Todo: Ask Fallback Extension (Categorised Failure Recovery)
 
 Plan: `tasks/plan.md`
-Spec: `docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md`
+Spec: `docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md`
+Branch: `feat/ask-fallback-extension` (from `main`, NOT from `fix/ask-parser-marker-in-string`)
 
-## Task 1 — Parser fallback (`app/workflow/ask_parser.go`, `_test.go`) — complete
+## Pre-flight
 
-- [x] Add `ResultSource string` field to `AskResult` (`json:"-"`)
-- [x] Schema-path success sets `ResultSource = "schema"`
-- [x] Marker-not-found path runs syntactic check, returns `"raw_fallback"` on pass
-- [x] Syntactic check: non-empty after `TrimSpace`, meets min-length (10 runes)
-- [x] Test: schema path → `"schema"`
-- [x] Test: missing-marker + plain text → `"raw_fallback"`
-- [x] Test: missing-marker + empty / whitespace / short stdout → error
-- [x] Test: marker present + malformed JSON → unchanged error
-- [x] `go test ./app/workflow -run TestParseAskOutput -v` green
-- [x] `go vet ./...` clean
-- [x] regression fix: redact_log_test ask cases now drive parse-fail via marker-present + malformed JSON
+- [ ] Confirm with human: spec is approved as-is or with edits
+- [ ] Confirm with human: four `fallback_*` constant spellings are final
+- [ ] Confirm with human: empty-stdout wording `:x: Agent 沒有產生任何答案`
+- [ ] Confirm with human: branch deletion of `fix/ask-parser-marker-in-string` (destructive, requires explicit go-ahead)
+- [ ] `git checkout main && git pull && git checkout -b feat/ask-fallback-extension`
 
-## Task 2 — Handler banner + metric (`app/workflow/ask.go`, `_test.go`) — complete
+## Task 1 — Parser refactor (`app/workflow/ask_parser.go`, `_test.go`)
 
-- [x] Branch on `parsed.ResultSource` in `HandleResult`
-- [x] Prepend `:warning: 請驗證輸出答案,AGENT 並未遵守輸出格式\n\n` on fallback path
-- [x] Increment `WorkflowCompletionsTotal{status="fallback_raw"}` on fallback path
-- [x] Banner prepended before `askMaxChars` truncation (source ordering verified)
-- [x] Test: schema path → no banner, asserted by `TestAskWorkflow_HandleResult_SchemaPathHasNoBanner`
-- [x] Test: fallback path → banner present + `fallback_raw` metric increment
-- [x] `go test ./app/workflow -run TestAskWorkflow_HandleResult -v` green
-- [x] `go build ./...` clean
-- [x] `go mod tidy` pulled `prometheus/client_golang/prometheus/testutil` into app module
+- [ ] Replace `ResultSourceRawFallback` const with four new consts:
+  - [ ] `ResultSourceFallbackMarkerMissing = "fallback_marker_missing"`
+  - [ ] `ResultSourceFallbackSegmentsNoJSON = "fallback_segments_no_json"`
+  - [ ] `ResultSourceFallbackUnmarshal = "fallback_unmarshal"`
+  - [ ] `ResultSourceFallbackEmptyAnswer = "fallback_empty_answer"`
+- [ ] Add private helper `fallbackOrFail(output, reason string) (AskResult, error)` per spec sketch
+- [ ] Refactor `ParseAskOutput`:
+  - [ ] Marker-missing branch routes through `fallbackOrFail(output, ResultSourceFallbackMarkerMissing)`
+  - [ ] Segment-not-`{` branch tracks `ResultSourceFallbackSegmentsNoJSON` as `lastReason`
+  - [ ] Unmarshal-fail branch tracks `ResultSourceFallbackUnmarshal`
+  - [ ] Empty-answer branch tracks `ResultSourceFallbackEmptyAnswer`
+  - [ ] Loop fall-through routes through `fallbackOrFail(output, lastReason)`
+  - [ ] Schema success unchanged
+- [ ] Update doc comment on `ParseAskOutput` to describe the new contract; remove the pointer to old §Design Decisions #2
+- [ ] Test updates in `ask_parser_test.go`:
+  - [ ] `TestParseAskOutput_Valid` — unchanged (schema path)
+  - [ ] `TestParseAskOutput_MarkerMissing_FallbackToRaw` → rename + assert new constant `ResultSourceFallbackMarkerMissing`
+  - [ ] `TestParseAskOutput_MalformedJSON` → flip semantic: now expects fallback success with `ResultSourceFallbackUnmarshal`; rename to `TestParseAskOutput_MalformedJSON_FallsBackToUnmarshal`
+  - [ ] `TestParseAskOutput_EmptyAnswer` → flip semantic: now expects fallback success with `ResultSourceFallbackEmptyAnswer`; rename to `TestParseAskOutput_EmptyAnswer_FallsBackToEmptyAnswer`
+  - [ ] Add `TestParseAskOutput_MarkerInBodyNoJSON` (covers 2026-04-26 incident: marker referenced in markdown body, no JSON object) → expects `ResultSourceFallbackSegmentsNoJSON`
+  - [ ] `TestParseAskOutput_MarkerMissing_EmptyFails` — keep (true empty still errors)
+  - [ ] `TestParseAskOutput_MarkerMissing_WhitespaceOnlyFails` — keep
+  - [ ] `TestParseAskOutput_MarkerMissing_TooShortFails` — keep
+  - [ ] `TestParseAskOutput_MultipleMarkers_LastWins` — verify still passes (schema path unaffected)
+  - [ ] `TestParseAskOutput_FenceMarkers` — verify still passes (schema path)
+- [ ] Verify: `go test ./app/workflow -run TestParseAskOutput -v` green
+- [ ] Verify: `go vet ./app/...` clean
 
-## Task 3 — End-to-end verification — complete
+### Checkpoint after Task 1
 
-- [x] `go test ./...` green (app + root modules)
-- [x] `go test ./test/...` green (import direction)
-- [x] `go build ./cmd/agentdock` succeeds
-- [x] Manual sanity covered by `TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric` exercising the synthesised missing-marker case end-to-end through `HandleResult`
+- [ ] Stop and confirm with human: are the four `fallback_*` constant spellings + the empty-stdout wording final before continuing to Task 2?
 
-## Checkpoints
+## Task 2 — Handler simplify (`app/workflow/ask.go`, `_test.go`)
 
-- [ ] After Task 1: confirm threshold value (10 runes) and `ResultSource` constant naming (`ResultSourceSchema` / `ResultSourceRawFallback`) — awaiting human review
-- [ ] After Task 2: confirm banner wording (`:warning: 請驗證輸出答案,AGENT 並未遵守輸出格式`) with stakeholders — awaiting human review
-- [ ] After Task 3: open PR — awaiting human go-ahead
+- [ ] Replace the `if err != nil { ... }` body in `HandleResult` (`app/workflow/ask.go:443-455`):
+  - [ ] Keep `logging.Redact` + truncation + `WARN` log (operator value)
+  - [ ] Replace `metrics ... "parse_failed"` increment — keep label, but it now only fires for true-empty stdout
+  - [ ] Replace post text with `:x: Agent 沒有產生任何答案`
+- [ ] Replace the `parsed.ResultSource == ResultSourceRawFallback` check (`app/workflow/ask.go:459-462`):
+  - [ ] Branch on `parsed.ResultSource != ResultSourceSchema` instead
+  - [ ] `status = parsed.ResultSource` (the new `fallback_*` value)
+  - [ ] Banner prepend unchanged
+- [ ] Banner constant `askFallbackBanner` unchanged
+- [ ] Test updates in `ask_test.go`:
+  - [ ] Existing `TestAskWorkflow_HandleResult_FallbackPrependsBannerAndIncMetric` (line 722) → split or generalise into per-category tests
+  - [ ] Add coverage for `fallback_segments_no_json` metric label increment + banner present
+  - [ ] Add coverage for `fallback_unmarshal` metric label increment + banner present
+  - [ ] Add coverage for `fallback_empty_answer` metric label increment + banner present
+  - [ ] Add coverage for true-empty stdout → posts `:x: Agent 沒有產生任何答案` + `parse_failed` metric
+  - [ ] Existing `TestAskWorkflow_HandleResult_SchemaPathHasNoBanner` — verify unchanged
+- [ ] Verify: `go test ./app/workflow -run TestAskWorkflow_HandleResult -v` green
+- [ ] Verify: `go build ./cmd/agentdock` succeeds
+
+### Checkpoint after Task 2
+
+- [ ] `go test ./...` green across all modules
+- [ ] `go test ./test/...` green (import direction)
+- [ ] Stop and confirm with human: handler behaviour matches expectation before housekeeping
+
+## Task 3 — Cleanup (spec annotation + CHANGELOG + branch close)
+
+- [ ] Add reversed-by note to top of `docs/superpowers/specs/2026-04-25-workflow-output-boundary-design.md`:
+  - [ ] `**Reversed in part by:** docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md (§Design Decisions #2, §Acceptance Criteria #3, §Ask Fallback Policy → Trigger Condition #2)`
+- [ ] Locate CHANGELOG-of-record (release-please managed `CHANGELOG.md` or release-notes draft):
+  - [ ] Add entry: `Ask metric label fallback_raw removed; replaced by fallback_marker_missing, fallback_segments_no_json, fallback_unmarshal, fallback_empty_answer.`
+- [ ] Confirm with human (per memory `feedback_merge_authorization`): delete local branch `fix/ask-parser-marker-in-string`?
+  - [ ] If yes: `git branch -D fix/ask-parser-marker-in-string` (commit `2c4a2db` recoverable from reflog 90 days)
+  - [ ] If no: leave branch as-is; spec acceptance only requires "not merged"
+
+### Checkpoint after Task 3 (Complete)
+
+- [ ] Open PR on `feat/ask-fallback-extension`
+- [ ] **STOP after PR open** — per memory, do not self-merge; user verifies CI
+- [ ] Image rebuild + k8s redeploy is downstream (release-please flow), not part of this plan


### PR DESCRIPTION
## Summary
- Reverses the narrow "missing-marker only" trigger from #205. Every parse failure shape (marker missing, segments without JSON, unmarshal failure, empty answer) now falls through to a transparency-bannered answer when stdout passes the syntactic gate.
- Replaces `:x: 解析失敗：%v` with `:x: Agent 沒有產生任何答案`, reserved for truly empty stdout. Other failures surface the raw agent output with the existing warning banner so the user can still see what the agent produced.
- `ResultSource` enum extended from `{schema, raw_fallback}` to `{schema, fallback_marker_missing, fallback_segments_no_json, fallback_unmarshal, fallback_empty_answer}`. Each fallback path increments its own metric label for operator observability.

## Spec
- `docs/superpowers/specs/2026-04-26-ask-fallback-extension-design.md` (new)
- Reverses §Design Decisions #2 of `2026-04-25-workflow-output-boundary-design.md`; that file now carries a "Reversed in part by" pointer at the top.

## Why
- Two-week pattern: PR #121 (doubled markers), #165 (fence pattern), #205 (missing marker), pending `fix/ask-parser-marker-in-string` (in-string marker), 2026-04-26 incident (marker referenced in markdown body, no JSON). Four parser-side patches, each resolving its case; new shape arrives the next week.
- LLM output is stochastic; deterministic parser cannot cover every shape by case-specific patching. Switch from "patch parser" to "fallback gracefully + observe via metrics".
- Pending branch `fix/ask-parser-marker-in-string` is closed without merging — its in-string marker case now falls through to `fallback_unmarshal` gracefully under the new contract (covered by `TestParseAskOutput_MarkerInStringValue_FallsBackToUnmarshal`).

## ⚠ BREAKING CHANGE
Metric label `WorkflowCompletionsTotal{workflow="ask",status="fallback_raw"}` is removed and replaced by four `fallback_*` labels. Dashboards keying on `fallback_raw` need to switch to a `fallback_*` regex or enumerate the new labels.

## Test plan
- [x] `go test ./app/workflow -run TestParseAskOutput -v` — 11/11 pass (incl. two new incident-pinning cases: in-string marker, marker-in-body-no-JSON)
- [x] `go test ./app/workflow -run TestAskWorkflow_HandleResult -v` — table-driven across 4 fallback labels + new true-empty case all pass
- [x] `go test ./app/workflow -run TestAskHandleResult_ParseFail -v` — redact tests refactored to drive via short stdout; pass
- [x] `go test ./...` — app, worker, shared, root (incl. import direction) all green
- [x] `go build ./cmd/agentdock` — exit 0
- [ ] **CI verification** — please verify before merge per repo convention
- [ ] **Image rebuild + k8s redeploy** — handled by release-please flow downstream of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)