### PR TITLE
feat(config): 把 agent 預設 timeout 拉到 30m，watchdog 配套 35m

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -55,7 +55,7 @@ func TestApplyDefaults_Timeouts(t *testing.T) {
 	if cfg.SemaphoreTimeout != 30*time.Second {
 		t.Errorf("semaphore = %v", cfg.SemaphoreTimeout)
 	}
-	if cfg.Queue.JobTimeout != 20*time.Minute {
+	if cfg.Queue.JobTimeout != 35*time.Minute {
 		t.Errorf("job_timeout = %v", cfg.Queue.JobTimeout)
 	}
 }

--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -57,7 +57,7 @@ func ApplyDefaults(cfg *Config) {
 		cfg.ChannelPriority = map[string]int{"default": 50}
 	}
 	if cfg.Queue.JobTimeout <= 0 {
-		cfg.Queue.JobTimeout = 20 * time.Minute
+		cfg.Queue.JobTimeout = 35 * time.Minute
 	}
 	if cfg.Queue.AgentIdleTimeout <= 0 {
 		cfg.Queue.AgentIdleTimeout = 5 * time.Minute

--- a/docs/configuration-app.en.md
+++ b/docs/configuration-app.en.md
@@ -108,7 +108,7 @@ queue:
   transport: redis                    # extension point; only redis is supported today
   store: redis                        # JobStore backend: redis (default) / mem
   store_ttl: 1h                       # per-record TTL when store=redis (ignored when store=mem)
-  job_timeout: 20m                    # watchdog: max job lifecycle
+  job_timeout: 35m                    # watchdog: max job lifecycle
   agent_idle_timeout: 5m              # stream-json: no-event timeout
   prepare_timeout: 3m
   cancel_timeout: 60s

--- a/docs/configuration-app.md
+++ b/docs/configuration-app.md
@@ -108,7 +108,7 @@ queue:
   transport: redis                    # 擴充點；目前僅支援 redis
   store: redis                        # JobStore backend：redis（預設）/ mem
   store_ttl: 1h                       # store=redis 時每筆紀錄的 TTL（store=mem 忽略）
-  job_timeout: 20m                    # watchdog：job 生命週期上限
+  job_timeout: 35m                    # watchdog：job 生命週期上限
   agent_idle_timeout: 5m              # stream-json 無事件多久視為卡住
   prepare_timeout: 3m
   cancel_timeout: 60s

--- a/docs/configuration-worker.en.md
+++ b/docs/configuration-worker.en.md
@@ -47,7 +47,7 @@ repo_cache:
 queue:
   capacity: 50
   transport: redis
-  job_timeout: 20m
+  job_timeout: 35m
   agent_idle_timeout: 5m
   prepare_timeout: 3m
   cancel_timeout: 60s

--- a/docs/configuration-worker.md
+++ b/docs/configuration-worker.md
@@ -45,7 +45,7 @@ repo_cache:
 queue:
   capacity: 50
   transport: redis
-  job_timeout: 20m
+  job_timeout: 35m
   agent_idle_timeout: 5m
   prepare_timeout: 3m
   cancel_timeout: 60s

--- a/worker/config/builtin_agents.go
+++ b/worker/config/builtin_agents.go
@@ -12,14 +12,14 @@ var BuiltinAgents = map[string]AgentConfig{
 	"claude": {
 		Command:  "claude",
 		Args:     []string{"--print", "--output-format", "stream-json", "-p", "{prompt}"},
-		Timeout:  15 * time.Minute,
+		Timeout:  30 * time.Minute,
 		SkillDir: ".claude/skills",
 		Stream:   true,
 	},
 	"codex": {
 		Command: "codex",
 		Args:    []string{"exec", "--skip-git-repo-check", "--color", "never", "{prompt}"},
-		Timeout: 15 * time.Minute,
+		Timeout: 30 * time.Minute,
 		// Codex CLI discovers skills from .agents/skills (repo/CWD scope),
 		// NOT .codex/skills. See https://developers.openai.com/codex/skills.
 		SkillDir: ".agents/skills",
@@ -32,7 +32,7 @@ var BuiltinAgents = map[string]AgentConfig{
 		// first "I dispatched" text — before the sub-agents return a parseable
 		// TRIAGE_RESULT. Internal auth plugins still load, so credentials stay intact.
 		Args:     []string{"run", "--pure", "{prompt}"},
-		Timeout:  15 * time.Minute,
+		Timeout:  30 * time.Minute,
 		SkillDir: ".opencode/skills",
 	},
 }

--- a/worker/config/defaults.go
+++ b/worker/config/defaults.go
@@ -41,7 +41,7 @@ func ApplyDefaults(cfg *Config) {
 		cfg.Queue.Transport = "redis"
 	}
 	if cfg.Queue.JobTimeout <= 0 {
-		cfg.Queue.JobTimeout = 20 * time.Minute
+		cfg.Queue.JobTimeout = 35 * time.Minute
 	}
 	if cfg.Queue.AgentIdleTimeout <= 0 {
 		cfg.Queue.AgentIdleTimeout = 5 * time.Minute


### PR DESCRIPTION
## Summary

- 內建 agent (claude/codex/opencode) 的 \`Timeout\` 從 **15m → 30m**，給複雜任務多一倍時間
- App 與 worker 兩端的 \`Queue.JobTimeout\` 從 **20m → 35m**，避免 watchdog 早於新 agent timeout kill 掉 job
- 同步更新 \`docs/configuration-{app,worker}{,.en}.md\` 範例 yaml

## Why

Production 上跑大型 repo 的 Ask / PR Review 容易撞 15m timeout（最近一筆 \`20260426-070947-f5d679c3\` 在 worker pod 看到 \`error=timeout after 15m0s\`，剛好整數）。

但只調 agent timeout 不夠：watchdog 從 \`Job.SubmittedAt\` 起算（\`shared/queue/watchdog.go:108\`），若 \`JobTimeout\` 維持 20m，新的 30m agent timeout 永遠 hit 不到 — watchdog 會在 20m 先 kill。所以兩個一起拉。

35m = 30m agent + 5m buffer，留給 prepare（3m）/ cancel（60s）這些既有 slack。watchdog 仍保持 strict superset 的角色。

## Changes

| File | Change |
|---|---|
| \`worker/config/builtin_agents.go\` | claude / codex / opencode timeout 15m → 30m |
| \`app/config/defaults.go\` | \`Queue.JobTimeout\` default 20m → 35m |
| \`worker/config/defaults.go\` | \`Queue.JobTimeout\` default 20m → 35m |
| \`app/config/config_test.go\` | \`TestApplyDefaults_Timeouts\` 期望值同步 |
| \`docs/configuration-{app,worker}{,.en}.md\` | 範例 yaml \`job_timeout\` 同步 |

## Test plan

- [x] \`cd app && go test ./config/...\`
- [x] \`cd worker && go test ./config/...\`
- [x] \`cd shared && go test ./queue/...\`
- [ ] CI 全綠（test + import_direction_test）
- [ ] Deploy ai-tools 後跑一筆原本會撞 15m 的 task 確認跑得完
- [ ] 留意 watchdog log，確認 \`job_timeout=35m0s\`

## 部署提醒

Production ConfigMap (\`agentdock\`) 內 \`app.yaml\` 把 \`job_timeout: 20m\` 寫死。Deploy 新 image 後若沒同步改 ConfigMap，ConfigMap 會 override 新 default。建議 deploy 前先 \`kubectl edit configmap -n ai-tools agentdock\` 把 \`job_timeout\` 改成 \`35m\` 或直接刪掉那行讓 default 生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)