### PR TITLE
fix: ask result race + agent CLI bumps

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -9,13 +9,15 @@ FROM node:22-alpine
 RUN apk add --no-cache git ca-certificates curl
 
 # Agent CLIs
-RUN npm install -g @anthropic-ai/claude-code @openai/codex
+ARG CLAUDE_CODE_VERSION=2.1.123
+ARG CODEX_VERSION=0.125.0
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @openai/codex@${CODEX_VERSION}
 
 # opencode 1.4.10+ uses an embedded WASM ripgrep backend, which eliminates the
 # "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
 # version downloaded a platform ripgrep binary at startup and failed to
 # extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
-ARG OPENCODE_VERSION=1.4.11
+ARG OPENCODE_VERSION=1.14.29
 RUN curl -sL https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-musl.tar.gz | \
     tar xzf - -C /usr/local/bin opencode
 

--- a/worker/pool/pool.go
+++ b/worker/pool/pool.go
@@ -207,6 +207,15 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	result := executeJob(jobCtx, job, deps, opts, logger)
 	status.setPrepareSeconds(result.PrepareSeconds)
 
+	// Promote the worker-side store to the terminal status BEFORE the final
+	// status report. publishStatus stamps state.Status onto the report's
+	// JobStatus field; if we do this after, the final report still says
+	// "running" and app-side StatusListener.maybeUpdateSlack races
+	// ResultListener — the cancel-button template can land after the
+	// workflow's final message and clobber it (see incident 2026-04-29
+	// job 20260429-041810-f0bd994e).
+	p.cfg.Store.UpdateStatus(ctx, job.ID, queue.JobStatus(result.Status))
+
 	// Send final status report (captures cost/tokens from result event).
 	status.alive = false
 	if p.cfg.Status != nil {
@@ -226,7 +235,6 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 		}
 	}
 
-	p.cfg.Store.UpdateStatus(ctx, job.ID, queue.JobStatus(result.Status))
 	if err := p.cfg.Results.Publish(ctx, result); err != nil {
 		logger.Error("failed to publish result", "error", err)
 	}

--- a/worker/pool/pool_test.go
+++ b/worker/pool/pool_test.go
@@ -736,3 +736,63 @@ func TestPool_StatusReportsIncludeJobStatus(t *testing.T) {
 		t.Errorf("no report with JobStatus=JobPreparing; seen=%v", seen)
 	}
 }
+
+// Pins the ordering of (Store.UpdateStatus → final publishStatus → Results.Publish):
+// the final status report MUST carry a terminal JobStatus, otherwise the
+// app-side StatusListener races ResultListener and can clobber the workflow's
+// final Slack message with a stale "running" template (incident 2026-04-29
+// job 20260429-041810-f0bd994e). If this test fails, the result-handling
+// race window is reopened — fix the worker, not the test.
+func TestPool_FinalStatusReportCarriesTerminalJobStatus(t *testing.T) {
+	store := queue.NewMemJobStore()
+	bundle := queuetest.NewBundle(10, 3, store)
+	defer bundle.Close()
+
+	recorder := &recordingStatusBus{}
+	agentOutput := "ok\n\n===ASK_RESULT===\n" + `{"answer": "yes"}`
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      &mockRunner{output: agentOutput},
+		RepoCache:   &mockRepo{path: "/tmp/test-repo"},
+		WorkerCount: 1,
+		Status:      recorder,
+		Logger:      slog.Default(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool.Start(ctx)
+	bundle.Attachments.Prepare(ctx, "j1", nil)
+	bundle.Queue.Submit(ctx, &queue.Job{
+		ID:       "j1",
+		Priority: 50,
+		PromptContext: &queue.PromptContext{
+			ThreadMessages: []queue.ThreadMessage{{User: "T", Timestamp: "1", Text: "test"}},
+			Channel:        "test",
+			Reporter:       "tester",
+			Goal:           "test goal",
+		},
+	})
+
+	resCh, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case <-resCh:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for result")
+	}
+
+	reports := recorder.snapshot()
+	if len(reports) == 0 {
+		t.Fatal("no status reports captured")
+	}
+	final := reports[len(reports)-1]
+	if final.JobStatus != queue.JobCompleted {
+		t.Errorf("final status report JobStatus=%q, want %q (otherwise app StatusListener races ResultListener and clobbers the answer)",
+			final.JobStatus, queue.JobCompleted)
+	}
+}


### PR DESCRIPTION
## Summary

- **worker race fix**: move `Store.UpdateStatus(result.Status)` ahead of the final `publishStatus`. Previously the last status report shipped with `JobStatus=running`, letting `StatusListener.maybeUpdateSlack` race `ResultListener` and clobber `AskWorkflow.post()`'s final answer with the debounced "開工啦！" + cancel-button template. Reproducer was 2026-04-29 job `20260429-041810-f0bd994e` (raw_output had legitimate marker+JSON, parser succeeded, but Slack still showed cancel button 3 min later → user cancelled).
- **image bumps**: opencode `1.4.11 → 1.14.29` (cross-minor, will surface any ConfigMap incompat — verify before rollout); claude-code (`2.1.123`) and codex (`0.125.0`) pinned via ARG instead of unpinned `npm install -g`.
- New `TestPool_FinalStatusReportCarriesTerminalJobStatus` pins the ordering so the race window can't silently re-open.

## Test plan

- [x] `go test ./pool/...` (worker)
- [x] `go test ./...` (app, shared, root)
- [ ] Build image, deploy to ai-tools, fire `@bot ask` with **prior_answer** path (the path that triggered 041810) — confirm answer shows on Slack instead of cancel template
- [ ] Same flow without prior_answer — confirm 042620-style success path still works
- [ ] Verify worker ConfigMap (`agent.build.variant`) still parses on opencode 1.14.x; if it errors with "Unrecognized key", drop the field from the ConfigMap