### PR TITLE
feat(worker): Ask multi-repo backend (refs schema, workdir, prompt, guard)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-ask-multi-repo.md
+++ b/docs/superpowers/plans/2026-04-29-ask-multi-repo.md
@@ -1,0 +1,1184 @@
+# Ask Multi-Repo Reference Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Ask workflow multi-repo reference support per spec — primary repo + N read-only ref repos, with refs cloned to an external path co-located with the primary worktree, sequential clone with partial-success, three-layer write-protection (skill prompt + output_rules injection + post-execute guard callback).
+
+**Architecture:** Two-PR delivery aligned with module ownership.
+- **PR 1 (backend, ~300 lines):** schema, prompt builder, worker prepare flow, post-execute guard. Lands without user-facing impact — produces no new behavior until PR 2 emits ref-bearing jobs.
+- **PR 2 (frontend + e2e, ~400 lines):** app workflow phases, BuildJob output_rules injection, SKILL.md update, e2e verification.
+
+**Tech Stack:** Go 1.25, three modules (`shared/`, `app/`, `worker/`), git CLI, slack-go. Test framework: stdlib `testing`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-ask-multi-repo-design.md`
+
+---
+
+## File Structure
+
+| Path | Module | PR | Responsibility |
+|---|---|---|---|
+| `shared/queue/job.go` | shared | 1 | `Job.RefRepos`, `RefRepo`, `PromptContext.RefRepos`, `PromptContext.UnavailableRefs`, `RefRepoContext` |
+| `shared/queue/job_test.go` | shared | 1 | JSON round-trip; old-job (no `RefRepos`) backwards-compat |
+| `worker/prompt/builder.go` | worker | 1 | `<ref_repos>` / `<unavailable_refs>` rendering between `<issue_context>` and `<response_language>` |
+| `worker/prompt/builder_test.go` | worker | 1 | Render presence/absence by field state |
+| `worker/pool/executor.go` | worker | 1 | `RepoProvider.PrepareAt` interface; `executeJob` ref orchestration; post-execute guard with `RefViolationCallback` |
+| `worker/pool/adapters.go` | worker | 1 | `RepoCacheAdapter.PrepareAt` impl |
+| `worker/pool/workdir.go` | worker | 1 | `RepoCloneProvider.Cleanup` extended to also rm refs root dir |
+| `worker/pool/workdir_test.go` | worker | 1 | `fakeRepoProvider.PrepareAt` + ref cleanup ordering test |
+| `worker/pool/executor_test.go` | worker | 1 | Post-execute guard callback unit test (fake `git status`) |
+| `worker/pool/pool_test.go` | worker | 1 | `mockRepo.PrepareAt` extension to satisfy interface |
+| `worker/integration/queue_redis_integration_test.go` | worker | 1 | Multi-repo Ask job e2e — primary + refs + partial-fail; cleanup invariants |
+| `worker/integration/queue_integration_test.go` | worker | 1 | `fakeRepo.PrepareAt` extension to satisfy interface |
+| `shared/metrics/metrics.go` | shared | 1 | New counter `ask_ref_write_violations_total` |
+| `app/workflow/ask.go` | app | 2 | `askState` extensions; new phases `ask_ref_decide` / `ask_ref_pick` / `ask_ref_continue` / `ask_ref_branch`; `BuildJob` ref + output_rules injection |
+| `app/workflow/ask_test.go` | app | 2 | Phase transitions; candidate filter (primary + dedup); 0-candidate skip; per-ref branch flow; output_rules injection |
+| `app/agents/skills/ask-assistant/SKILL.md` | app | 2 | Add "Reference repos" subsection in §5 with critical-fail-fast rule |
+
+---
+
+## PR 1 — Backend
+
+### Task 1: Schema additions in `shared/queue`
+
+**Files:**
+- Modify: `shared/queue/job.go`
+- Test: `shared/queue/job_test.go`
+
+**Background:**
+
+`Job` and `PromptContext` need additive fields with `omitempty` so old jobs serialize byte-for-byte unchanged. `RefRepoContext.Path` is filled by worker at runtime (post-prepare); the JSON tags exist because PromptContext is the carrier from worker-prepare to worker-build-prompt — they happen to round-trip through JSON nowhere on the wire (Job is the wire format), but the tags are kept for symmetry with other PromptContext fields and to allow optional debug serialization.
+
+**Steps:**
+
+- [ ] **1.1 Add `RefRepo` type + `Job.RefRepos` field.**
+
+In `shared/queue/job.go`, between existing `AttachmentMeta` and `ThreadMessage` (matching grouping of other request-side types):
+
+```go
+// RefRepo is a read-only reference repo attached alongside the primary repo.
+// Repo is owner/name (mirrors Job.Repo); CloneURL is the worker's clone target;
+// Branch empty = default branch.
+type RefRepo struct {
+    Repo     string `json:"repo"`
+    CloneURL string `json:"clone_url"`
+    Branch   string `json:"branch,omitempty"`
+}
+```
+
+In `Job` struct, append (omitempty):
+
+```go
+RefRepos []RefRepo `json:"ref_repos,omitempty"`
+```
+
+- [ ] **1.2 Add `RefRepoContext` type + `PromptContext.RefRepos` / `UnavailableRefs` fields.**
+
+Below `ThreadMessage`:
+
+```go
+// RefRepoContext is one ref repo as seen by the prompt builder. Path is the
+// absolute on-disk path the agent should grep/read; filled by worker after
+// PrepareAt succeeds. Empty Branch = default branch.
+type RefRepoContext struct {
+    Repo   string `json:"repo"`
+    Branch string `json:"branch,omitempty"`
+    Path   string `json:"path"`
+}
+```
+
+In `PromptContext`, append:
+
+```go
+RefRepos        []RefRepoContext `json:"ref_repos,omitempty"`
+UnavailableRefs []string         `json:"unavailable_refs,omitempty"`
+```
+
+- [ ] **1.3 Round-trip + backwards-compat tests.**
+
+In `shared/queue/job_test.go`, add:
+
+```go
+func TestJob_RefRepos_RoundTrip(t *testing.T) {
+    in := Job{
+        ID: "abc", Repo: "foo/bar", CloneURL: "https://example/foo/bar.git",
+        RefRepos: []RefRepo{
+            {Repo: "frontend/web", CloneURL: "https://example/frontend/web.git", Branch: "main"},
+            {Repo: "backend/api", CloneURL: "https://example/backend/api.git"},
+        },
+    }
+    raw, err := json.Marshal(in)
+    if err != nil { t.Fatal(err) }
+    var out Job
+    if err := json.Unmarshal(raw, &out); err != nil { t.Fatal(err) }
+    // Compare RefRepos field-by-field; full deepequal would also need other
+    // unset fields to align, which adds noise.
+    if !reflect.DeepEqual(in.RefRepos, out.RefRepos) {
+        t.Fatalf("RefRepos mismatch: in=%+v out=%+v", in.RefRepos, out.RefRepos)
+    }
+}
+
+func TestJob_OldJob_NoRefRepos_StillParses(t *testing.T) {
+    // Old job shape — no ref_repos key at all; must unmarshal cleanly with
+    // RefRepos == nil.
+    raw := []byte(`{"id":"abc","repo":"foo/bar","clone_url":"https://example/foo/bar.git"}`)
+    var out Job
+    if err := json.Unmarshal(raw, &out); err != nil { t.Fatal(err) }
+    if out.RefRepos != nil {
+        t.Fatalf("expected nil RefRepos on old-job parse, got %+v", out.RefRepos)
+    }
+}
+```
+
+Same pattern for `PromptContext.RefRepos` / `UnavailableRefs` round-trip.
+
+**Verification:**
+- [ ] `go test ./shared/queue/...` passes.
+- [ ] No diff in serialized form for any existing test job.
+
+**Estimated scope:** S (1-2 files, ~80 LOC + tests).
+
+---
+
+### Task 2: Prompt builder rendering
+
+**Files:**
+- Modify: `worker/prompt/builder.go`
+- Test: `worker/prompt/builder_test.go`
+
+**Background:**
+
+`BuildPrompt` currently renders blocks in a fixed order. Per spec §4.5, the new blocks slot after `<issue_context>` and before `<response_language>`. The `<ref_repos>` block lists each ref's repo, branch, and absolute path; `<unavailable_refs>` is a parallel block listing failed refs by `owner/name`. Both blocks render only when their corresponding slice is non-empty (mirrors `<extra_description>` / `<prior_answer>` patterns already in the function).
+
+The path attribute is rendered raw (after `xmlEscape`) — agents need the literal path to `Read` / `Grep`. Branch is omitted when empty so default-branch refs don't get an empty `branch=""` attribute.
+
+**Steps:**
+
+- [ ] **2.1 Add `<ref_repos>` rendering after `<issue_context>` close.**
+
+In `BuildPrompt`, after the `</issue_context>\n\n` write:
+
+```go
+if len(ctx.RefRepos) > 0 {
+    b.WriteString("<ref_repos>\n")
+    for _, r := range ctx.RefRepos {
+        if r.Branch != "" {
+            fmt.Fprintf(&b,
+                "  <ref repo=\"%s\" branch=\"%s\" path=\"%s\"/>\n",
+                xmlEscape(r.Repo), xmlEscape(r.Branch), xmlEscape(r.Path),
+            )
+        } else {
+            fmt.Fprintf(&b,
+                "  <ref repo=\"%s\" path=\"%s\"/>\n",
+                xmlEscape(r.Repo), xmlEscape(r.Path),
+            )
+        }
+    }
+    b.WriteString("</ref_repos>\n\n")
+}
+
+if len(ctx.UnavailableRefs) > 0 {
+    b.WriteString("<unavailable_refs>\n")
+    for _, repo := range ctx.UnavailableRefs {
+        fmt.Fprintf(&b, "  <repo>%s</repo>\n", xmlEscape(repo))
+    }
+    b.WriteString("</unavailable_refs>\n\n")
+}
+```
+
+- [ ] **2.2 Tests for both render conditions.**
+
+In `worker/prompt/builder_test.go`:
+
+```go
+func TestBuildPrompt_RefReposRendered(t *testing.T) {
+    ctx := queue.PromptContext{
+        Goal: "g", Channel: "c", Reporter: "r",
+        RefRepos: []queue.RefRepoContext{
+            {Repo: "frontend/web", Branch: "main", Path: "/tmp/refs/frontend__web"},
+            {Repo: "backend/api", Path: "/tmp/refs/backend__api"}, // default branch
+        },
+    }
+    out := BuildPrompt(ctx, nil, nil)
+    if !strings.Contains(out, `<ref repo="frontend/web" branch="main" path="/tmp/refs/frontend__web"/>`) {
+        t.Errorf("missing branch-attr ref render; got:\n%s", out)
+    }
+    if !strings.Contains(out, `<ref repo="backend/api" path="/tmp/refs/backend__api"/>`) {
+        t.Errorf("missing default-branch ref render; got:\n%s", out)
+    }
+}
+
+func TestBuildPrompt_UnavailableRefsRendered(t *testing.T) {
+    ctx := queue.PromptContext{
+        Goal: "g", Channel: "c", Reporter: "r",
+        UnavailableRefs: []string{"broken/repo"},
+    }
+    out := BuildPrompt(ctx, nil, nil)
+    if !strings.Contains(out, "<unavailable_refs>") || !strings.Contains(out, "<repo>broken/repo</repo>") {
+        t.Errorf("missing unavailable_refs render; got:\n%s", out)
+    }
+}
+
+func TestBuildPrompt_NoRefRepos_NoBlock(t *testing.T) {
+    ctx := queue.PromptContext{Goal: "g", Channel: "c", Reporter: "r"}
+    out := BuildPrompt(ctx, nil, nil)
+    if strings.Contains(out, "<ref_repos>") || strings.Contains(out, "<unavailable_refs>") {
+        t.Errorf("expected no ref blocks for empty fields; got:\n%s", out)
+    }
+}
+```
+
+**Verification:**
+- [ ] `go test ./worker/prompt/...` passes.
+- [ ] `TestBuildPrompt_*` existing tests still pass (regression).
+
+**Dependencies:** Task 1 (uses new types).
+
+**Estimated scope:** S (2 files, ~50 LOC + tests).
+
+---
+
+### Task 3: `RepoProvider.PrepareAt` interface + adapter
+
+**Files:**
+- Modify: `worker/pool/executor.go` (interface)
+- Modify: `worker/pool/adapters.go` (RepoCacheAdapter impl)
+- Test extension: `worker/pool/workdir_test.go::fakeRepoProvider`
+- Test extension: `worker/pool/pool_test.go::mockRepo`
+- Test extension: `worker/integration/queue_integration_test.go::fakeRepo`
+
+**Background:**
+
+The existing `RepoProvider.Prepare(cloneURL, branch, token) (string, error)` returns a worktree path under `RepoCache.WorktreeDir()`. For refs, the caller must specify the target path (under `<primary worktree>-refs/<owner>__<repo>/`). Adding a new method `PrepareAt(cloneURL, branch, token, targetPath string) error` keeps the existing signature untouched and avoids breaking the `Prepare` caller.
+
+`RepoCacheAdapter.PrepareAt` re-uses `EnsureRepo` for the bare clone and `AddWorktree(barePath, branch, targetPath)` for the worktree creation — same pattern as `Prepare` but with caller-supplied target. The mkdir of the parent dir is the caller's responsibility (worker creates `<primary>-refs/` once before looping refs).
+
+All three test fakes (`fakeRepoProvider` / `mockRepo` / `fakeRepo`) must implement `PrepareAt` to satisfy the interface, but their behavior is allowed to be a no-op + record-call for tests that don't exercise refs.
+
+**Steps:**
+
+- [ ] **3.1 Add `PrepareAt` to `RepoProvider` interface in `executor.go`.**
+
+```go
+type RepoProvider interface {
+    Prepare(cloneURL, branch, token string) (string, error)
+    PrepareAt(cloneURL, branch, token, targetPath string) error  // NEW
+    RemoveWorktree(worktreePath string) error
+    CleanAll() error
+    PurgeStale() error
+}
+```
+
+- [ ] **3.2 Implement on `RepoCacheAdapter` in `adapters.go`.**
+
+```go
+// PrepareAt clones into targetPath rather than the cache's default worktree dir.
+// Used for ref repos so worker can co-locate them with the primary worktree.
+func (a *RepoCacheAdapter) PrepareAt(cloneURL, branch, token, targetPath string) error {
+    barePath, err := a.Cache.EnsureRepo(cloneURL, token)
+    if err != nil {
+        return err
+    }
+    // git worktree add requires the target dir not to exist.
+    if err := os.RemoveAll(targetPath); err != nil {
+        return fmt.Errorf("clear ref target %s: %w", targetPath, err)
+    }
+    return a.Cache.AddWorktree(barePath, branch, targetPath)
+}
+```
+
+- [ ] **3.3 Extend test fakes.**
+
+In `worker/pool/workdir_test.go::fakeRepoProvider`, add:
+
+```go
+func (f *fakeRepoProvider) PrepareAt(cloneURL, branch, token, targetPath string) error {
+    f.prepareAtCalls = append(f.prepareAtCalls, fakePrepareAtCall{
+        cloneURL: cloneURL, branch: branch, target: targetPath,
+    })
+    if f.prepareAtErr != nil {
+        return f.prepareAtErr
+    }
+    // Create the target dir so caller's mkdir-then-prepare flow looks real.
+    return os.MkdirAll(targetPath, 0755)
+}
+```
+
+Same shape on `mockRepo` (in `pool_test.go`) and `fakeRepo` (in `queue_integration_test.go`); behavior should default to "succeed and create the dir" so existing tests pass without modification.
+
+**Verification:**
+- [ ] `go build ./worker/...` succeeds (interface implemented everywhere).
+- [ ] `go test ./worker/pool/...` and `go test ./worker/integration/...` pass.
+
+**Dependencies:** None (pure infrastructure).
+
+**Estimated scope:** S (5 files, ~80 LOC).
+
+---
+
+### Task 4: `executeJob` ref orchestration + cleanup
+
+**Files:**
+- Modify: `worker/pool/executor.go`
+- Modify: `worker/pool/workdir.go`
+- Test: `worker/pool/workdir_test.go`
+- Test: `worker/integration/queue_redis_integration_test.go`
+
+**Background:**
+
+After `provider.Prepare(job)` returns the primary worktree path, executeJob must:
+
+1. If `job.RefRepos` is non-empty AND `job.CloneURL != ""` (refs without a primary make no sense; defensive skip), compute refs root = `<primary path> + "-refs"` and `MkdirAll` it.
+2. Sequentially `provider.PrepareAt(ref.CloneURL, ref.Branch, token, target)` for each ref where `target = <refs root>/<owner>__<repo>` (slashes in `Repo` become `__`).
+3. Successful refs append to `[]queue.RefRepoContext` (Repo, Branch, Path) and to `successfulRefPaths []string` (for guard + cleanup).
+4. Failed refs append to `[]string` of `owner/name` form.
+5. Mutate `job.PromptContext.RefRepos = successful` and `job.PromptContext.UnavailableRefs = failed` BEFORE the `BuildPrompt` call.
+6. Cleanup ordering: ref worktrees (reversed) → refs root dir → primary (existing `provider.Cleanup`).
+
+The cleanup extension must survive primary-prepare success + ref-prepare any-state, AND not break the cancellation path (which already routes through `classifyResult` + the existing cleanup deferred chain). Cleanest implementation: add a slice `[]string` of "extra paths to remove" on `executeJob`'s local scope, defer their cleanup right after `provider.Prepare` returns success.
+
+**Steps:**
+
+- [ ] **4.1 Add helper `prepareRefs` in `worker/pool/workdir.go`.**
+
+```go
+// prepareRefs clones each ref into <primaryPath>-refs/<owner>__<repo>/ in
+// sequence. Returns successful contexts (with absolute paths), unavailable
+// refs (owner/name form), the refs-root dir to clean up, and an error only
+// if the refs-root mkdir fails (per-ref errors are collected as unavailable).
+func prepareRefs(provider RepoProvider, primaryPath, token string, refs []queue.RefRepo, logger *slog.Logger) (
+    successful []queue.RefRepoContext,
+    successfulPaths []string,
+    unavailable []string,
+    refsRoot string,
+    err error,
+) {
+    if len(refs) == 0 {
+        return nil, nil, nil, "", nil
+    }
+    refsRoot = primaryPath + "-refs"
+    if err := os.MkdirAll(refsRoot, 0755); err != nil {
+        return nil, nil, nil, "", fmt.Errorf("mkdir refs root: %w", err)
+    }
+    for _, r := range refs {
+        target := filepath.Join(refsRoot, refDirName(r.Repo))
+        if perr := provider.PrepareAt(r.CloneURL, r.Branch, token, target); perr != nil {
+            logger.Warn("ref clone failed; continuing with partial context",
+                "phase", "處理中", "ref", r.Repo, "branch", r.Branch, "error", perr)
+            unavailable = append(unavailable, r.Repo)
+            continue
+        }
+        successful = append(successful, queue.RefRepoContext{
+            Repo: r.Repo, Branch: r.Branch, Path: target,
+        })
+        successfulPaths = append(successfulPaths, target)
+    }
+    if len(refs) >= 5 {
+        logger.Info("multi-ref ask with high count", "phase", "處理中", "count", len(refs))
+    }
+    return successful, successfulPaths, unavailable, refsRoot, nil
+}
+
+// refDirName flattens owner/name → owner__name. GitHub disallows __ in repo
+// names, so collisions are impossible.
+func refDirName(repo string) string {
+    return strings.ReplaceAll(repo, "/", "__")
+}
+```
+
+- [ ] **4.2 Wire into `executeJob` after `provider.Prepare`.**
+
+```go
+// existing:
+provider := selectProvider(job, deps.repoCache, ghToken)
+repoPath, err := provider.Prepare(job)
+// ... existing prepareSeconds + isEmptyRepoReference handling ...
+
+// NEW: ref handling — only if primary is real and refs are requested.
+var refContexts []queue.RefRepoContext
+var successfulRefPaths []string
+var unavailableRefs []string
+var refsRootDir string
+if job.CloneURL != "" && len(job.RefRepos) > 0 {
+    var refErr error
+    refContexts, successfulRefPaths, unavailableRefs, refsRootDir, refErr = prepareRefs(
+        provider, repoPath, ghToken, job.RefRepos, logger,
+    )
+    if refErr != nil {
+        return classifyResult(job, startedAt, fmt.Errorf("refs prepare: %w", refErr), repoPath, ctx, deps.store)
+    }
+}
+defer cleanupRefs(provider, successfulRefPaths, refsRootDir)
+
+// existing PromptContext nil check stays here ...
+
+// NEW: mutate PromptContext fields before BuildPrompt.
+job.PromptContext.RefRepos = refContexts
+job.PromptContext.UnavailableRefs = unavailableRefs
+```
+
+- [ ] **4.3 Add `cleanupRefs` helper in `workdir.go`.**
+
+```go
+// cleanupRefs removes ref worktrees (reverse order) then the refs-root dir.
+// Best-effort: failures are logged at debug, not surfaced — primary cleanup
+// happens via provider.Cleanup regardless.
+func cleanupRefs(provider RepoProvider, paths []string, refsRoot string) {
+    for i := len(paths) - 1; i >= 0; i-- {
+        _ = provider.RemoveWorktree(paths[i])
+    }
+    if refsRoot != "" {
+        _ = os.RemoveAll(refsRoot)
+    }
+}
+```
+
+- [ ] **4.4 Unit test for `prepareRefs` with mixed success/failure.**
+
+`worker/pool/workdir_test.go`:
+
+```go
+func TestPrepareRefs_PartialSuccess(t *testing.T) {
+    primary := t.TempDir() + "/triage-repo-abc"
+    if err := os.MkdirAll(primary, 0755); err != nil { t.Fatal(err) }
+
+    fake := &fakeRepoProvider{
+        prepareAtBehavior: func(target string) error {
+            if strings.Contains(target, "broken__repo") {
+                return fmt.Errorf("simulated clone fail")
+            }
+            return os.MkdirAll(target, 0755)
+        },
+    }
+    refs := []queue.RefRepo{
+        {Repo: "frontend/web", CloneURL: "u1", Branch: "main"},
+        {Repo: "broken/repo",  CloneURL: "u2"},
+        {Repo: "backend/api",  CloneURL: "u3", Branch: "release"},
+    }
+    successful, successfulPaths, unavailable, refsRoot, err := prepareRefs(
+        fake, primary, "token", refs, slog.Default(),
+    )
+    if err != nil { t.Fatal(err) }
+    if len(successful) != 2 || len(unavailable) != 1 {
+        t.Fatalf("partial-success counts wrong: ok=%d fail=%d", len(successful), len(unavailable))
+    }
+    if unavailable[0] != "broken/repo" {
+        t.Errorf("unavailable mismatch: %v", unavailable)
+    }
+    if !strings.HasSuffix(refsRoot, "-refs") {
+        t.Errorf("refs root naming wrong: %s", refsRoot)
+    }
+    if !strings.HasSuffix(successful[0].Path, "frontend__web") {
+        t.Errorf("ref dir naming wrong: %s", successful[0].Path)
+    }
+    if len(successfulPaths) != 2 {
+        t.Errorf("successfulPaths length mismatch: %d", len(successfulPaths))
+    }
+}
+
+func TestPrepareRefs_EmptyRefs_NoOp(t *testing.T) {
+    successful, _, unavailable, refsRoot, err := prepareRefs(
+        &fakeRepoProvider{}, "/tmp/p", "t", nil, slog.Default(),
+    )
+    if err != nil || len(successful) != 0 || len(unavailable) != 0 || refsRoot != "" {
+        t.Fatalf("nil refs should no-op: ok=%v fail=%v root=%q err=%v",
+            successful, unavailable, refsRoot, err)
+    }
+}
+```
+
+- [ ] **4.5 Integration test for multi-repo Ask flow.**
+
+In `worker/integration/queue_redis_integration_test.go`, add a test that submits an Ask job with 2 refs (one valid, one with bogus CloneURL), verifies:
+- worktree directory structure (`<primary>` exists, `<primary>-refs/<repo1>__<repo2>` exists)
+- prompt receives `<ref_repos>` for the successful ref
+- prompt receives `<unavailable_refs>` for the bogus one
+- after job completes, both directories are removed (cleanup invariant)
+
+Reuse existing `fakeRepo` infrastructure; add a `prepareAtFailFor` map to the fake to selectively fail a clone URL.
+
+**Verification:**
+- [ ] `go test ./worker/pool/...` passes including new tests.
+- [ ] `go test ./worker/integration/...` passes.
+- [ ] `go test ./test/...` (import-direction test) still passes.
+- [ ] No new top-level lint warnings.
+
+**Dependencies:** Tasks 1 + 2 + 3.
+
+**Estimated scope:** M (3-4 files, ~200 LOC + ~120 LOC tests).
+
+---
+
+### Task 5: Post-execute guard with `RefViolationCallback`
+
+**Files:**
+- Modify: `worker/pool/executor.go`
+- Modify: `shared/metrics/metrics.go`
+- Test: `worker/pool/executor_test.go`
+
+**Background:**
+
+After `runner.Run` returns, walk each successful ref worktree and run `git status --porcelain`. Non-empty output = agent wrote into the ref. The callback receives the violation; Ask installs a lenient callback that increments a metric and warn-logs. Issue (#217) will install a strict callback that fails the job — keep the abstraction clean enough that #217 only swaps the callback.
+
+The metric is a counter labeled by the ref `repo` for ops visibility. No alert rule is added in this PR — that's an SRE follow-up after the metric has data.
+
+**Steps:**
+
+- [ ] **5.1 Define callback type + lenient impl in `executor.go`.**
+
+```go
+// RefViolationCallback is invoked when post-execute guard finds modifications
+// in a ref worktree. Ask installs a lenient impl (warn + metric); Issue (#217)
+// will install a strict impl that fails the job.
+type RefViolationCallback func(refContext queue.RefRepoContext, diffPreview string, logger *slog.Logger)
+
+// askLenientRefViolation is the Ask-workflow callback: warn-log + metric, no
+// job-fail. Worktree cleanup happens regardless, so writes have no persistent
+// effect — the guard is observability, not enforcement.
+func askLenientRefViolation(ref queue.RefRepoContext, diff string, logger *slog.Logger) {
+    logger.Warn("agent wrote into ref repo (lenient: not failing job)",
+        "phase", "處理中",
+        "ref", ref.Repo,
+        "diff_preview", truncateDiff(diff),
+    )
+    metrics.AskRefWriteViolationsTotal.WithLabelValues(ref.Repo).Inc()
+}
+
+func truncateDiff(s string) string {
+    s = strings.TrimSpace(s)
+    if len(s) > 200 {
+        return s[:200] + "…(truncated)"
+    }
+    return s
+}
+```
+
+- [ ] **5.2 Add `runRefGuard` helper that runs `git status --porcelain` per ref.**
+
+```go
+// runRefGuard walks successful ref contexts, runs `git status --porcelain` in
+// each, invokes onViolation when the output is non-empty.
+func runRefGuard(refs []queue.RefRepoContext, onViolation RefViolationCallback, logger *slog.Logger) {
+    if onViolation == nil {
+        return
+    }
+    for _, ref := range refs {
+        out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
+        if err != nil {
+            // git missing or worktree corrupt is operationally noisy; skip rather
+            // than escalate — guard is best-effort observability.
+            logger.Debug("ref guard: git status failed; skipping",
+                "phase", "處理中", "ref", ref.Repo, "error", err)
+            continue
+        }
+        if diff := strings.TrimSpace(string(out)); diff != "" {
+            onViolation(ref, diff, logger)
+        }
+    }
+}
+```
+
+- [ ] **5.3 Wire `runRefGuard` into `executeJob` after `runner.Run`.**
+
+```go
+// existing:
+output, err := deps.runner.Run(ctx, repoPath, promptXML, opts)
+if err != nil { ... }
+
+// NEW: only when refs were prepared, and only on the success path (failures
+// route through classifyResult earlier; running guard after a failed agent
+// run is noise).
+runRefGuard(refContexts, askLenientRefViolation, logger)
+```
+
+(Note: when #217 lands, the callback selection will move into a per-task-type lookup; for now Ask is the only consumer so hardcoding is OK.)
+
+- [ ] **5.4 Add metric registration in `shared/metrics/metrics.go`.**
+
+```go
+AskRefWriteViolationsTotal = prometheus.NewCounterVec(
+    prometheus.CounterOpts{
+        Name: "ask_ref_write_violations_total",
+        Help: "Number of times an Ask-workflow agent wrote into a ref repo (lenient: violation does not fail the job).",
+    },
+    []string{"repo"},
+)
+```
+
+Register in the `init()` block alongside the other counters.
+
+- [ ] **5.5 Unit test guard with stubbed worktree state.**
+
+`worker/pool/executor_test.go`:
+
+```go
+func TestRunRefGuard_DetectsViolation(t *testing.T) {
+    // Create a real git worktree, modify a tracked file, expect callback fired.
+    dir := t.TempDir()
+    run(t, dir, "git", "init")
+    run(t, dir, "git", "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+        "--allow-empty", "-m", "init")
+    if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0644); err != nil {
+        t.Fatal(err)
+    }
+
+    var fired []string
+    cb := func(ref queue.RefRepoContext, diff string, logger *slog.Logger) {
+        fired = append(fired, ref.Repo)
+    }
+    runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+    if len(fired) != 1 || fired[0] != "foo/bar" {
+        t.Fatalf("expected violation fired for foo/bar; got %v", fired)
+    }
+}
+
+func TestRunRefGuard_CleanWorktree_NoCallback(t *testing.T) {
+    dir := t.TempDir()
+    run(t, dir, "git", "init")
+    run(t, dir, "git", "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+        "--allow-empty", "-m", "init")
+
+    var fired int
+    cb := func(_ queue.RefRepoContext, _ string, _ *slog.Logger) { fired++ }
+    runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+    if fired != 0 {
+        t.Fatalf("clean worktree should not fire callback, fired=%d", fired)
+    }
+}
+```
+
+(`run` helper exists in `shared/github/repo_test.go`; if not importable here, copy the 6-line helper into `executor_test.go`.)
+
+**Verification:**
+- [ ] `go test ./worker/pool/...` passes.
+- [ ] `go test ./shared/metrics/...` passes (metric registration smoke).
+- [ ] Counter visible at `:metrics-port/metrics` after a manual ask with refs.
+
+**Dependencies:** Task 4 (refs already prepared by the time guard runs).
+
+**Estimated scope:** S (3 files, ~80 LOC + ~40 LOC tests).
+
+---
+
+### Checkpoint: PR 1 ready
+
+- [ ] All `shared/queue/`, `worker/prompt/`, `worker/pool/`, `worker/integration/`, `shared/metrics/` tests pass.
+- [ ] `go build ./...` clean.
+- [ ] `go test ./test/...` (import-direction) still passes.
+- [ ] Old jobs (no `RefRepos` field) parse and execute byte-for-byte unchanged — verified by Task 1.3 backwards-compat test + an integration run with a no-ref Ask.
+- [ ] PR description includes a manual log capture from a single-ref + multi-ref worker run showing the new prepare/guard flow logs.
+- [ ] Open PR titled `feat(worker): Ask multi-repo backend (refs schema, workdir, prompt, guard)` referencing `#216`.
+- [ ] **Wait for CI green + user review before merging** (per memory: PR merge authorization).
+
+---
+
+## PR 2 — Frontend + e2e
+
+### Task 6: `askState` extensions + `BranchTargetRepo` plumbing
+
+**Files:**
+- Modify: `app/workflow/ask.go`
+- Test: `app/workflow/ask_test.go`
+
+**Background:**
+
+`askState` gains four fields per spec §4.4. `BranchSelectedRepo()` switches from reading `SelectedRepo` to reading `BranchTargetRepo`; the workflow is responsible for setting `BranchTargetRepo` before each branch-select phase (primary OR ref). This keeps `BranchStateReader` interface untouched and `HandleBranchSuggestion` (in app/bot) ignorant of refs.
+
+**Steps:**
+
+- [ ] **6.1 Extend `askState` struct.**
+
+```go
+type askState struct {
+    // ...existing fields unchanged...
+
+    AddRefs          bool
+    RefRepos         []queue.RefRepo // accumulated as user picks; Branch filled later
+    RefBranchIdx     int             // current ref index during ask_ref_branch loop
+    BranchTargetRepo string          // set before each branch select phase
+}
+```
+
+- [ ] **6.2 Update `BranchSelectedRepo` to read `BranchTargetRepo`.**
+
+```go
+func (s *askState) BranchSelectedRepo() string {
+    if s == nil {
+        return ""
+    }
+    return s.BranchTargetRepo
+}
+```
+
+- [ ] **6.3 Set `BranchTargetRepo = SelectedRepo` when entering primary branch select.**
+
+In `afterRepoSelectedStep` (line ~287), at the point before returning the `ask_branch_select` NextStep:
+
+```go
+st.BranchTargetRepo = st.SelectedRepo
+p.Phase = "ask_branch_select"
+```
+
+This preserves existing behavior: primary branch selection still works exactly as today.
+
+- [ ] **6.4 Test: existing `BranchSelectedRepo` callers see the expected value.**
+
+In `app/workflow/ask_test.go`, add:
+
+```go
+func TestAskState_BranchSelectedRepo_PrimaryPhase(t *testing.T) {
+    st := &askState{SelectedRepo: "foo/bar", BranchTargetRepo: "foo/bar"}
+    if got := st.BranchSelectedRepo(); got != "foo/bar" {
+        t.Errorf("primary phase: expected foo/bar, got %s", got)
+    }
+}
+
+func TestAskState_BranchSelectedRepo_RefPhase(t *testing.T) {
+    st := &askState{
+        SelectedRepo:     "foo/bar",
+        BranchTargetRepo: "frontend/web",
+        RefRepos:         []queue.RefRepo{{Repo: "frontend/web"}},
+    }
+    if got := st.BranchSelectedRepo(); got != "frontend/web" {
+        t.Errorf("ref phase: expected frontend/web, got %s", got)
+    }
+}
+```
+
+**Verification:**
+- [ ] `go test ./app/workflow/...` passes.
+- [ ] No existing test fails (regression).
+
+**Dependencies:** Task 1 (uses `queue.RefRepo`).
+
+**Estimated scope:** S (2 files, ~30 LOC + tests).
+
+---
+
+### Task 7: New phases — `ask_ref_decide` / `ask_ref_pick` / `ask_ref_continue` / `ask_ref_branch`
+
+**Files:**
+- Modify: `app/workflow/ask.go`
+- Test: `app/workflow/ask_test.go`
+
+**Background:**
+
+Four new phases form the ref loop. All of them re-use the existing selector-message ts via `chat.update` so the thread doesn't accumulate rows. `ask_ref_continue` is the loop pivot — user picks "再加一個" → back to `ask_ref_pick`; "開始問問題" → into `ask_ref_branch` (which itself loops over `RefRepos` until idx exhausts, then drops into the existing prior-answer/description flow).
+
+**Pre-check: 0-candidate skip.** Before posting `ask_ref_decide`, evaluate the candidate pool (channel repos minus primary minus already-picked refs). If empty, skip the entire ref flow and route directly to `priorAnswerOrDescriptionStep`.
+
+**Candidate filtering:** for each `ask_ref_pick` invocation, the option list is `(channelRepos OR external_select) − {primary} − {already-picked refs}`. dedup is by `Repo` field (one repo, one ref — spec §4.7).
+
+**Per-ref branch:** mirrors primary's `afterRepoSelectedStep` rules: `branch_select` off → skip; ≤ 1 branch → use that one; else → external_select with type-ahead. Each ref makes the decision independently.
+
+**Steps:**
+
+- [ ] **7.1 Insert ref decision step after primary branch select / skip.**
+
+`Selection` cases for `ask_repo_select` (skip-attach branch) and `ask_branch_select` currently hand off to `priorAnswerOrDescriptionStep`. Inject a new wrapper `maybeAskRefStep(p)` that:
+
+1. If `len(refCandidates(p)) == 0` → call `priorAnswerOrDescriptionStep(p)` (existing path).
+2. Else → set `p.Phase = "ask_ref_decide"`, return the decide selector.
+
+Replace `return w.priorAnswerOrDescriptionStep(p), nil` in those two cases with `return w.maybeAskRefStep(p), nil`.
+
+- [ ] **7.2 Implement `refCandidates` helper.**
+
+```go
+// refCandidates returns the channel-allowed repo list minus primary and
+// already-picked refs. Returns nil when the channel uses external search
+// (caller must dispatch to type-ahead pickup instead of static list).
+func (w *AskWorkflow) refCandidates(p *Pending) (list []string, useExternalSearch bool) {
+    st, _ := p.State.(*askState)
+    cc := w.cfg.ChannelDefaults
+    if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+        cc = c
+    }
+    repos := cc.GetRepos()
+    if len(repos) == 0 {
+        return nil, true // external search will run; primary still excluded by suggestion handler
+    }
+    picked := make(map[string]bool, len(st.RefRepos))
+    for _, r := range st.RefRepos {
+        picked[r.Repo] = true
+    }
+    for _, r := range repos {
+        if r == st.SelectedRepo || picked[r] {
+            continue
+        }
+        list = append(list, r)
+    }
+    return list, false
+}
+```
+
+- [ ] **7.3 `ask_ref_decide` selector.**
+
+```go
+func (w *AskWorkflow) refDecideStep(p *Pending) NextStep {
+    return NextStep{
+        Kind: NextStepSelector,
+        Selector: &SelectorSpec{
+            Prompt:   ":books: 加入參考 repo 嗎？(唯讀脈絡)",
+            ActionID: "ask_ref_decide",
+            Options: []SelectorOption{
+                {Label: "加入", Value: "add"},
+                {Label: "不用", Value: "skip"},
+            },
+        },
+        Pending: p,
+    }
+}
+```
+
+In `Selection`, add `case "ask_ref_decide":`:
+- `value == "skip"` → `priorAnswerOrDescriptionStep`
+- `value == "add"` → `st.AddRefs = true`; transition to `ask_ref_pick`.
+
+- [ ] **7.4 `ask_ref_pick` selector (single-select with current candidates, OR external search).**
+
+```go
+func (w *AskWorkflow) refPickStep(p *Pending) NextStep {
+    list, externalSearch := w.refCandidates(p)
+    p.Phase = "ask_ref_pick"
+    if externalSearch {
+        return NextStep{
+            Kind: NextStepSelector,
+            Selector: &SelectorSpec{
+                Prompt:         ":point_right: 選參考 repo:",
+                ActionID:       "ask_ref",
+                Searchable:     true,
+                Placeholder:    "Type to search repos...",
+                CancelActionID: "ask_ref_cancel",
+                CancelLabel:    "← 返回 (不加 ref)",
+            },
+            Pending: p,
+        }
+    }
+    options := make([]SelectorOption, 0, len(list)+1)
+    for _, r := range list {
+        options = append(options, SelectorOption{Label: r, Value: r})
+    }
+    options = append(options, SelectorOption{Label: "← 返回 (不加 ref)", Value: "back_to_decide"})
+    return NextStep{
+        Kind: NextStepSelector,
+        Selector: &SelectorSpec{
+            Prompt:   ":point_right: 選參考 repo:",
+            ActionID: "ask_ref",
+            Options:  options,
+        },
+        Pending: p,
+    }
+}
+```
+
+`Selection` case `ask_ref_pick`:
+- `value == "back_to_decide"` or `value == "ask_ref_cancel"` → reset `st.AddRefs = false`, route to `priorAnswerOrDescriptionStep`.
+- otherwise → append `queue.RefRepo{Repo: value, CloneURL: cleanCloneURL(value)}` to `st.RefRepos`; transition to `ask_ref_continue`.
+
+- [ ] **7.5 `ask_ref_continue` selector.**
+
+```go
+func (w *AskWorkflow) refContinueStep(p *Pending) NextStep {
+    p.Phase = "ask_ref_continue"
+    list, externalSearch := w.refCandidates(p)
+    options := []SelectorOption{
+        {Label: "開始問問題", Value: "done"},
+    }
+    if len(list) > 0 || externalSearch {
+        options = append([]SelectorOption{{Label: "再加一個 ref", Value: "more"}}, options...)
+    }
+    return NextStep{
+        Kind: NextStepSelector,
+        Selector: &SelectorSpec{
+            Prompt:   fmt.Sprintf(":heavy_plus_sign: 已加 %d 個 ref。", len(p.State.(*askState).RefRepos)),
+            ActionID: "ask_ref_continue",
+            Options:  options,
+        },
+        Pending: p,
+    }
+}
+```
+
+`Selection` case `ask_ref_continue`:
+- `value == "more"` → `refPickStep`.
+- `value == "done"` → start ref-branch loop: `st.RefBranchIdx = 0`, call `nextRefBranchStep(p)`.
+
+- [ ] **7.6 `ask_ref_branch` per-ref loop.**
+
+```go
+func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
+    st := p.State.(*askState)
+    if st.RefBranchIdx >= len(st.RefRepos) {
+        return w.priorAnswerOrDescriptionStep(p)
+    }
+    target := st.RefRepos[st.RefBranchIdx].Repo
+
+    // Mirror primary branch-select skip rules.
+    cc := w.cfg.ChannelDefaults
+    if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+        cc = c
+    }
+    if !cc.IsBranchSelectEnabled() {
+        // No branch select for any ref — leave Branch empty, advance.
+        st.RefBranchIdx++
+        return w.nextRefBranchStep(p)
+    }
+
+    var branches []string
+    if len(cc.Branches) > 0 {
+        branches = cc.Branches
+    } else if w.repoCache != nil {
+        ghToken := ""
+        if w.cfg.Secrets != nil {
+            ghToken = w.cfg.Secrets["GH_TOKEN"]
+        }
+        if rp, err := w.repoCache.EnsureRepo(target, ghToken); err == nil {
+            if lb, lerr := w.repoCache.ListBranches(rp); lerr == nil {
+                branches = lb
+            }
+        }
+    }
+    if len(branches) <= 1 {
+        if len(branches) == 1 {
+            st.RefRepos[st.RefBranchIdx].Branch = branches[0]
+        }
+        st.RefBranchIdx++
+        return w.nextRefBranchStep(p)
+    }
+
+    st.BranchTargetRepo = target
+    p.Phase = "ask_ref_branch"
+    options := make([]SelectorOption, 0, len(branches)+1)
+    for _, b := range branches {
+        options = append(options, SelectorOption{Label: b, Value: b})
+    }
+    options = append(options, SelectorOption{Label: "取消", Value: "取消"})
+    return NextStep{
+        Kind: NextStepSelector,
+        Selector: &SelectorSpec{
+            Prompt:   fmt.Sprintf(":point_right: 選 `%s` 的 branch?", target),
+            ActionID: "ask_ref_branch",
+            Options:  options,
+        },
+        Pending: p,
+    }
+}
+```
+
+`Selection` case `ask_ref_branch`:
+- `value == "取消"` → `NextStepCancel`.
+- otherwise → `st.RefRepos[st.RefBranchIdx].Branch = value`; `st.RefBranchIdx++`; recurse `nextRefBranchStep(p)`.
+
+- [ ] **7.7 Tests for new phases.**
+
+`app/workflow/ask_test.go`:
+
+```go
+func TestAsk_RefDecide_AddPath(t *testing.T) { ... select "add" → next phase = ask_ref_pick }
+func TestAsk_RefDecide_SkipPath(t *testing.T) { ... select "skip" → no RefRepos in BuildJob output }
+func TestAsk_RefPick_DedupPrimary(t *testing.T) { ... primary "foo/bar" excluded from candidate list }
+func TestAsk_RefPick_DedupAlreadyPicked(t *testing.T) { ... can't pick same ref twice }
+func TestAsk_RefContinue_NoMoreCandidates(t *testing.T) { ... only "開始問問題" appears }
+func TestAsk_RefBranch_SkipsWhenBranchSelectDisabled(t *testing.T)
+func TestAsk_RefBranch_PerRefIndependent(t *testing.T) { ... ref1 has 2 branches → picker; ref2 has 1 → skip }
+func TestAsk_RefDecide_ZeroCandidates_PhaseSkipped(t *testing.T) { ... channel has only 1 repo == primary → maybeAskRefStep routes straight to description prompt }
+```
+
+(Each test sets up an askWorkflow with a fixture config + invokes Selection with the expected sequence; assert phase progression and final state.)
+
+**Verification:**
+- [ ] `go test ./app/workflow/...` passes including new tests.
+- [ ] `go test ./...` (full suite) clean.
+
+**Dependencies:** Task 6.
+
+**Estimated scope:** L (1 file + 1 test file, ~250 LOC + ~250 LOC tests). **Justification for L (not split further):** the four new phases form one indivisible state machine — splitting them across tasks creates dead-code intermediate states.
+
+---
+
+### Task 8: `BuildJob` ref + `output_rules` injection
+
+**Files:**
+- Modify: `app/workflow/ask.go`
+- Test: `app/workflow/ask_test.go`
+
+**Background:**
+
+`BuildJob` populates `Job.RefRepos` from `st.RefRepos` and conditionally appends two output rules to `PromptContext.OutputRules` when refs are non-empty. The two rules correspond to spec §4.6 Layer 2: read-only enforcement + critical-fail-fast directive.
+
+The CloneURL on each ref is set during `ask_ref_pick` via `cleanCloneURL`; here it just flows through.
+
+**Steps:**
+
+- [ ] **8.1 Populate `Job.RefRepos` in `BuildJob`.**
+
+After the existing `cloneURL` derivation for primary:
+
+```go
+// Pass through ref repos as captured during the ref loop.
+job.RefRepos = st.RefRepos // nil-safe: zero-len slice marshals as empty/omitted
+```
+
+- [ ] **8.2 Conditionally inject `output_rules`.**
+
+```go
+outputRules := w.cfg.Workflows.Ask.Prompt.OutputRules
+if len(st.RefRepos) > 0 {
+    outputRules = append(outputRules,
+        "不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。",
+        "若 <unavailable_refs> 含關鍵 ref，必須在答案開頭聲明「無法取得 X repo 脈絡，無法回答」並停手；不要 best-effort 拼湊。",
+    )
+}
+// then wire outputRules into PromptContext below.
+```
+
+- [ ] **8.3 Tests.**
+
+```go
+func TestBuildJob_NoRefs_NoOutputRulesInjection(t *testing.T) {
+    // primary only — output_rules length == config-defined length
+}
+func TestBuildJob_WithRefs_TwoRulesAppended(t *testing.T) {
+    // RefRepos non-empty → output_rules len == config-defined + 2
+    // verify exact wording on the two appended rules
+}
+func TestBuildJob_RefRepos_Pasthrough(t *testing.T) {
+    // Job.RefRepos === st.RefRepos
+}
+```
+
+**Verification:**
+- [ ] `go test ./app/workflow/...` passes.
+
+**Dependencies:** Tasks 6 + 7.
+
+**Estimated scope:** S (2 files, ~25 LOC + ~50 LOC tests).
+
+---
+
+### Task 9: SKILL.md update
+
+**Files:**
+- Modify: `app/agents/skills/ask-assistant/SKILL.md`
+
+**Background:**
+
+Add a "Reference repos" subsection to §5 (Action boundaries). Includes the critical-fail-fast directive that mirrors the second injected output_rule.
+
+**Steps:**
+
+- [ ] **9.1 Insert subsection in §5.**
+
+After the existing "**Read-only on the repo**" / "**No ticketing, no reviewing**" / etc. groupings, before "These rules apply even when..." trailer, add:
+
+```markdown
+**Reference repos (absolute paths in `<ref_repos>`)**
+
+If the prompt has a `<ref_repos>` block, those directories are mounted at the
+absolute paths listed for read-only context. Rules:
+
+- You CAN: grep, read, follow imports, run `git log --oneline` in them.
+- You CANNOT: write, commit, edit, mv, rm any file under those paths.
+- Refs are physically OUTSIDE your cwd; use the absolute paths exactly as
+  listed in `<ref_repos>`. Don't try to compute relative paths from cwd.
+
+If `<unavailable_refs>` lists a repo:
+
+- If the unavailable ref is **critical** to answering this question
+  (i.e., the question fundamentally requires that repo's code), you must
+  state plainly at the answer's opening: "無法取得 X repo 脈絡，這題我答不了 — 請確認 PAT 對該 repo 有讀權後重 trigger"
+  and stop. Do not best-effort patchwork an answer from the available refs.
+- If the unavailable ref is non-critical, mention it in the answer
+  ("以下回答僅基於 Y 與 Z，X repo 無法取得") and continue.
+```
+
+**Verification:**
+- [ ] Markdown renders correctly (manual check).
+- [ ] No skill-loader test breakage.
+
+**Dependencies:** None (pure docs change, can land independently — but bundles with PR 2 for atomicity).
+
+**Estimated scope:** XS (1 file, ~30 lines).
+
+---
+
+### Task 10: e2e Slack walk-through + AC verification
+
+**Files:**
+- Update PR 2 description with screenshots / log captures
+- Possibly minor test additions if e2e surfaces gaps
+
+**Background:**
+
+Manual verification against AC-1 to AC-14. Particularly important is AC-5 (chat.update message-row count), which can only be confirmed by visual inspection of a real Slack thread.
+
+**Steps:**
+
+- [ ] **10.1 Configure a test channel with 3 repos.**
+
+Pick three small repos the test PAT has access to. Update channel config locally.
+
+- [ ] **10.2 Run three flows: 0-ref, 1-ref, 3-ref.**
+
+For each:
+- Trigger with `@bot ask`.
+- Walk through phases.
+- Capture a screenshot when the ask completes.
+- Count permanent message rows (not counting attachments / replies).
+
+- [ ] **10.3 Force ref clone failure.**
+
+Add a ref with a bogus clone URL (e.g., a private repo the PAT can't see). Verify:
+- Job completes.
+- Answer mentions "無法取得 X repo 脈絡".
+- Worker log shows ref-failure warn.
+
+- [ ] **10.4 Force write violation.**
+
+Use a primary + 1 ref. In the ask, explicitly instruct the agent: "Write `test` to `<ref absolute path>/foo.txt`". Verify:
+- Worker log shows `agent wrote into ref repo (lenient...)`.
+- `ask_ref_write_violations_total{repo="..."} > 0`.
+- User still receives an answer.
+
+- [ ] **10.5 0-candidate skip.**
+
+Configure a channel with only 1 repo. Run `@bot ask` and pick that repo as primary. Verify the thread does NOT contain the "加入參考 repo？" message.
+
+- [ ] **10.6 Document AC results in PR description.**
+
+Map screenshot / log evidence to each AC. AC-1 through AC-14.
+
+**Verification:**
+- [ ] All 14 ACs evidenced in PR description.
+- [ ] No regression in single-repo Ask (compare against pre-PR baseline screenshot).
+
+**Dependencies:** Tasks 6 + 7 + 8 + 9 (the full feature must be deployed to test channel).
+
+**Estimated scope:** M (no code change ideally; ~1-2 hours of manual e2e + writing).
+
+---
+
+### Checkpoint: PR 2 ready
+
+- [ ] All ACs (AC-1 to AC-14) evidenced in PR description.
+- [ ] `go test ./...` clean.
+- [ ] Manual e2e showing N=3 ref scenario produces ≤ 2 new permanent rows in Slack thread.
+- [ ] SKILL.md change visible to agents (verified by inspecting prompt logs from a test run).
+- [ ] PR description titled `feat(workflow/ask): multi-repo support (frontend + e2e)` referencing `#216`.
+- [ ] **Wait for CI green + user review before merging.**
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `multi_static_select` reconsideration after seeing real UX (could push back to spec) | Med | Spec §1 explicitly closed this; if e2e screenshots reveal sequential UX is too clicky, redirect rather than retro-fitting. Keep the door open: §10 leaves room for v2 modal. |
+| Sequential ref clone hits `prepare_timeout` at N ≥ 5 in production | Med | Spec §8 assumption; metric `worker_prepare_seconds` watched. If it bites, refactor `RepoCache.EnsureRepo` to per-repo lock — separate scope, not blocking this PR. |
+| Agent CLIs interpret absolute paths inconsistently across `claude` / `opencode` / `codex` / `gemini` | Low | All four use absolute path natively in their `Read`/`read_file`/equivalent tools. Manual e2e covers `claude` (default agent); other CLIs verified later via the same prompt schema (no per-agent code path). |
+| `RemoveAll` on refs root races a still-running git process inside a ref worktree | Low | Worker only calls cleanup after `runner.Run` returns; agents don't fork persistent git processes. If observed, add a 100ms grace before `RemoveAll`. |
+
+## Open Questions
+
+None — all resolved during spec grilling (Q1-Q14). Re-open only on production data.

--- a/docs/superpowers/specs/2026-04-29-ask-multi-repo-design.md
+++ b/docs/superpowers/specs/2026-04-29-ask-multi-repo-design.md
@@ -1,0 +1,423 @@
+# Ask Workflow: Multi-Repo Reference Support (1 Primary + N Refs)
+
+**Date:** 2026-04-29
+**Status:** Design ratified, ready for impl
+**Issue:** #216 (Ask scope)
+**Parent:** #215 (umbrella, 1 primary + N refs model)
+**Sibling, deferred:** #217 (Issue scope — depends on this; Ask post-execute guard 抽成 callback 預留 #217 用 strict 策略)
+
+---
+
+## 1. Premise Check (與 #215 的差異點)
+
+接受 #215 的核心：1 primary + N refs，寫權限只給 primary，job schema 加法式擴充，Ask 先做、Issue 後做。
+
+**對 #215 / #216 提案的兩處關鍵反轉，已在設計討論中收斂：**
+
+1. **refs 移出 primary cwd**（推翻 #215「`.refs/<owner>__<repo>/` 在 cwd 之內」）。改成獨立外部路徑、prompt 帶絕對路徑告知 agent。理由：
+   - `.claude/skills` 自動發現本來就只服務 primary，refs 不需要。
+   - 完全規避 primary `.gitignore` 對 ref grep 的污染風險（#215 自己標 TBD 的那條），不必開 spike。
+   - cleanup / 後置 guard 邏輯不必在巢狀樹上 walk。
+2. **Slack ref 多選改為「序列 single-select」**（推翻 #216「`multi_static_select` + 完成按鈕」）。理由：
+   - Slack message 上的 `multi_static_select` 沒有 atomic submit，要靠伺服端累積 selection state，脆弱。
+   - 序列 single-select 100% 重用既有 `PostSmartSelector` 路徑，零新 Slack adapter code。
+   - chat.update 重用同一條 selector message，AC「ref 流程在 thread 永久新增訊息行數 ≤ 2」一樣達標。
+
+**Read-only 強度升格為三層防線**：SKILL.md（軟引導）→ `output_rules` 動態注入（硬約束）→ worker post-execute guard（觀察用，可注入策略給 #217 改 strict）。理由：本 case 是「同一 prompt 內的硬規則」，不能只依賴 SKILL.md 軟引導（user memory「Skill vs output_rules 強度差」）。
+
+## 2. Problem
+
+當前 Ask workflow 只能掛單一 repo。跨 repo 問題（典型：前端報錯 + 後端 schema 變動）只能挑一邊問，agent 看不到對面 codebase 就只能猜。
+
+## 3. Goals / Non-Goals
+
+### Goals
+
+1. Ask 可以在 primary repo 之外掛 N 個 ref repo 作為唯讀脈絡。
+2. Worker 在 prepare 階段把 refs sequential 解到外部路徑（與 primary worktree 同層、配對命名），agent 透過 prompt 拿到絕對路徑。
+3. Slack thread 不會因為 ref UX 爆訊息行數（N 個 ref 永久新增訊息 ≤ 2 條，靠 chat.update 同一條 selector message 改寫）。
+4. 不掛 ref 時行為與現在一致（regression-free）。
+5. ref clone 失敗不阻塞 primary（partial success；prompt 帶 `<unavailable_refs>` 通知 agent；agent 必要時自我聲明「資訊不足、無法回答」）。
+6. 多層防線阻擋 agent 寫入 ref：SKILL.md → `output_rules` 硬約束 → worker post-execute guard（callback 形式，本 spec 用 lenient 策略，#217 換 strict）。
+
+### Non-Goals (本 spec 不做)
+
+- Issue workflow 多 repo（→ #217）
+- PR Review 多 repo（明確砍掉）
+- ref repo 數量硬上限（N ≥ 5 info-log，無強制 cap）
+- ref 的 cache 共享優化（先量再決定）
+- 同 repo 不同 branch 同時當 ref（禁止；要比 branch 在 primary 內 `git diff`）
+- 多選 widget（`multi_static_select` / modal） — 改序列 single-select
+- per-ref token / 獨立 auth 範疇 — 沿用 worker 級 `GH_TOKEN`，治理仍 channel-level
+
+## 4. Design
+
+### 4.1 Job Schema (`shared/queue/job.go`)
+
+加法式擴充：
+
+```go
+type Job struct {
+    // ...existing fields unchanged...
+    RefRepos []RefRepo `json:"ref_repos,omitempty"`
+}
+
+// RefRepo 是 primary 之外的唯讀脈絡 repo。Repo 為 owner/name 形式（與 Job.Repo 對齊），
+// CloneURL 是 worker 用的 https URL，Branch 是要 checkout 的 branch（空字串 = 預設 branch）。
+type RefRepo struct {
+    Repo     string `json:"repo"`
+    CloneURL string `json:"clone_url"`
+    Branch   string `json:"branch,omitempty"`
+}
+```
+
+`omitempty` 確保舊 job 序列化形狀不變。worker 收到 `RefRepos == nil` 或 `len == 0` 走原路徑。
+
+`PromptContext` 同步擴充（見 §4.5）。
+
+### 4.2 Workdir Layout (`worker/pool/`)
+
+**refs 不在 primary cwd 內。** 與 primary worktree 同層、配對命名：
+
+```
+<repo_cache.dir>/worktrees/
+  ├── triage-repo-abc123/                ← primary worktree (cwd, 不變)
+  │    ├── .git/                         ← primary 的 worktree git ref
+  │    ├── .claude/, CLAUDE.md, ...
+  │    └── <primary repo files>
+  └── triage-repo-abc123-refs/           ← refs root (NEW)
+       ├── frontend__web/                ← ref 1
+       │    ├── .git/                    ← 自己的 worktree git ref
+       │    └── ...
+       └── backend__api/                 ← ref 2
+            ├── .git/
+            └── ...
+```
+
+命名規則：refs root path = primary worktree path + `-refs` 後綴。  
+ref 子目錄 = `<owner>__<repo>`（slash → 雙底線；GitHub repo 名稱不允許底線連續，碰撞風險為 0）。
+
+**為什麼這個 layout：**
+
+- **同根目錄治理**：refs root 也在 `<repo_cache.dir>/worktrees/` 下，既有 `RepoCache.PurgeStale` / `agentdock worker --clean-cache` 自動覆蓋。
+- **debug 友善**：殘留 directory 看路徑就知道是哪個 job 的 ref（同前綴）。
+- **物理隔離 grep 風險**：primary 的 `.gitignore` 不會傳到外部 path，agent CLI / ripgrep 行為與單獨對 ref 跑時一致。
+- **cleanup 邏輯對稱**：refs root 整個 `os.RemoveAll`，每個 ref 獨立 worktree 也可走 `RepoProvider.RemoveWorktree` 個別清。
+
+### 4.3 Worker Prepare Flow
+
+`executeJob` 在 primary 解開後（不變）依序：
+
+1. 計算 refs root path = primary worktree path + `-refs`，`MkdirAll` 建立。
+2. 對 `job.RefRepos` 中**每一個 ref，sequential**：
+   - 解到 `<refs root>/<owner>__<repo>/`。
+   - 失敗（auth / 404 / branch 不存在 / 網路 timeout / git 任何錯）→ 收集成 `unavailableRefs []string`，繼續下一個（partial success）。
+3. 把成功 prepare 的 ref 列表（`[]RefRepoContext`）與 `unavailableRefs` 一起塞進 `PromptContext`（§4.5）給 prompt builder。
+4. 跑 agent。
+5. **post-execute guard（callback 形式）**：對每個成功掛上的 ref worktree 跑 `git status --porcelain`，違規透過注入的 `OnViolation` callback 處理。本 spec（Ask）的 callback 只升 metric + warn log，不 fail job（lenient）；#217（Issue）會注入 strict callback。
+6. **Cleanup**（reversed order）：先 ref worktrees（`RemoveWorktree`），再 refs root 目錄（`os.RemoveAll`），最後 primary worktree（`provider.Cleanup`）。
+
+#### Sequential 不平行的原因
+
+`RepoCache.EnsureRepo` 有 single global `sync.Mutex`，平行呼叫會在 lock 上排隊，wall-clock 完全沒改善。要平行得先 refactor 成 per-repo lock — 不在本 spec 範圍。
+
+#### prepare_timeout
+
+預設 3min 不動。冷快取單 repo ~10-30s、熱快取 < 5s；N=5 全冷最壞 ~150s 仍在 budget 內。觀察 metric `worker_prepare_seconds` 一段時間，若 N ≥ 5 的 job 平均逼近 80% 上限再回頭加。
+
+#### Cancellation 行為
+
+ctx 中斷期間，`executeJob` 走既有 `classifyResult` → `cancelledResult` 路徑。cleanup 由 `provider.Cleanup` 負責 —  refs root 也是 worktree base 下的目錄，整個 cleanup（reversed order）跑完。**不為 cancellation 做特殊處理**。
+
+#### Auth scope
+
+ref clone 用 worker 級 `GH_TOKEN`（與 primary 同），透過既有 `gitAuthEnv` 注入 — 不在 cmdline / .git/config 留下 token。**不引入 per-ref token**；治理仍 channel-level（channel 配置允許的 repo 才會出現在候選池）。如果 PAT 對某 ref 沒讀權，clone 401 → `unavailableRefs` 路徑。
+
+#### `RepoProvider` 介面變更
+
+`worker/pool/executor.go::RepoProvider` 加新 method：
+
+```go
+type RepoProvider interface {
+    Prepare(cloneURL, branch, token string) (string, error)
+    PrepareAt(cloneURL, branch, token, targetPath string) error  // ← NEW
+    RemoveWorktree(worktreePath string) error
+    CleanAll() error
+    PurgeStale() error
+}
+```
+
+`PrepareAt` 與 `Prepare` 的差別：caller 指定 worktree 落點，不從 cache 預設 `worktrees/<random>` 取。`RepoCacheAdapter.PrepareAt` 內部走 `EnsureRepo` + `AddWorktree(barePath, branch, targetPath)`。
+
+### 4.4 Slack UX (`app/workflow/ask.go`)
+
+#### Phase 序列
+
+primary repo + branch 選完之後插入 ref 流程，**重用同一條 selector message**透過 `chat.update` 改寫：
+
+```
+ask_repo_prompt           → 原有
+ask_repo_select           → 原有
+ask_branch_select         → 原有 (only if branch_select enabled)
+
+ask_ref_decide            → NEW   "加入參考 repo？" 是 / 否
+ask_ref_pick              → NEW   單選 ref repo（mirror primary 來源）
+ask_ref_continue          → NEW   "再加一個 ref / 開始問問題"
+ask_ref_branch            → NEW   選此 ref 的 branch（per-ref，跳過規則同 primary）
+
+ask_prior_answer_prompt   → 原有
+ask_description_prompt    → 原有
+```
+
+`ask_ref_pick` 與 `ask_ref_continue` 構成 loop：每選完一個 ref 就詢問是否繼續；user 點「再加一個」→ chat.update 回 `ask_ref_pick`；點「開始問問題」→ 進 `ask_ref_branch` 階段（也是 loop，per-ref）。
+
+**`ask_ref_decide` 前置守衛**：進入此 phase 前先評估候選池大小。若濾掉 primary 後**候選 = 0**，跳過整個 ref 流程，直接走 `ask_prior_answer_prompt` / `ask_description_prompt`，thread 不出現「加入參考 repo？」這條沒意義訊息。
+
+#### `askState` 擴充
+
+```go
+type askState struct {
+    // ...existing fields unchanged...
+
+    AddRefs          bool                // ask_ref_decide 結果
+    RefRepos         []queue.RefRepo     // 累積中：pick 階段填 Repo+CloneURL，branch 階段補 Branch
+    RefBranchIdx     int                 // ask_ref_branch 用：目前在問第幾個 ref 的 branch
+    BranchTargetRepo string              // primary 階段=SelectedRepo；ref 階段=RefRepos[RefBranchIdx].Repo
+}
+
+// BranchSelectedRepo 改讀 BranchTargetRepo（既有介面契約不變）。
+func (s *askState) BranchSelectedRepo() string { return s.BranchTargetRepo }
+```
+
+`BranchStateReader` 介面**不動**，封裝在 askState 內部。`HandleBranchSuggestion` 不需要懂 phase。
+
+#### Branch UX 行數約束（AC）
+
+具體：N ≥ 3 時，ref 流程在 thread 永久新增的訊息行數 **≤ 2**。
+
+實作策略：
+- `ask_ref_decide` 用 `UpdateMessage` / `UpdateMessageWithButton` 把先前的「branch 選擇器」訊息改寫成「加入參考 repo？」。
+- 若 user 點「不加」→ 同條訊息再 update 成下一個 phase 的問題。
+- 若 user 點「加入」→ 同條訊息 update 成 ref repo 選擇器。每一次 ref pick / continue / per-ref branch 都用 `UpdateMessage` 改寫**同一個 ts**，不發新訊息。
+- 整個 ref 流程結束 → 同條訊息再 update 成 `ask_description_prompt`。
+
+換句話說，整個 ref 流程**只佔 1 條訊息位置**（chat.update 不斷改寫同一條）。
+
+#### 不擴 `SelectorSpec`
+
+序列 single-select 100% 重用既有 `PostSmartSelector` 路徑（button / static_select / external_select 自動分流照舊）。**`SelectorSpec` 不加 `MultiSelect`，slack adapter 不動。**
+
+### 4.5 Prompt Context (`shared/queue/job.go`)
+
+`PromptContext` 加：
+
+```go
+type PromptContext struct {
+    // ...existing fields unchanged...
+    RefRepos        []RefRepoContext `json:"ref_repos,omitempty"`
+    UnavailableRefs []string         `json:"unavailable_refs,omitempty"`  // owner/name 形式
+}
+
+type RefRepoContext struct {
+    Repo   string `json:"repo"`              // owner/name
+    Branch string `json:"branch,omitempty"`  // 空 = 預設 branch
+    Path   string `json:"path"`              // 絕對路徑，e.g., /var/cache/.../triage-repo-abc-refs/frontend__web
+}
+```
+
+`worker/prompt/builder.go::BuildPrompt` 在 `<issue_context>` 之後 render：
+
+```xml
+<ref_repos>
+  <ref repo="frontend/web" branch="main" path="/.../triage-repo-abc-refs/frontend__web"/>
+  <ref repo="backend/api"  branch="release-2026q2" path="/.../triage-repo-abc-refs/backend__api"/>
+</ref_repos>
+
+<unavailable_refs>
+  <repo>broken-org/missing-repo</repo>
+</unavailable_refs>
+```
+
+只在非空時 render。
+
+### 4.6 Skill + Output Rules（三層防線）
+
+#### Layer 1（軟引導）：`app/agents/skills/ask-assistant/SKILL.md`
+
+`§5 Action boundaries` 之下新增「Reference repos」段：
+
+```markdown
+**Reference repos (絕對路徑於 `<ref_repos>` 中)**
+
+If the prompt has a `<ref_repos>` block, those directories are mounted at the
+absolute paths listed for read-only context. Rules:
+
+- You CAN: grep, read, follow imports, run `git log --oneline` in them.
+- You CANNOT: write, commit, edit, mv, rm any file under those paths.
+- Refs are physically OUTSIDE your cwd; use the absolute paths exactly as
+  listed in `<ref_repos>`. Don't try to compute relative paths to them.
+
+If `<unavailable_refs>` lists a repo:
+- Treat it as missing context.
+- If the unavailable ref is **critical** to answering this question
+  (i.e., the question fundamentally requires that repo's code), you must
+  state plainly: "無法取得 X repo 脈絡，這題我答不了 — 請確認 PAT 對該 repo 有讀權後重 trigger"
+  and stop. Do not best-effort patchwork an answer from the available refs.
+- If the unavailable ref is non-critical, mention it in the answer
+  ("以下回答僅基於 Y 與 Z，X repo 無法取得") and continue.
+```
+
+#### Layer 2（硬約束）：`output_rules` 動態注入
+
+`app/workflow/ask.go::BuildJob` 在 `RefRepos` 非空時，往 `OutputRules` 動態 append 兩條：
+
+```
+不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。
+若 <unavailable_refs> 含關鍵 ref，必須在答案開頭聲明「無法取得 X repo 脈絡，無法回答」並停手；不要 best-effort 拼湊。
+```
+
+第二條對應 SKILL.md Layer 1 的 fail-fast 規則 — `output_rules` 是 prompt 末端的硬約束，即使 SKILL.md 被忽略也能擋。
+
+#### Layer 3（觀察）：Worker post-execute guard（callback 形式）
+
+```go
+// worker/pool/executor.go (sketch)
+type RefViolationCallback func(ref RefRepoContext, diff string, logger *slog.Logger)
+
+// Ask 注入 lenient callback：
+func askLenientCallback(ref RefRepoContext, diff string, logger *slog.Logger) {
+    logger.Warn("agent wrote into ref repo (lenient: not failing job)",
+        "phase", "處理中", "ref", ref.Repo, "diff_preview", truncate(diff, 200))
+    metrics.AskRefWriteViolationsTotal.WithLabelValues(ref.Repo).Inc()
+}
+
+// Issue (#217) 注入 strict callback：
+func issueStrictCallback(ref RefRepoContext, diff string, logger *slog.Logger) error {
+    return fmt.Errorf("agent wrote into ref repo %s: %s", ref.Repo, truncate(diff, 200))
+}
+```
+
+guard 邏輯共用：遍歷 successful refs，跑 `git status --porcelain`，輸出非空 → call callback。callback signature 不返 error 是因為 Ask 不需要中斷；#217 的 strict 版本可以 panic-equivalent 或透過另一支 signature。具體 abstraction 等 PR 1 寫完再 polish — 重點是**guard 偵測邏輯一份、行為策略可注入**。
+
+#### 為什麼 lenient 對 Ask、不 strict
+
+- **無 user-visible harm**：worktree 一定被 cleanup，寫入物理上不存在。
+- **Ask best-effort 路線**：沒 retry button、parser fail 走 fallback；post-execute fail 跟整體路線衝突。
+- **真正治本在 prompt 端**：Layer 2 的 `output_rules` + Layer 1 的 SKILL.md fail-fast 規則才是治本。Layer 3 是觀察用。
+- **#217 不同**：Issue 會建 ticket，違規 ref 引用會造成 cross-repo 誤導，guard 該 strict。
+
+### 4.7 ref repo 候選來源
+
+ref 候選池與 primary 同源，**濾掉 primary**：
+
+| Channel 配置 | primary 用 | ref 候選來源 |
+| --- | --- | --- |
+| `GetRepos()` 非空 | static button list | 同 list 濾掉 primary |
+| `GetRepos()` 為空 | external_select type-ahead | 同 type-ahead，suggestion handler 排除 primary |
+
+**不允許同 repo 不同 branch 重複當 ref**：UI 上選第二次同 repo 時被濾掉（依 ref `Repo` 欄位 dedup）。要比 branch 用 primary 內 `git diff` 解。
+
+濾完候選池 = 0 → `ask_ref_decide` 直接 skip（見 §4.4 phase 前置守衛）。
+
+## 5. Acceptance Criteria
+
+- [ ] **AC-1（Schema）** `Job.RefRepos` / `RefRepo` / `PromptContext.RefRepos` / `UnavailableRefs` 正確 omitempty 序列化；舊 job（無此欄位）解析測試通過。
+- [ ] **AC-2（regression）** Job 不帶 `RefRepos` 時，整個 Ask 行為與現在 byte-for-byte 一致（unit + integration）。
+- [ ] **AC-3（單 ref）** 帶 1 個 ref，worker workdir 出現 `<primary>-refs/<owner>__<repo>/`，prompt 含 `<ref_repos>` block，agent 可 grep 該路徑。
+- [ ] **AC-4（多 ref）** 帶 N=3 ref，AC-3 對所有 ref 成立；prepare 時間線性增長（log 觀察，不卡 SLO）。
+- [ ] **AC-5（Slack UX 行數）** N ≥ 3 時，ref 流程在 thread 永久新增訊息行數 ≤ 2（chat.update 同條改寫驗證；截圖記錄）。
+- [ ] **AC-6（partial fail）** 故意給一個壞 CloneURL ref，job 不 fail；prompt 含 `<unavailable_refs>`；agent 回覆有「無法取得 X」字樣（透過 SKILL.md + output_rules 引導）。
+- [ ] **AC-7（critical-ref fail-fast）** 故意把核心 repo 設成壞 CloneURL，agent 回覆開頭聲明「無法取得 X repo 脈絡，無法回答」，不嘗試拼湊答案（驗 output_rules 第二條硬規則生效）。
+- [ ] **AC-8（write guard, lenient）** e2e 故意叫 agent 寫進 ref；worker log 有 `agent wrote into ref repo (lenient...)` warn，metric `ask_ref_write_violations_total` += 1，**job 仍 success**。
+- [ ] **AC-9（output_rules 動態注入）** 帶 ref 時 prompt 末端 output_rules 含「不可寫入...」與「critical fail-fast」兩行；不帶 ref 時兩行皆無。
+- [ ] **AC-10（候選濾掉 primary）** primary 已選 `foo/bar`，ref 候選不出現 `foo/bar`（static list + external_select 兩種來源都驗）。
+- [ ] **AC-11（dedup 同 repo）** 已選 `foo/bar` 當 ref，再選 ref 時 `foo/bar` 不出現。
+- [ ] **AC-12（候選為 0 跳過 ref decide）** Channel 配置只允許 1 個 repo，primary 選掉它後，ref 流程整個 skip — thread 不出現「加入參考 repo？」訊息。
+- [ ] **AC-13（per-ref branch picker）** 每個 ref 跑與 primary 對稱的 branch 跳過邏輯（`branch_select` 關 / branches ≤ 1 → 各自跳過；否則 type-ahead）。
+- [ ] **AC-14（Cancellation cleanup）** ref prepare 進行中 user cancel job → refs root 與 primary worktree 全部 cleanup，無殘留 directory。
+
+## 6. Testing Strategy
+
+### Unit tests
+
+- `shared/queue/job_test.go` — `RefRepos` JSON round-trip；舊 job 解析（無此欄位）。
+- `worker/prompt/builder_test.go` — `<ref_repos>`、`<unavailable_refs>` 渲染條件（皆空 → 不 render；有值 → 對應形狀）。
+- `worker/pool/workdir_test.go` — fake `RepoProvider.PrepareAt` 模擬成功 / 失敗組合，驗 `unavailableRefs` 累積、cleanup 順序、refs root path 計算。
+- `worker/pool/executor_test.go` — post-execute guard callback 被呼叫的條件（fake `git status` output）；lenient callback 不返 error 行為。
+- `app/workflow/ask_test.go` — 新 phase 流轉（attach=yes, refs=yes/no, ref pick + continue + per-ref branch）；候選 0 時 skip ref decide；dedup 已選 ref；branch UX phase 切換把 `BranchTargetRepo` 設對。
+
+### Integration tests
+
+- `worker/integration/queue_redis_integration_test.go` — submit 帶 `RefRepos` 的 Ask job，驗 worktree 結構（primary + refs root + ref 子目錄），agent 跑完 cleanup 完整。
+- 一個 ref 故意設無效 CloneURL，驗 partial-success：job success、prompt 含 `<unavailable_refs>`。
+
+### Slack UX 手動驗收
+
+開測試 channel 配 3 個 repo，跑 ask flow 三次：(0 ref, 1 ref, 3 ref)。重點：
+- 截圖訊息序列，驗 AC-5 永久訊息數量。
+- 每次 ref pick / continue / branch 點擊都觀察 selector message ts 是否不變（chat.update 確實 in-place）。
+- 故意把候選池逼到 0（primary 選掉唯一 repo），驗 AC-12 ref decide 被 skip。
+
+## 7. Boundaries
+
+### Always do
+
+- Job schema additive，不破壞舊 job。
+- 新 phase 的 selector 都用 chat.update 重用既有 selector message ts，不發新訊息。
+- ref 失敗不阻塞 primary。
+- `RefRepos` 非空時自動往 `output_rules` 注入兩條硬約束（read-only + critical fail-fast）。
+- worker post-execute 對每個成功 ref 跑 `git status --porcelain`，違規透過注入的 callback 處理（Ask: lenient warn + metric）。
+- ref 候選 mirror primary 來源、濾 primary、dedup 已選 ref；候選 0 跳過 ref decide phase。
+- cleanup reversed order：refs root → primary worktree。
+
+### Ask first
+
+- ref 數量 hard cap 決策（spec 不設，但若 prepare metric 顯示 N ≥ 5 job 跑爆 timeout，回頭加）。
+- 是否要把 refs root 改 read-only mount（host 權限做不到時更嚴格的方案）。
+- 是否要 per-ref token / 獨立 auth 範疇（spec 維持 channel-level、worker 級 PAT；若 SRE 想要更細治理另開 issue）。
+
+### Never do
+
+- 用 `--dangerously-skip-permissions` 之類 flag 放開 host sandbox（user memory「Worker 部署環境不可假設」）。
+- 把 ref 寫權限從 prompt 放開（即使使用者要求）。
+- 在 primary worktree 內掛 nested git worktree（已被 §4.2 改外部 path 解掉，但實作時要守住別走回頭路）。
+- 砍 `output_rules` 那兩條動態注入（即使 user-facing 看不到，那是治本的 prompt-level 防線）。
+
+## 8. Assumptions to Validate (during impl)
+
+| 假設 | 驗法 | 不成立時的退路 |
+| --- | --- | --- |
+| Sequential clone 在 N=3 時仍能在 `prepare_timeout`（預設 3min）內完成 | 觀察 metric `worker_prepare_seconds` | 加 budget；refactor `RepoCache` 成 per-repo lock 啟用平行 |
+| ref 寫入違規率夠低，metric 觀察就夠、不需要 fs-level read-only 強制 | 觀察 `ask_ref_write_violations_total` 一段時間 | host 容器化部署時掛 readonly bind mount；laptop 部署只能靠 prompt |
+| 既有 channels 配置足以涵蓋多 repo 場景（type-ahead 路徑也 OK） | 與使用者確認既有 channel repos 配置 | 若需要更精細治理，另開 issue 加 ref-only allow list |
+
+> **不需要 spike 的事項**：
+> - `.refs/` 與 `.gitignore` 互動 — refs 已移外部 path（§4.2），完全規避此問題。
+> - Slack `multi_static_select` + chat.update 行為 — 改用序列 single-select（§4.4），完全規避。
+
+## 9. Out of Scope (本 spec 不做)
+
+- **#217 Issue workflow 多 repo + body 引用** — 等 #216 land 後接著做，沿用本 spec 的 schema、workdir layout、UX；guard callback 改 strict 策略。
+- **PR Review 多 repo** — #215 已決議砍掉。
+- **ref repo 共享 cache 優化** — 先量再決定。
+- **refs root mount 成 read-only fs** — host 權限做不到，留 v2。
+- **多選 widget（modal 或 multi_static_select）** — 序列 single-select 解決 UX 需求，無動機回頭。
+- **ref 數量硬上限** — 無，N ≥ 5 info-log 觀察。
+- **同 repo 不同 branch 同時當 ref** — 禁止。
+- **per-ref token / 獨立 auth scope** — 沿用 worker 級 PAT。
+
+## 10. Implementation Order
+
+**2 顆 PR：**
+
+| PR | 範圍 | 中間態 |
+| --- | --- | --- |
+| **PR 1 — backend** | `shared/queue/job.go`（schema + PromptContext 擴充）、`worker/prompt/builder.go`（`<ref_repos>` / `<unavailable_refs>` 渲染）、`worker/pool/`（`PrepareAt`、`executeJob` 處理 RefRepos、sequential clone、partial success、refs root cleanup、post-execute guard callback w/ Ask lenient impl）、相關 unit + integration tests | 舊行為 byte-for-byte 不破。worker 收到帶 `RefRepos` 的 job 能正確 prepare、跑 agent、cleanup；但因為 app 還沒能產出這種 job，functionally 等於沒上線（safe to land alone）。 |
+| **PR 2 — frontend + e2e** | `app/workflow/ask.go`（askState 擴充、新 phase、`BranchTargetRepo` 切換、BuildJob output_rules 動態注入、ref 候選濾 primary + dedup + 0-候選 skip）、`app/agents/skills/ask-assistant/SKILL.md`（Reference repos + critical fail-fast 段落）、ask_test.go 對新 phase 的覆蓋、Slack 手動 e2e 截圖紀錄到 PR description | 完整 user-facing 流程啟用，AC-1 到 AC-14 全部可驗。 |
+
+**為什麼 2 顆而不是 1 顆**：
+- PR 1 是 worker / shared 兩個獨立 module 的 atomic 改動，沒碰 app — 對應 user memory「App/Worker 區分」分界。Review 時只看 backend 行為。
+- PR 2 是 app + skill prompt + e2e，全是 user-visible 流程。Review 重心是 UX 與 prompt 行為。
+- 中間態乾淨：PR 1 land 後沒有 user-facing 改動；PR 2 land 後 e2e 可跑。
+
+**PR 大小估**：PR 1 ~300 行（含 tests）、PR 2 ~400 行（含 tests + SKILL.md）。都在 review 友善區間。

--- a/shared/metrics/metrics.go
+++ b/shared/metrics/metrics.go
@@ -116,6 +116,17 @@ var WorkflowRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Count of workflow retry attempts and exhaustions.",
 }, []string{"workflow", "outcome"})
 
