### PR TITLE
fix(pr-review): 修正 diff 來源與 422 錯誤訊息誤譯

### DIFF
--- a/agents/skills/github-pr-review/SKILL.md
+++ b/agents/skills/github-pr-review/SKILL.md
@@ -67,15 +67,24 @@ better than fake feedback.
 
 ### 3. Analyze the diff
 
-Fetch the diff:
+Fetch the diff via GitHub (authoritative — uses GitHub's own merge-base):
 
 ```bash
-# The helper also fetches this internally; you can inspect it directly for planning.
-gh_api_url="https://api.github.com/repos/{owner}/{repo}/pulls/{number}/files"
+# Whole-PR unified diff:
+gh pr diff "$PR_NUMBER"
+
+# Per-file with patches (the helper also calls this internally):
+gh api "repos/{owner}/{repo}/pulls/{number}/files"
 ```
 
-Or just read files on disk (they're already checked out at PR head). Use
-`git diff origin/<base>..HEAD` if you need to see the exact hunk shape.
+Or read files on disk — they're checked out at PR head.
+
+**Do NOT use `git diff origin/<base>..HEAD`.** The worker's bare repo is a
+long-lived shared cache: `origin/main` (and other base refs) get fetched
+and updated to GitHub's *current* tip on every job. If the PR was opened a
+while ago and `<base>` has advanced since, `origin/<base>..HEAD` reverses
+in those new commits and you'll comment on lines that aren't in the PR's
+real diff. Always anchor the diff to the PR API, not local refs.
 
 For each concerning change, prepare a comment candidate:
 - `path`: repo-relative file path

--- a/shared/prreview/github.go
+++ b/shared/prreview/github.go
@@ -301,7 +301,19 @@ func createReview(ctx context.Context, apiBase, prURL, token string, payload *Cr
 	case 404:
 		return 0, fmt.Errorf("%s", ErrGitHubNotFound)
 	case 422:
-		return 0, fmt.Errorf("%s", ErrGitHubStaleCommit)
+		body, _ := io.ReadAll(resp.Body)
+		detail := strings.TrimSpace(string(body))
+		// GitHub 422 covers many validation failures. Only the commit_id /
+		// head-sha mismatch maps to "PR head moved"; surface other 422s with
+		// their raw GitHub message so operators can diagnose (e.g. body
+		// missing, comment line outside diff, malformed payload).
+		low := strings.ToLower(detail)
+		if strings.Contains(low, "commit_id") ||
+			strings.Contains(low, "head sha") ||
+			strings.Contains(low, "no commit found") {
+			return 0, fmt.Errorf("%s: %s", ErrGitHubStaleCommit, detail)
+		}
+		return 0, fmt.Errorf("create review 422: %s", detail)
 	}
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)

--- a/shared/prreview/review_test.go
+++ b/shared/prreview/review_test.go
@@ -257,6 +257,41 @@ func TestValidateAndPost_StaleCommit422(t *testing.T) {
 	}
 }
 
+func TestValidateAndPost_Generic422_NotStaleCommit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/files") {
+			_, _ = io.WriteString(w, `[{"filename":"a.go","status":"modified","patch":"@@ -1 +1,2 @@\n a\n+b\n"}]`)
+			return
+		}
+		w.WriteHeader(422)
+		_, _ = io.WriteString(w, `{"message":"Body is required"}`)
+	}))
+	defer srv.Close()
+
+	r := ReviewJSON{
+		Summary: "ok", SeveritySummary: SummaryMinor,
+		Comments: []CommentJSON{
+			{Path: "a.go", Line: 2, Side: SideRight, Body: "nit", Severity: SeverityNit},
+		},
+	}
+	_, err := ValidateAndPost(context.Background(), ValidateAndPostInput{
+		Review:   &r,
+		PRURL:    "https://github.com/x/y/pull/42",
+		CommitID: "abc",
+		Token:    "tok",
+		APIBase:  srv.URL,
+	})
+	if err == nil {
+		t.Fatal("want error on 422")
+	}
+	if strings.Contains(err.Error(), ErrGitHubStaleCommit) {
+		t.Errorf("non-stale 422 should not be reported as stale commit, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Body is required") {
+		t.Errorf("expected GitHub message in error, got %v", err)
+	}
+}
+
 func TestValidateAndPost_Unauth401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)


### PR DESCRIPTION
## Summary
- SKILL.md 改用 `gh pr diff` / GitHub Files API 算 PR diff，避免 worker 共用 bare repo 的 origin refs drift 後 agent 拿到錯誤 diff
- `createReview` 422 拆解：含 `commit_id` / `head sha` / `no commit found` 等 keyword 才報 stale commit，其他 422 帶出 GitHub 原始訊息給 operator debug

## Background
測試時 niuma 在 PR #200 review 失敗，回 `:x: Review 失敗：PR head moved during review (422)`，但該 PR head 實際 2 天沒動。從 worker pod 撈 opencode session DB 後發現 agent 跑 `git diff origin/main..HEAD`，origin/main 是 fetch 後的最新 tip，包含 PR 200 之後 merge 進 main 的 9 個 commits（含 PR #205 ask-raw-fallback），所以 agent 評論的 3 個檔案 (`ask_parser.go`、`.release-please-manifest.json`、`redact_log_test.go`) 全部不在 PR 200 真實 diff 中。`filterAndTruncate` 全 skip 後送純 summary review GitHub 仍回 422，但被 hardcode 譯成 stale commit 誤導 operator。

## Test plan
- [x] `go test ./shared/prreview/...` 全綠（5 tests）
- [x] 既有 `TestValidateAndPost_StaleCommit422` 通過（mock body 含 "commit_id" → 走 stale 分支）
- [x] 新增 `TestValidateAndPost_Generic422_NotStaleCommit` 覆蓋非 stale 422
- [ ] CI 通過
- [ ] 部署後手動再觸發 PR review，確認 422 訊息會帶 GitHub 原始 message

🤖 Generated with [Claude Code](https://claude.com/claude-code)