+// AskRefWriteViolationsTotal counts post-execute guard violations: an Ask
+// agent wrote into a ref worktree despite the read-only contract. Lenient
+// strategy — increment + warn-log, do NOT fail the job. Surfaces prompt
+// drift; if this counter trends up, the SKILL.md / output_rules need
+// strengthening, not the runtime guard.
+var AskRefWriteViolationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "ask_ref_write_violations_total",
+	Help:      "Number of times an Ask-workflow agent wrote into a ref repo (lenient: violation does not fail the job).",
+}, []string{"repo"})
+
 // ---- Handler ----
 
 var HandlerDedupRejectionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -200,6 +211,7 @@ func Register(reg prometheus.Registerer, q queue.JobQueue, store queue.JobStore)
 		AgentTokensTotal,
 		WorkflowCompletionsTotal,
 		WorkflowRetryTotal,
+		AskRefWriteViolationsTotal,
 		HandlerDedupRejectionsTotal,
 		HandlerRateLimitTotal,
 		WatchdogKillsTotal,

--- a/shared/queue/job.go
+++ b/shared/queue/job.go
@@ -41,6 +41,7 @@ type Job struct {
 	PromptContext    *PromptContext           `json:"prompt_context,omitempty"`
 	SubmittedAt      time.Time                `json:"submitted_at"`
 	EncryptedSecrets []byte                   `json:"encrypted_secrets,omitempty"`
+	RefRepos         []RefRepo                `json:"ref_repos,omitempty"`
 }
 
 type AttachmentMeta struct {
@@ -49,6 +50,15 @@ type AttachmentMeta struct {
 	Size        int64  `json:"size"`
 	MimeType    string `json:"mime_type"`
 	DownloadURL string `json:"download_url"`
+}
+
+// RefRepo is a read-only reference repo attached alongside the primary repo.
+// Repo is owner/name (mirrors Job.Repo); CloneURL is the worker's clone target;
+// Branch empty = default branch.
+type RefRepo struct {
+	Repo     string `json:"repo"`
+	CloneURL string `json:"clone_url"`
+	Branch   string `json:"branch,omitempty"`
 }
 
 type ThreadMessage struct {
@@ -74,6 +84,23 @@ type PromptContext struct {
 	// Slice shape reserves room for multi-turn history; v1 only fills the
 	// most recent qualifying message.
 	PriorAnswer []ThreadMessage `json:"prior_answer,omitempty"`
+	// RefRepos lists ref repos that prepared successfully, with their
+	// absolute paths on the worker for the agent to grep/read. Filled by
+	// worker after PrepareAt, not by the app at BuildJob time.
+	RefRepos []RefRepoContext `json:"ref_repos,omitempty"`
+	// UnavailableRefs lists ref repos (owner/name) whose clone failed.
+	// Filled by worker; the prompt builder renders an `<unavailable_refs>`
+	// block so the agent knows which context is missing.
+	UnavailableRefs []string `json:"unavailable_refs,omitempty"`
+}
+
+// RefRepoContext is one ref repo as seen by the prompt builder. Path is the
+// absolute on-disk path the agent should grep/read; filled by worker after
+// PrepareAt succeeds. Empty Branch = default branch.
+type RefRepoContext struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch,omitempty"`
+	Path   string `json:"path"`
 }
 
 type JobResult struct {

--- a/shared/queue/job_test.go
+++ b/shared/queue/job_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -151,5 +152,109 @@ func TestJob_WorkflowArgsOmitEmpty(t *testing.T) {
 	buf, _ := json.Marshal(j)
 	if strings.Contains(string(buf), "workflow_args") {
 		t.Errorf("empty WorkflowArgs should be omitted: %s", buf)
+	}
+}
+
+// TestJob_RefRepos_RoundTrip ensures the new RefRepos field marshals and
+// unmarshals losslessly. Default-branch refs (Branch == "") must drop the
+// field via omitempty so the wire shape stays minimal.
+func TestJob_RefRepos_RoundTrip(t *testing.T) {
+	in := Job{
+		ID:       "abc",
+		Repo:     "foo/bar",
+		CloneURL: "https://example/foo/bar.git",
+		RefRepos: []RefRepo{
+			{Repo: "frontend/web", CloneURL: "https://example/frontend/web.git", Branch: "main"},
+			{Repo: "backend/api", CloneURL: "https://example/backend/api.git"},
+		},
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"ref_repos":[`) {
+		t.Errorf("expected ref_repos array in JSON, got: %s", raw)
+	}
+	// Default-branch ref must omit the branch key. Marshal a single bare
+	// RefRepo so the assertion isn't muddled by Job.Branch (which has no
+	// omitempty by design — it's a top-level required-shaped field).
+	defaultBranchOnly, _ := json.Marshal(RefRepo{Repo: "x/y", CloneURL: "u"})
+	if strings.Contains(string(defaultBranchOnly), `"branch"`) {
+		t.Errorf("default-branch RefRepo should omit branch field: %s", defaultBranchOnly)
+	}
+
+	var out Job
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in.RefRepos, out.RefRepos) {
+		t.Fatalf("RefRepos mismatch:\n in=%+v\nout=%+v", in.RefRepos, out.RefRepos)
+	}
+}
+
+// TestJob_OldJob_NoRefRepos_StillParses asserts pre-RefRepos jobs (no field
+// in JSON) parse cleanly with RefRepos == nil. Critical for the deploy-window
+// where workers running new code receive jobs queued by older app code.
+func TestJob_OldJob_NoRefRepos_StillParses(t *testing.T) {
+	raw := []byte(`{"id":"abc","repo":"foo/bar","clone_url":"https://example/foo/bar.git"}`)
+	var out Job
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.RefRepos != nil {
+		t.Fatalf("expected nil RefRepos on old-job parse, got %+v", out.RefRepos)
+	}
+}
+
+// TestJob_RefRepos_OmitEmpty asserts that a job with no refs serializes
+// without the ref_repos key entirely.
+func TestJob_RefRepos_OmitEmpty(t *testing.T) {
+	j := &Job{ID: "j1", TaskType: "ask"}
+	buf, _ := json.Marshal(j)
+	if strings.Contains(string(buf), "ref_repos") {
+		t.Errorf("empty RefRepos should be omitted: %s", buf)
+	}
+}
+
+// TestPromptContext_RefFields_RoundTrip covers the worker-filled fields on
+// PromptContext. Empty paths/branches drop via omitempty; populated fields
+// survive a round-trip.
+func TestPromptContext_RefFields_RoundTrip(t *testing.T) {
+	in := PromptContext{
+		Channel:  "general",
+		Reporter: "Bob",
+		Goal:     "ask",
+		RefRepos: []RefRepoContext{
+			{Repo: "frontend/web", Branch: "main", Path: "/tmp/refs/frontend__web"},
+			{Repo: "backend/api", Path: "/tmp/refs/backend__api"},
+		},
+		UnavailableRefs: []string{"broken/repo"},
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out PromptContext
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in.RefRepos, out.RefRepos) {
+		t.Errorf("RefRepos mismatch:\n in=%+v\nout=%+v", in.RefRepos, out.RefRepos)
+	}
+	if !reflect.DeepEqual(in.UnavailableRefs, out.UnavailableRefs) {
+		t.Errorf("UnavailableRefs mismatch:\n in=%+v\nout=%+v", in.UnavailableRefs, out.UnavailableRefs)
+	}
+}
+
+// TestPromptContext_RefFields_OmitEmpty asserts the new fields drop from JSON
+// when unset, so the existing wire shape for non-ref jobs is unchanged.
+func TestPromptContext_RefFields_OmitEmpty(t *testing.T) {
+	pc := &PromptContext{Channel: "c", Reporter: "r", Goal: "g"}
+	buf, _ := json.Marshal(pc)
+	if strings.Contains(string(buf), "ref_repos") {
+		t.Errorf("empty RefRepos should be omitted: %s", buf)
+	}
+	if strings.Contains(string(buf), "unavailable_refs") {
+		t.Errorf("empty UnavailableRefs should be omitted: %s", buf)
 	}
 }

--- a/worker/integration/queue_integration_test.go
+++ b/worker/integration/queue_integration_test.go
@@ -38,6 +38,12 @@ func (f *fakeRepo) Prepare(cloneURL, branch, token string) (string, error) {
 	return "/tmp/fake-repo", nil
 }
 
+// PrepareAt satisfies RepoProvider for tests that don't exercise refs.
+// Defaults to no-op success.
+func (f *fakeRepo) PrepareAt(cloneURL, branch, token, targetPath string) error {
+	return nil
+}
+
 func (f *fakeRepo) RemoveWorktree(path string) error { return nil }
 func (f *fakeRepo) CleanAll() error                  { return nil }
 func (f *fakeRepo) PurgeStale() error                { return nil }

--- a/worker/pool/adapters.go
+++ b/worker/pool/adapters.go
@@ -46,6 +46,24 @@ func (a *RepoCacheAdapter) Prepare(cloneURL, branch, token string) (string, erro
 	return worktreePath, nil
 }
 
+// PrepareAt clones into targetPath rather than the cache's default worktree
+// dir. Used for ref repos so worker can co-locate them with the primary
+// worktree under `<primary>-refs/<owner>__<repo>`.
+//
+// Caller is responsible for the PARENT of targetPath existing; this method
+// removes targetPath itself first because git worktree add requires the
+// target dir not to exist.
+func (a *RepoCacheAdapter) PrepareAt(cloneURL, branch, token, targetPath string) error {
+	barePath, err := a.Cache.EnsureRepo(cloneURL, token)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(targetPath); err != nil {
+		return fmt.Errorf("clear ref target %s: %w", targetPath, err)
+	}
+	return a.Cache.AddWorktree(barePath, branch, targetPath)
+}
+
 func (a *RepoCacheAdapter) RemoveWorktree(path string) error { return a.Cache.RemoveWorktree(path) }
 func (a *RepoCacheAdapter) CleanAll() error                  { return a.Cache.CleanAll() }
 func (a *RepoCacheAdapter) PurgeStale() error                { return a.Cache.PurgeStale() }

--- a/worker/pool/executor.go
+++ b/worker/pool/executor.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/Ivantseng123/agentdock/shared/crypto"
+	"github.com/Ivantseng123/agentdock/shared/metrics"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 	"github.com/Ivantseng123/agentdock/worker/agent"
 	"github.com/Ivantseng123/agentdock/worker/prompt"
@@ -22,8 +24,17 @@ type Runner interface {
 }
 
 // RepoProvider abstracts repo clone/checkout (for testing).
+//
+// Prepare creates a worktree under the cache's default worktree dir; used for
+// the primary repo whose path is opaque to the caller.
+//
+// PrepareAt creates a worktree at the caller-supplied path; used for ref
+// repos so worker can co-locate them with the primary worktree (the path
+// shape is `<primary worktree>-refs/<owner>__<repo>`). Caller is responsible
+// for the parent dir.
 type RepoProvider interface {
 	Prepare(cloneURL, branch, token string) (string, error)
+	PrepareAt(cloneURL, branch, token, targetPath string) error
 	RemoveWorktree(worktreePath string) error
 	CleanAll() error
 	PurgeStale() error
@@ -109,6 +120,36 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 		return failedResult(job, startedAt, fmt.Errorf("malformed job: missing prompt_context"), repoPath)
 	}
 
+	// Ref repos — only when primary is real (CloneURL set; refs without a
+	// primary have no anchor for refsRoot). Sequential clone with partial
+	// success: per-ref failures collect into UnavailableRefs and never abort
+	// the job. Cleanup deferred so cancellation / failure paths still rm.
+	var refContexts []queue.RefRepoContext
+	var successfulRefPaths []string
+	var unavailableRefs []string
+	var refsRoot string
+	if job.CloneURL != "" && len(job.RefRepos) > 0 {
+		var refErr error
+		refContexts, successfulRefPaths, unavailableRefs, refsRoot, refErr = prepareRefs(
+			deps.repoCache, repoPath, ghToken, job.RefRepos, logger,
+		)
+		if refErr != nil {
+			// Only refs-root mkdir failures bubble up; per-ref failures are
+			// absorbed into unavailableRefs by prepareRefs itself.
+			return classifyResult(job, startedAt, fmt.Errorf("refs prepare: %w", refErr), repoPath, ctx, deps.store)
+		}
+		logger.Info("Refs 已就緒",
+			"phase", "處理中",
+			"count_success", len(refContexts),
+			"count_unavailable", len(unavailableRefs),
+		)
+	}
+	defer cleanupRefs(deps.repoCache, successfulRefPaths, refsRoot)
+
+	// Worker-filled fields on PromptContext: Path is only known after PrepareAt.
+	job.PromptContext.RefRepos = refContexts
+	job.PromptContext.UnavailableRefs = unavailableRefs
+
 	// Write attachments into worktree — cleaned up together with RemoveWorktree.
 	var attachInfos []prompt.AttachmentInfo
 	if len(attachments) > 0 {
@@ -153,6 +194,12 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 	logger.Info("Agent 執行完成", "phase", "完成", "output_len", len(output))
 	logger.Debug("Agent output 內容", "phase", "完成", "output", output)
 
+	// Post-execute ref guard. Only fires when refs were prepared; lenient
+	// callback for Ask (warn + metric, do NOT fail). #217 will route Issue
+	// jobs through a strict callback. Today Ask is the only multi-repo
+	// workflow, so the callback selection is hardcoded.
+	runRefGuard(refContexts, askLenientRefViolation, logger)
+
 	// Ship the raw agent output to the app. Parsing and REJECTED/ERROR/parse-failed
 	// classification live in the app-side result listener — worker has no
 	// business interpreting agent output or deciding whether to create an issue.
@@ -164,6 +211,57 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 		StartedAt:      startedAt,
 		FinishedAt:     time.Now(),
 		PrepareSeconds: prepareSeconds,
+	}
+}
+
+// RefViolationCallback is invoked when post-execute guard finds modifications
+// in a ref worktree. Ask installs a lenient impl (warn + metric); Issue (#217)
+// will install a strict impl that fails the job. The two-arg shape lets a
+// future strict impl record violations, then the caller decides whether to
+// continue — this spec only ships the lenient flavour, but the abstraction
+// is a callback so the strict impl can drop in without restructuring.
+type RefViolationCallback func(refContext queue.RefRepoContext, diffPreview string, logger *slog.Logger)
+
+// askLenientRefViolation is the Ask-workflow callback: warn-log + metric.
+// Worktree cleanup happens regardless, so writes have no persistent effect —
+// the guard is observability, not enforcement (spec §4.6 Layer 3, Q8).
+func askLenientRefViolation(ref queue.RefRepoContext, diff string, logger *slog.Logger) {
+	logger.Warn("agent wrote into ref repo (lenient: not failing job)",
+		"phase", "處理中",
+		"ref", ref.Repo,
+		"diff_preview", truncateRefDiff(diff),
+	)
+	metrics.AskRefWriteViolationsTotal.WithLabelValues(ref.Repo).Inc()
+}
+
+// truncateRefDiff caps the log preview at 200 chars so a multi-MB diff can't
+// blow up log volume on a misbehaving agent run.
+func truncateRefDiff(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 200 {
+		return s[:200] + "…(truncated)"
+	}
+	return s
+}
+
+// runRefGuard walks successful ref worktrees and runs `git status --porcelain`
+// in each. Non-empty output → invoke callback. `git status` failure is logged
+// at debug and skipped (a corrupt worktree shouldn't escalate; cleanup runs
+// regardless). When refs is empty or onViolation is nil, this is a no-op.
+func runRefGuard(refs []queue.RefRepoContext, onViolation RefViolationCallback, logger *slog.Logger) {
+	if onViolation == nil || len(refs) == 0 {
+		return
+	}
+	for _, ref := range refs {
+		out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
+		if err != nil {
+			logger.Debug("ref guard: git status failed; skipping",
+				"phase", "處理中", "ref", ref.Repo, "error", err)
+			continue
+		}
+		if diff := strings.TrimSpace(string(out)); diff != "" {
+			onViolation(ref, diff, logger)
+		}
 	}
 }
 

--- a/worker/pool/executor_test.go
+++ b/worker/pool/executor_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -249,4 +252,278 @@ func TestExecuteJob_PrePrepareGuardSkipsClone(t *testing.T) {
 	if result.Status != "cancelled" {
 		t.Errorf("status = %q, want cancelled", result.Status)
 	}
+}
+
+// initGitWorktree creates a tiny initialised git repo at dir with one empty
+// commit. Returns the path. Used by the ref-guard tests so `git status` has
+// a real worktree to walk.
+func initGitWorktree(t *testing.T, dir string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=t@t", "-c", "user.name=t",
+			"commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// TestRunRefGuard_DetectsViolation creates a real git worktree, modifies a
+// tracked-ish file, and asserts the callback fires with the right ref.
+// Tests the lenient-callback path's most important property: it observes
+// without interrupting (no error returned, just side effects).
+func TestRunRefGuard_DetectsViolation(t *testing.T) {
+	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("agent wrote here"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired []string
+	cb := func(ref queue.RefRepoContext, diff string, _ *slog.Logger) {
+		fired = append(fired, ref.Repo)
+		if !strings.Contains(diff, "f.txt") {
+			t.Errorf("diff should mention f.txt, got %q", diff)
+		}
+	}
+	runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+
+	if len(fired) != 1 || fired[0] != "foo/bar" {
+		t.Fatalf("expected one violation for foo/bar; got %v", fired)
+	}
+}
+
+// TestRunRefGuard_CleanWorktree_NoCallback asserts the no-violation path
+// doesn't fire the callback — important so the metric only counts real
+// violations, not background activity.
+func TestRunRefGuard_CleanWorktree_NoCallback(t *testing.T) {
+	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
+
+	var fired int
+	cb := func(_ queue.RefRepoContext, _ string, _ *slog.Logger) { fired++ }
+	runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+
+	if fired != 0 {
+		t.Fatalf("clean worktree must not fire callback, fired=%d", fired)
+	}
+}
+
+// TestRunRefGuard_NilCallback_NoOp ensures the guard is safe to invoke even
+// when no callback is configured (defensive — callers shouldn't normally
+// pass nil, but the impl should not panic).
+func TestRunRefGuard_NilCallback_NoOp(t *testing.T) {
+	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
+	runRefGuard([]queue.RefRepoContext{{Repo: "x/y", Path: dir}}, nil, slog.Default())
+}
+
+// TestRunRefGuard_EmptyRefs_NoOp covers the no-refs path so the callback
+// definitely doesn't fire and no git command runs.
+func TestRunRefGuard_EmptyRefs_NoOp(t *testing.T) {
+	var fired int
+	cb := func(_ queue.RefRepoContext, _ string, _ *slog.Logger) { fired++ }
+	runRefGuard(nil, cb, slog.Default())
+	if fired != 0 {
+		t.Fatalf("empty refs must not fire callback, fired=%d", fired)
+	}
+}
+
+// TestTruncateRefDiff covers the log-volume cap on diff previews.
+func TestTruncateRefDiff(t *testing.T) {
+	short := "M f.txt"
+	if got := truncateRefDiff(short); got != short {
+		t.Errorf("short input changed: in=%q out=%q", short, got)
+	}
+	long := strings.Repeat("x", 500)
+	got := truncateRefDiff(long)
+	if !strings.HasSuffix(got, "…(truncated)") {
+		t.Errorf("long input not truncated: %q", got)
+	}
+	if len(got) > 220 { // 200 + truncation marker
+		t.Errorf("truncated length too long: %d", len(got))
+	}
+}
+
+// recordingRepo is a RepoProvider that records every call and lets the test
+// dictate per-target PrepareAt outcomes. Used by the multi-repo executeJob
+// test below where we need both success and failure paths exercised in one
+// run plus the ability to assert cleanup ordering.
+type recordingRepo struct {
+	primaryPath   string
+	prepareAtFail map[string]bool // key: target path suffix; value: should fail
+	prepareAtCalls []string         // recorded target paths in call order
+	removedWorktrees []string
+}
+
+func (r *recordingRepo) Prepare(cloneURL, branch, token string) (string, error) {
+	if err := os.MkdirAll(r.primaryPath, 0755); err != nil {
+		return "", err
+	}
+	return r.primaryPath, nil
+}
+
+func (r *recordingRepo) PrepareAt(cloneURL, branch, token, target string) error {
+	r.prepareAtCalls = append(r.prepareAtCalls, target)
+	for suffix, shouldFail := range r.prepareAtFail {
+		if strings.HasSuffix(target, suffix) && shouldFail {
+			return fmt.Errorf("simulated clone failure for %s", target)
+		}
+	}
+	// Initialise a real git worktree so the post-execute guard's git status
+	// has something to walk. Without this, guard would log debug + skip.
+	return initBareGitFolder(target)
+}
+
+func (r *recordingRepo) RemoveWorktree(path string) error {
+	r.removedWorktrees = append(r.removedWorktrees, path)
+	return nil
+}
+func (r *recordingRepo) CleanAll() error   { return nil }
+func (r *recordingRepo) PurgeStale() error { return nil }
+
+func initBareGitFolder(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=t@t", "-c", "user.name=t",
+			"commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git %v: %w\n%s", args, err, out)
+		}
+	}
+	return nil
+}
+
+// TestExecuteJob_MultiRepo_EndToEnd is the executor-level integration test
+// for the ref pipeline: schema → prepareRefs → PromptContext fill → builder
+// renders ref blocks → guard fires on dirty refs → cleanup walks all paths
+// in reverse order. One ref clones successfully (and gets dirtied to
+// trigger the lenient guard); a second ref deliberately fails to clone.
+func TestExecuteJob_MultiRepo_EndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+
+	tmp := t.TempDir()
+	primaryPath := filepath.Join(tmp, "triage-repo-abc")
+
+	repo := &recordingRepo{
+		primaryPath: primaryPath,
+		prepareAtFail: map[string]bool{
+			"broken__repo": true, // second ref clone fails
+		},
+	}
+
+	// dirtyingRunner writes into the successful ref's worktree before
+	// returning so the post-execute guard sees a non-empty `git status` and
+	// fires the lenient callback. Path is deterministic from refDirName.
+	runner := &dirtyingRunner{
+		dirtyPath: filepath.Join(primaryPath+"-refs", "frontend__web", "agent-wrote-here.txt"),
+		output:    "answer body",
+	}
+
+	store := queue.NewMemJobStore()
+	job := &queue.Job{
+		ID:       "j-multi",
+		Repo:     "primary/repo",
+		CloneURL: "https://example.com/primary/repo.git",
+		Branch:   "main",
+		PromptContext: &queue.PromptContext{
+			Channel:  "general",
+			Reporter: "Alice",
+			Goal:     "answer the question",
+			OutputRules: []string{"do not write to refs"},
+		},
+		RefRepos: []queue.RefRepo{
+			{Repo: "frontend/web", CloneURL: "https://example.com/frontend/web.git", Branch: "main"},
+			{Repo: "broken/repo", CloneURL: "https://example.com/broken/repo.git"},
+		},
+	}
+	store.Put(context.Background(), job)
+
+	deps := executionDeps{
+		attachments: queuetest.NewAttachmentStore(),
+		repoCache:   repo,
+		runner:      runner,
+		store:       store,
+	}
+
+	res := executeJob(context.Background(), job, deps, agent.RunOptions{}, slog.Default())
+
+	if res.Status != "completed" {
+		t.Fatalf("status = %q, want completed (Error=%q)", res.Status, res.Error)
+	}
+
+	// Successful ref clones once at <primary>-refs/<owner>__<name>.
+	gotTargets := repo.prepareAtCalls
+	if len(gotTargets) != 2 {
+		t.Fatalf("PrepareAt call count = %d, want 2 (got %v)", len(gotTargets), gotTargets)
+	}
+	wantSuffixes := []string{"frontend__web", "broken__repo"}
+	for i, want := range wantSuffixes {
+		if !strings.HasSuffix(gotTargets[i], want) {
+			t.Errorf("PrepareAt[%d] target = %q, want suffix %q", i, gotTargets[i], want)
+		}
+	}
+
+	// Prompt contains the successful ref + the unavailable ref.
+	if !strings.Contains(runner.gotPrompt, "<ref_repos>") {
+		t.Errorf("prompt missing <ref_repos> block:\n%s", runner.gotPrompt)
+	}
+	if !strings.Contains(runner.gotPrompt, `repo="frontend/web"`) {
+		t.Errorf("prompt missing successful ref:\n%s", runner.gotPrompt)
+	}
+	if !strings.Contains(runner.gotPrompt, "<unavailable_refs>") {
+		t.Errorf("prompt missing <unavailable_refs> block:\n%s", runner.gotPrompt)
+	}
+	if !strings.Contains(runner.gotPrompt, "<repo>broken/repo</repo>") {
+		t.Errorf("prompt missing unavailable entry for broken/repo:\n%s", runner.gotPrompt)
+	}
+
+	// Cleanup: ref worktree removed (RemoveWorktree called for the successful
+	// ref's path), refs root rm'd. Order is reversed (only one successful
+	// ref here), and the refs-root dir should be gone after job.
+	if len(repo.removedWorktrees) != 1 {
+		t.Errorf("RemoveWorktree call count = %d, want 1 (got %v)",
+			len(repo.removedWorktrees), repo.removedWorktrees)
+	}
+	if !strings.HasSuffix(repo.removedWorktrees[0], "frontend__web") {
+		t.Errorf("RemoveWorktree path = %q, want suffix frontend__web",
+			repo.removedWorktrees[0])
+	}
+	refsRoot := primaryPath + "-refs"
+	if _, err := os.Stat(refsRoot); !os.IsNotExist(err) {
+		t.Errorf("refs root should be cleaned up; stat err = %v", err)
+	}
+}
+
+// dirtyingRunner writes a file into a ref worktree before returning, to
+// trigger the post-execute guard. Used only by the multi-repo end-to-end
+// test above.
+type dirtyingRunner struct {
+	dirtyPath  string
+	output     string
+	gotPrompt  string
+	gotWorkDir string
+}
+
+func (d *dirtyingRunner) Run(ctx context.Context, workDir, prompt string, opts agent.RunOptions) (string, error) {
+	d.gotPrompt = prompt
+	d.gotWorkDir = workDir
+	if d.dirtyPath != "" {
+		_ = os.WriteFile(d.dirtyPath, []byte("agent leaked"), 0644)
+	}
+	return d.output, nil
 }

--- a/worker/pool/pool_test.go
+++ b/worker/pool/pool_test.go
@@ -42,6 +42,13 @@ func (m *mockRepo) Prepare(cloneURL, branch, token string) (string, error) {
 	return m.path, m.err
 }
 
+// PrepareAt satisfies RepoProvider for tests that don't exercise refs.
+// Defaults to success without creating the dir — pool_test fixtures don't
+// inspect the filesystem, so a no-op is enough to keep the interface honest.
+func (m *mockRepo) PrepareAt(cloneURL, branch, token, targetPath string) error {
+	return nil
+}
+
 func (m *mockRepo) RemoveWorktree(path string) error {
 	m.removedWorktrees = append(m.removedWorktrees, path)
 	return nil

--- a/worker/pool/workdir.go
+++ b/worker/pool/workdir.go
@@ -2,7 +2,10 @@ package pool
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
@@ -63,4 +66,80 @@ func selectProvider(job *queue.Job, repo RepoProvider, token string) WorkDirProv
 		return &EmptyDirProvider{}
 	}
 	return &RepoCloneProvider{Repo: repo, Token: token}
+}
+
+// refsRootPath returns the directory in which ref worktrees live, derived
+// from the primary worktree path. The "-refs" suffix keeps ref dirs in the
+// same parent (the cache's worktrees/) so existing cleanup paths cover them.
+func refsRootPath(primaryPath string) string {
+	return primaryPath + "-refs"
+}
+
+// refDirName flattens owner/name → owner__name. GitHub disallows __ in repo
+// names, so collisions across distinct refs are impossible. Used for the
+// per-ref subdirectory name under refsRootPath.
+func refDirName(repo string) string {
+	return strings.ReplaceAll(repo, "/", "__")
+}
+
+// prepareRefs sequentially clones each ref into <refsRoot>/<owner>__<repo>/.
+// Per-ref errors collect into `unavailable` (owner/name) and the loop
+// continues — partial success is the contract (spec §4.3). Returns:
+//
+//   - successful: ref contexts with absolute paths, fed to PromptContext.RefRepos
+//   - successfulPaths: same paths in slice form, used by guard + cleanup
+//   - unavailable: owner/name list of failed refs, fed to PromptContext.UnavailableRefs
+//   - refsRoot: the parent dir; "" when refs is empty (no mkdir performed)
+//
+// err returns non-nil only when the refs-root mkdir itself fails — per-ref
+// failures are absorbed into `unavailable`.
+func prepareRefs(provider RepoProvider, primaryPath, token string, refs []queue.RefRepo, logger *slog.Logger) (
+	successful []queue.RefRepoContext,
+	successfulPaths []string,
+	unavailable []string,
+	refsRoot string,
+	err error,
+) {
+	if len(refs) == 0 {
+		return nil, nil, nil, "", nil
+	}
+	refsRoot = refsRootPath(primaryPath)
+	if mkErr := os.MkdirAll(refsRoot, 0755); mkErr != nil {
+		return nil, nil, nil, "", fmt.Errorf("mkdir refs root: %w", mkErr)
+	}
+	for _, r := range refs {
+		target := filepath.Join(refsRoot, refDirName(r.Repo))
+		if pErr := provider.PrepareAt(r.CloneURL, r.Branch, token, target); pErr != nil {
+			logger.Warn("ref clone failed; continuing with partial context",
+				"phase", "處理中", "ref", r.Repo, "branch", r.Branch, "error", pErr)
+			unavailable = append(unavailable, r.Repo)
+			continue
+		}
+		successful = append(successful, queue.RefRepoContext{
+			Repo: r.Repo, Branch: r.Branch, Path: target,
+		})
+		successfulPaths = append(successfulPaths, target)
+	}
+	if len(refs) >= 5 {
+		// Spec §3 / Q10: no hard cap, info-log at N≥5 for ops awareness.
+		logger.Info("multi-ref ask with high count",
+			"phase", "處理中",
+			"count_total", len(refs),
+			"count_success", len(successful),
+			"count_unavailable", len(unavailable),
+		)
+	}
+	return successful, successfulPaths, unavailable, refsRoot, nil
+}
+
+// cleanupRefs removes ref worktrees in reverse order then the refs-root dir.
+// Best-effort: failures are silent because primary cleanup runs regardless,
+// and a leftover ref dir gets reaped by the next PurgeStale.
+func cleanupRefs(provider RepoProvider, paths []string, refsRoot string) {
+	for i := len(paths) - 1; i >= 0; i-- {
+		_ = provider.RemoveWorktree(paths[i])
+	}
+	if refsRoot != "" {
+		_ = os.RemoveAll(refsRoot)
+	}
 }

--- a/worker/pool/workdir_test.go
+++ b/worker/pool/workdir_test.go
@@ -1,8 +1,11 @@
 package pool
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Ivantseng123/agentdock/shared/queue"
@@ -61,6 +64,13 @@ func TestSelectProvider_ChoosesByCloneURL(t *testing.T) {
 	}
 }
 
+type fakePrepareAtCall struct {
+	cloneURL string
+	branch   string
+	token    string
+	target   string
+}
+
 type fakeRepoProvider struct {
 	prepared struct {
 		cloneURL string
@@ -68,6 +78,12 @@ type fakeRepoProvider struct {
 		token    string
 	}
 	cleaned string
+
+	// PrepareAt-related state. behavior is the per-call hook for tests that
+	// want to selectively fail clones; nil = default success (mkdir target).
+	prepareAtCalls    []fakePrepareAtCall
+	prepareAtBehavior func(target string) error
+	removed           []string
 }
 
 func (f *fakeRepoProvider) Prepare(cloneURL, branch, token string) (string, error) {
@@ -76,9 +92,26 @@ func (f *fakeRepoProvider) Prepare(cloneURL, branch, token string) (string, erro
 	f.prepared.token = token
 	return "/tmp/fake-repo", nil
 }
-func (f *fakeRepoProvider) RemoveWorktree(p string) error { f.cleaned = p; return nil }
-func (f *fakeRepoProvider) CleanAll() error               { return nil }
-func (f *fakeRepoProvider) PurgeStale() error             { return nil }
+
+func (f *fakeRepoProvider) PrepareAt(cloneURL, branch, token, targetPath string) error {
+	f.prepareAtCalls = append(f.prepareAtCalls, fakePrepareAtCall{
+		cloneURL: cloneURL, branch: branch, token: token, target: targetPath,
+	})
+	if f.prepareAtBehavior != nil {
+		return f.prepareAtBehavior(targetPath)
+	}
+	// Default: succeed and create the target dir so callers see a real path
+	// they can RemoveAll later.
+	return os.MkdirAll(targetPath, 0755)
+}
+
+func (f *fakeRepoProvider) RemoveWorktree(p string) error {
+	f.cleaned = p
+	f.removed = append(f.removed, p)
+	return nil
+}
+func (f *fakeRepoProvider) CleanAll() error   { return nil }
+func (f *fakeRepoProvider) PurgeStale() error { return nil }
 
 func TestRepoCloneProvider_ForwardsArgs(t *testing.T) {
 	fake := &fakeRepoProvider{}
@@ -160,5 +193,146 @@ func TestSkillMountInEmptyDir_ForEachRunner(t *testing.T) {
 				t.Errorf("skill file not found at %s: %v", want, err)
 			}
 		})
+	}
+}
+
+// TestPrepareRefs_PartialSuccess ensures one failed ref clone is absorbed
+// into UnavailableRefs while successful refs flow through into RefRepos.
+// This is the core "best-effort" contract from spec §4.3 / Q3.
+func TestPrepareRefs_PartialSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	primary := filepath.Join(tmp, "triage-repo-abc")
+	if err := os.MkdirAll(primary, 0755); err != nil {
+		t.Fatalf("setup primary: %v", err)
+	}
+
+	fake := &fakeRepoProvider{
+		prepareAtBehavior: func(target string) error {
+			if strings.Contains(target, "broken__repo") {
+				return fmt.Errorf("simulated clone fail")
+			}
+			return os.MkdirAll(target, 0755)
+		},
+	}
+	refs := []queue.RefRepo{
+		{Repo: "frontend/web", CloneURL: "u1", Branch: "main"},
+		{Repo: "broken/repo", CloneURL: "u2"},
+		{Repo: "backend/api", CloneURL: "u3", Branch: "release"},
+	}
+	successful, successfulPaths, unavailable, refsRoot, err :=
+		prepareRefs(fake, primary, "tkn", refs, slog.Default())
+	if err != nil {
+		t.Fatalf("prepareRefs returned err: %v", err)
+	}
+
+	if len(successful) != 2 {
+		t.Errorf("successful count = %d, want 2 (refs=%+v)", len(successful), successful)
+	}
+	if len(unavailable) != 1 || unavailable[0] != "broken/repo" {
+		t.Errorf("unavailable = %v, want [broken/repo]", unavailable)
+	}
+	if len(successfulPaths) != 2 {
+		t.Errorf("successfulPaths len = %d, want 2", len(successfulPaths))
+	}
+	if !strings.HasSuffix(refsRoot, "-refs") {
+		t.Errorf("refs root naming wrong: %s", refsRoot)
+	}
+	if !strings.HasSuffix(successful[0].Path, "frontend__web") {
+		t.Errorf("ref dir naming wrong for ref[0]: %s", successful[0].Path)
+	}
+	if successful[0].Branch != "main" {
+		t.Errorf("ref[0] branch = %q, want main", successful[0].Branch)
+	}
+	if successful[1].Branch != "release" {
+		t.Errorf("ref[1] branch = %q, want release", successful[1].Branch)
+	}
+
+	// Token is forwarded for every PrepareAt call.
+	for i, c := range fake.prepareAtCalls {
+		if c.token != "tkn" {
+			t.Errorf("prepareAtCalls[%d].token = %q, want tkn", i, c.token)
+		}
+	}
+}
+
+// TestPrepareRefs_EmptyRefs_NoOp asserts the function is a clean no-op
+// when no refs are requested — refsRoot stays empty (no mkdir) and no
+// PrepareAt calls fire.
+func TestPrepareRefs_EmptyRefs_NoOp(t *testing.T) {
+	fake := &fakeRepoProvider{}
+	successful, successfulPaths, unavailable, refsRoot, err :=
+		prepareRefs(fake, "/tmp/p", "t", nil, slog.Default())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(successful) != 0 || len(unavailable) != 0 || len(successfulPaths) != 0 {
+		t.Errorf("non-empty results for nil refs: ok=%v fail=%v paths=%v",
+			successful, unavailable, successfulPaths)
+	}
+	if refsRoot != "" {
+		t.Errorf("refsRoot = %q, want empty for nil refs", refsRoot)
+	}
+	if len(fake.prepareAtCalls) != 0 {
+		t.Errorf("expected zero PrepareAt calls, got %d", len(fake.prepareAtCalls))
+	}
+}
+
+// TestPrepareRefs_MkdirFailure surfaces refs-root mkdir errors as the
+// only failure mode that bubbles up — per-ref failures absorb to
+// `unavailable` (covered by PartialSuccess test).
+func TestPrepareRefs_MkdirFailure(t *testing.T) {
+	// Force a mkdir failure by passing a primary path whose parent is a file.
+	tmp := t.TempDir()
+	parentFile := filepath.Join(tmp, "blocker")
+	if err := os.WriteFile(parentFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// "blocker/triage-repo-x" → mkdir attempts to use blocker as parent dir.
+	primary := filepath.Join(parentFile, "triage-repo-x")
+
+	refs := []queue.RefRepo{{Repo: "any/ref", CloneURL: "u"}}
+	_, _, _, _, err :=
+		prepareRefs(&fakeRepoProvider{}, primary, "t", refs, slog.Default())
+	if err == nil {
+		t.Fatalf("expected mkdir error for primary %q, got nil", primary)
+	}
+}
+
+// TestCleanupRefs_ReverseOrder asserts cleanup walks ref worktrees in
+// reverse-add order and rm's the refs-root last. Order-sensitive only for
+// log/debug consistency — semantically the order doesn't matter, but
+// reversing matches the typical "last in, first out" cleanup pattern.
+func TestCleanupRefs_ReverseOrder(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "refs-root")
+	paths := []string{
+		filepath.Join(root, "a"),
+		filepath.Join(root, "b"),
+		filepath.Join(root, "c"),
+	}
+	for _, p := range paths {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fake := &fakeRepoProvider{}
+	cleanupRefs(fake, paths, root)
+
+	if got := fake.removed; len(got) != 3 || got[0] != paths[2] || got[2] != paths[0] {
+		t.Errorf("RemoveWorktree order = %v, want reversed of %v", got, paths)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("refs root should be removed; stat err = %v", err)
+	}
+}
+
+// TestCleanupRefs_EmptyArgs asserts no-op behavior when refs were not
+// prepared (zero paths + empty root).
+func TestCleanupRefs_EmptyArgs(t *testing.T) {
+	fake := &fakeRepoProvider{}
+	cleanupRefs(fake, nil, "")
+	if len(fake.removed) != 0 {
+		t.Errorf("expected zero RemoveWorktree calls, got %v", fake.removed)
 	}
 }

--- a/worker/prompt/builder.go
+++ b/worker/prompt/builder.go
@@ -87,6 +87,37 @@ func BuildPrompt(ctx queue.PromptContext, extraRules []string, attachments []Att
 	}
 	b.WriteString("</issue_context>\n\n")
 
+	// <ref_repos> — successful ref repos with absolute on-disk paths. Worker
+	// fills these after PrepareAt so the agent knows where to grep / read.
+	if len(ctx.RefRepos) > 0 {
+		b.WriteString("<ref_repos>\n")
+		for _, r := range ctx.RefRepos {
+			if r.Branch != "" {
+				fmt.Fprintf(&b,
+					"  <ref repo=\"%s\" branch=\"%s\" path=\"%s\"/>\n",
+					xmlEscape(r.Repo), xmlEscape(r.Branch), xmlEscape(r.Path),
+				)
+			} else {
+				fmt.Fprintf(&b,
+					"  <ref repo=\"%s\" path=\"%s\"/>\n",
+					xmlEscape(r.Repo), xmlEscape(r.Path),
+				)
+			}
+		}
+		b.WriteString("</ref_repos>\n\n")
+	}
+
+	// <unavailable_refs> — refs the user requested but worker couldn't clone.
+	// Listed by owner/name so the agent can self-declare missing context per
+	// SKILL.md's critical-fail-fast rule.
+	if len(ctx.UnavailableRefs) > 0 {
+		b.WriteString("<unavailable_refs>\n")
+		for _, repo := range ctx.UnavailableRefs {
+			fmt.Fprintf(&b, "  <repo>%s</repo>\n", xmlEscape(repo))
+		}
+		b.WriteString("</unavailable_refs>\n\n")
+	}
+
 	// <response_language> — always rendered if non-empty (the app has a default).
 	if ctx.Language != "" {
 		fmt.Fprintf(&b, "<response_language>%s</response_language>\n\n", xmlEscape(ctx.Language))

--- a/worker/prompt/builder_test.go
+++ b/worker/prompt/builder_test.go
@@ -461,3 +461,99 @@ func TestBuildPrompt_OutputRulesArray_MultipleRendered(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildPrompt_RefRepos_Rendered covers both the with-branch and
+// default-branch render paths. Default-branch refs must omit the branch
+// attribute so the agent doesn't see an empty branch="" string and infer
+// "no branch / detached HEAD" — that's not what default-branch means.
+func TestBuildPrompt_RefRepos_Rendered(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		Channel:        "c",
+		Reporter:       "r",
+		Goal:           "g",
+		RefRepos: []queue.RefRepoContext{
+			{Repo: "frontend/web", Branch: "main", Path: "/tmp/refs/frontend__web"},
+			{Repo: "backend/api", Path: "/tmp/refs/backend__api"},
+		},
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if !strings.Contains(got, `<ref_repos>`) {
+		t.Fatalf("missing <ref_repos> block:\n%s", got)
+	}
+	if !strings.Contains(got, `<ref repo="frontend/web" branch="main" path="/tmp/refs/frontend__web"/>`) {
+		t.Errorf("missing branch-attr ref render:\n%s", got)
+	}
+	if !strings.Contains(got, `<ref repo="backend/api" path="/tmp/refs/backend__api"/>`) {
+		t.Errorf("missing default-branch ref render:\n%s", got)
+	}
+	// The default-branch ref must NOT include branch="".
+	if strings.Contains(got, `<ref repo="backend/api" branch="" path=`) {
+		t.Errorf("default-branch ref leaked empty branch attribute:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_UnavailableRefs_Rendered covers the failure-list block
+// that signals to the agent which refs were requested but couldn't be
+// cloned. Used by SKILL.md's critical-fail-fast rule.
+func TestBuildPrompt_UnavailableRefs_Rendered(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages:  []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		Channel:         "c",
+		Reporter:        "r",
+		Goal:            "g",
+		UnavailableRefs: []string{"broken/repo", "missing/other"},
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if !strings.Contains(got, "<unavailable_refs>") {
+		t.Fatalf("missing <unavailable_refs> block:\n%s", got)
+	}
+	for _, want := range []string{"<repo>broken/repo</repo>", "<repo>missing/other</repo>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing unavailable entry %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestBuildPrompt_NoRefs_NoBlock asserts the existing prompt shape is
+// regression-free when no ref fields are populated — neither block renders.
+func TestBuildPrompt_NoRefs_NoBlock(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		Channel:        "c",
+		Reporter:       "r",
+		Goal:           "g",
+	}
+	got := BuildPrompt(ctx, nil, nil)
+	if strings.Contains(got, "<ref_repos>") {
+		t.Errorf("expected no <ref_repos> when empty, got:\n%s", got)
+	}
+	if strings.Contains(got, "<unavailable_refs>") {
+		t.Errorf("expected no <unavailable_refs> when empty, got:\n%s", got)
+	}
+}
+
+// TestBuildPrompt_RefRepos_BeforeResponseLanguage asserts the new block
+// slots between <issue_context> and <response_language>, matching spec §4.5.
+func TestBuildPrompt_RefRepos_BeforeResponseLanguage(t *testing.T) {
+	ctx := queue.PromptContext{
+		ThreadMessages: []queue.ThreadMessage{{User: "A", Timestamp: "1", Text: "t"}},
+		Channel:        "c",
+		Reporter:       "r",
+		Language:       "zh-TW",
+		Goal:           "g",
+		RefRepos:       []queue.RefRepoContext{{Repo: "x/y", Path: "/p"}},
+	}
+	got := BuildPrompt(ctx, nil, nil)
+
+	issueIdx := strings.Index(got, "</issue_context>")
+	refIdx := strings.Index(got, "<ref_repos>")
+	langIdx := strings.Index(got, "<response_language>")
+	if issueIdx == -1 || refIdx == -1 || langIdx == -1 {
+		t.Fatalf("missing sections: issue=%d ref=%d lang=%d", issueIdx, refIdx, langIdx)
+	}
+	if !(issueIdx < refIdx && refIdx < langIdx) {
+		t.Errorf("expected issue_context < ref_repos < response_language, got issue=%d ref=%d lang=%d",
+			issueIdx, refIdx, langIdx)
+	}
+}


### PR DESCRIPTION
## Summary

Backend half of #216 (Ask multi-repo support). PR 1 of 2 — lands without user-facing impact: worker can now consume jobs with `Job.RefRepos`, but app still emits no such jobs until PR 2 wires the Slack flow.

Spec: \`docs/superpowers/specs/2026-04-29-ask-multi-repo-design.md\`
Plan: \`docs/superpowers/plans/2026-04-29-ask-multi-repo.md\`

## What's in here

**Schema (additive, omitempty)**

- \`Job.RefRepos []RefRepo\`
- \`PromptContext.RefRepos []RefRepoContext\` (worker-filled, paths only known post-clone)
- \`PromptContext.UnavailableRefs []string\` (worker-filled)
- Old jobs (no \`ref_repos\` key) still parse byte-for-byte unchanged — covered by \`TestJob_OldJob_NoRefRepos_StillParses\`.

**Workdir layout (spec §4.2)**

Refs live at \`<primary worktree>-refs/<owner>__<repo>/\` — co-located with primary under the same cache parent (\`<repo_cache.dir>/worktrees/\`). Each ref is an independent worktree (own \`.git/\`), so primary's git operations don't recurse into them. Cleanup naturally inherits existing \`PurgeStale\` / \`agentdock worker --clean-cache\` paths.

This is a reversal of the original #215 layout (\`.refs/\` inside primary cwd) — see spec §1 for rationale.

**Worker prepare flow (spec §4.3, Q3)**

- New interface method: \`RepoProvider.PrepareAt(cloneURL, branch, token, target)\` — caller-supplied path, vs the existing \`Prepare\` which uses the cache's default worktree dir.
- \`prepareRefs\` helper: sequential clone (forced by \`RepoCache\` global mutex), partial-success contract — per-ref failures absorb into \`UnavailableRefs\` and never abort the job.
- \`cleanupRefs\` runs in reverse order: ref worktrees → refs-root dir → primary (via existing \`provider.Cleanup\` defer chain). Cancellation path inherits cleanup automatically.

**Three-layer write protection — Layer 3 ships in this PR (spec §4.6)**

- \`RefViolationCallback\` type abstraction so #217 can install a strict callback without restructuring.
- \`askLenientRefViolation\`: warn-log + metric, do NOT fail the job. Worktree cleanup runs regardless, so writes have no persistent effect.
- New counter: \`ask_ref_write_violations_total{repo}\`.

Layers 1 + 2 (SKILL.md soft guidance + \`output_rules\` hard injection) ship with PR 2.

## Tests

| Test | Purpose |
|---|---|
| \`TestJob_RefRepos_RoundTrip\` / \`TestJob_OldJob_NoRefRepos_StillParses\` / \`TestJob_RefRepos_OmitEmpty\` | Schema marshals correctly + backwards-compat |
| \`TestPromptContext_RefFields_RoundTrip\` / \`TestPromptContext_RefFields_OmitEmpty\` | New PromptContext fields |
| \`TestBuildPrompt_RefRepos_Rendered\` (with/without branch) | Prompt rendering for successful refs |
| \`TestBuildPrompt_UnavailableRefs_Rendered\` | Failure-list block |
| \`TestBuildPrompt_NoRefs_NoBlock\` | Regression: existing prompt shape unchanged when no refs |
| \`TestBuildPrompt_RefRepos_BeforeResponseLanguage\` | Block ordering per spec §4.5 |
| \`TestPrepareRefs_PartialSuccess\` | Core best-effort contract — one fail, two succeed |
| \`TestPrepareRefs_EmptyRefs_NoOp\` / \`TestPrepareRefs_MkdirFailure\` | Edge cases |
| \`TestCleanupRefs_ReverseOrder\` / \`TestCleanupRefs_EmptyArgs\` | Cleanup ordering |
| \`TestRunRefGuard_DetectsViolation\` (real git worktree) / \`*_CleanWorktree_NoCallback\` / \`*_NilCallback_NoOp\` / \`*_EmptyRefs_NoOp\` | Post-execute guard |
| \`TestTruncateRefDiff\` | Log-volume cap |
| \`TestExecuteJob_MultiRepo_EndToEnd\` | Full pipeline integration with real git: schema → prepareRefs → PromptContext fill → builder renders ref blocks → guard fires on dirty refs → cleanup walks paths in reverse |

End-to-end test log capture (success + failure + violation in one run):

\`\`\`
INFO 準備 repo 中
INFO Repo 已就緒 path=.../triage-repo-abc
WARN ref clone failed; continuing with partial context ref=broken/repo
INFO Refs 已就緒 count_success=1 count_unavailable=1
INFO Prompt 已組裝 length=986
INFO Agent 執行完成
WARN agent wrote into ref repo (lenient: not failing job) ref=frontend/web diff_preview=\"?? agent-wrote-here.txt\"
\`\`\`

## Test plan

- [ ] CI green
- [ ] Worker still works on existing single-repo Ask jobs (no regression — should be a no-op since \`RefRepos == nil\` skips the new branch entirely)
- [ ] After PR 2 lands: real Slack walk-through

## Out of scope (deferred to PR 2)

- App workflow Slack phases (\`ask_ref_decide\` / pick / continue / branch)
- \`output_rules\` dynamic injection in \`BuildJob\`
- SKILL.md \"Reference repos\" section
- Manual e2e + AC verification

Refs #216
🤖 Generated with [Claude Code](https://claude.com/claude-code)