### PR TITLE
feat(workflow/ask): multi-repo frontend (Slack phases, output_rules, SKILL)

### DIFF
--- a/app/agents/skills/ask-assistant/SKILL.md
+++ b/app/agents/skills/ask-assistant/SKILL.md
@@ -189,6 +189,30 @@ bot useful. Don't cross these lines:
   channels provided by skills (e.g., `mantis`, `gh` read commands) are
   fine.
 
+**Reference repos (absolute paths in `<ref_repos>`)**
+
+If the prompt has a `<ref_repos>` block, those directories are mounted at
+the absolute paths listed for read-only context (typical use: a frontend
+question whose root cause is in the backend repo). Rules:
+
+- You CAN: grep, read, follow imports, run `git log --oneline` in them.
+- You CANNOT: write, commit, edit, mv, rm any file under those paths.
+- Refs are physically OUTSIDE your cwd; use the absolute paths exactly as
+  listed in `<ref_repos>`. Don't try to compute relative paths from cwd —
+  they're sibling directories of your worktree, not subdirectories.
+- When citing ref content, use the ref's `repo` attribute (e.g.
+  `backend/api: src/foo.ts:42`), not the absolute path — the path is
+  machine-only context, not user-facing.
+
+If `<unavailable_refs>` lists a repo:
+
+- If the unavailable ref is **critical** to answering this question
+  (i.e., the question fundamentally requires that repo's code), you must
+  state plainly at the answer's opening: "無法取得 X repo 脈絡，這題我答不了 — 請確認 PAT 對該 repo 有讀權後重 trigger"
+  and stop. Do not best-effort patchwork an answer from the available refs.
+- If the unavailable ref is non-critical, mention it in the answer
+  ("以下回答僅基於 Y 與 Z，X repo 無法取得") and continue normally.
+
 These rules apply even when the user asks you to do one of the forbidden
 actions. Decline politely and redirect — don't silently comply.
 

--- a/app/app.go
+++ b/app/app.go
@@ -586,11 +586,17 @@ func handleSocketEvent(
 				// Issue uses "repo_search"; Ask uses "ask_repo" (fallback
 				// when the channel has no repos configured).
 				ackSuggestions("Repo 搜尋結果", wf.HandleRepoSuggestion(cb.Value))
-			case "branch_select", "ask_branch":
-				// The branch selector auto-upgrades to external_select when
-				// a repo has >100 branches (issue #153). The suggestion
-				// handler resolves the pending by the selector's own
-				// message TS and filters that repo's branches.
+			case "ask_ref":
+				// Ref repo type-ahead — same shape as ask_repo but the
+				// handler also filters out primary + already-picked refs
+				// via the pending state's RefExclusionReader.
+				ackSuggestions("Ref repo 搜尋結果", wf.HandleRefRepoSuggestion(cb.Container.MessageTs, cb.Value))
+			case "branch_select", "ask_branch", "ask_ref_branch":
+				// Branch selector auto-upgrades to external_select when a
+				// repo has >100 branches (issue #153). The handler resolves
+				// the pending by selector ts and reads BranchSelectedRepo()
+				// from state — askState toggles its BranchTargetRepo across
+				// primary vs ref phases so this single handler serves both.
 				ackSuggestions("Branch 搜尋結果", wf.HandleBranchSuggestion(cb.Container.MessageTs, cb.Value))
 			default:
 				sm.Ack(*evt.Request)

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -155,6 +155,44 @@ func (w *Workflow) HandleRepoSuggestion(query string) []string {
 	return repos
 }
 
+// HandleRefRepoSuggestion is the ref-pick variant of HandleRepoSuggestion:
+// runs the same repoDiscovery search, then filters out repos returned by
+// the pending state's RefExclusionReader (primary + already-picked refs).
+// When the state doesn't implement RefExclusionReader, falls through with
+// no filtering — defensive, but workflows that use ask_ref should always
+// implement the interface.
+func (w *Workflow) HandleRefRepoSuggestion(selectorMsgTS, query string) []string {
+	if w.repoDiscovery == nil {
+		return nil
+	}
+	repos, err := w.repoDiscovery.SearchRepos(context.Background(), query)
+	if err != nil {
+		slog.Warn("Ref repo 搜尋失敗", "phase", "失敗", "error", err)
+		return nil
+	}
+	w.mu.Lock()
+	pending, ok := w.pending[selectorMsgTS]
+	w.mu.Unlock()
+	if !ok || pending == nil {
+		return repos
+	}
+	excluder, ok := pending.State.(workflow.RefExclusionReader)
+	if !ok {
+		return repos
+	}
+	excluded := make(map[string]bool)
+	for _, r := range excluder.RefExclusions() {
+		excluded[r] = true
+	}
+	out := repos[:0:len(repos)]
+	for _, r := range repos {
+		if !excluded[r] {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // maxBranchSuggestions caps the type-ahead result list. External_select is
 // also bounded at 100 options per Slack's own API limit.
 const maxBranchSuggestions = 100

--- a/app/bot/workflow.go
+++ b/app/bot/workflow.go
@@ -18,7 +18,13 @@ import (
 // evicted and the thread is condensed to the "selection timed out"
 // breadcrumb. Per-Workflow field so tests can shorten it without racing on
 // package state.
-const defaultPendingTimeout = 1 * time.Minute
+//
+// 5min covers realistic human pauses between clicks (re-reading the
+// prompt, switching context to verify a repo name) without keeping
+// abandoned sessions alive forever. Was 1min — too tight for the new
+// multi-step Ask ref flow (#216) where a 4-ref pick takes more clicks
+// than the previous max.
+const defaultPendingTimeout = 5 * time.Minute
 
 // Workflow is the thin Slack-side handler. Real triage logic lives in
 // app/workflow workflows reached through the dispatcher.
@@ -288,6 +294,15 @@ var transitionalValues = map[string]bool{
 	"跳過":             true, // description prompt: "跳過"
 	"back_to_repo":   true, // issue/ask back button to repo picker
 	"back_to_attach": true, // ask back from repo picker to attach prompt
+	// Ref flow (#216) — every navigation pivot is a no-info choice; the
+	// substantive picks are the ref repo + branch themselves, which still
+	// leave breadcrumbs. Without these markings, a 3-ref ask grows by
+	// 8+ extra ack lines (decide+more*N+done+back).
+	"add":            true, // ask_ref_decide: "加入"
+	"more":           true, // ask_ref_continue: "再加一個 ref"
+	"done":           true, // ask_ref_continue: "開始問問題"
+	"back_to_decide": true, // ask_ref_pick: "← 不加 ref" (static button value)
+	"← 不加 ref":       true, // ask_ref_pick: external_select cancel button label
 }
 
 // isTransitionalValue reports whether a selection value represents a pure
@@ -344,8 +359,23 @@ func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, tr
 		// cleanup keeps this one, deletes everything else.
 		pending.DSelectorAckTS = selectorMsgTS
 		pending.SessionMsgTSs = removeTS(pending.SessionMsgTSs, selectorMsgTS)
+	} else if pending.NextAckMerges && pending.LastAckTS != "" && pending.LastAckValue != "" {
+		// Merge into the previous breadcrumb: e.g. "✅ owner/repo" becomes
+		// "✅ owner/repo, main" after the branch pick. Drops the standalone
+		// branch ack line so the thread doesn't show two breadcrumbs for
+		// what reads to the user as a single (repo + branch) decision.
+		combined := pending.LastAckValue + ", " + value
+		_ = w.slack.UpdateMessage(channelID, pending.LastAckTS, ":white_check_mark: "+combined)
+		_ = w.slack.DeleteMessage(channelID, selectorMsgTS)
+		pending.SessionMsgTSs = removeTS(pending.SessionMsgTSs, selectorMsgTS)
+		pending.LastAckValue = combined
+		// LastAckTS unchanged — still pointing at the merged breadcrumb.
 	} else {
 		_ = w.slack.UpdateMessage(channelID, selectorMsgTS, ":white_check_mark: "+value)
+		// Track this ack so a later MergeWithLastAck selector can fold its
+		// pick into our breadcrumb instead of leaving a standalone line.
+		pending.LastAckTS = selectorMsgTS
+		pending.LastAckValue = value
 		// Remember the repo ack so a later "重新選 repo" click can delete it —
 		// otherwise every rejected repo pick leaves behind a ":white_check_mark:
 		// owner/repo" line the user already disowned.
@@ -353,6 +383,10 @@ func (w *Workflow) HandleSelection(channelID, actionID, value, selectorMsgTS, tr
 			pending.RepoAckTS = selectorMsgTS
 		}
 	}
+	// Single-shot flag: reset whether or not we merged this round, so the
+	// next selector's MergeWithLastAck (or its absence) is the authoritative
+	// signal — never carry a stale true forward.
+	pending.NextAckMerges = false
 	step, err := w.dispatcher.HandleSelection(ctx, pending, value)
 	if err != nil {
 		w.logger.Error("HandleSelection dispatch failed", "phase", "失敗", "error", err)
@@ -642,6 +676,10 @@ func (w *Workflow) executeStep(ctx context.Context, pending *workflow.Pending, s
 			}
 			return
 		}
+		// Latch MergeWithLastAck onto pending so the next click merges its
+		// ack into the previous breadcrumb. Always set explicitly (true OR
+		// false) so a stale "true" from a prior selector can't carry over.
+		pending.NextAckMerges = step.Selector.MergeWithLastAck
 		w.storePending(selectorTS, pending)
 
 	case workflow.NextStepOpenModal:

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -48,15 +48,50 @@ type askState struct {
 	// descriptionPromptStep runs twice for the same ask (shouldn't happen
 	// in current flow, but cheap defense against future back-nav changes).
 	priorAnswerFetchAttempted bool
+
+	// Multi-repo (ref) state. AddRefs is the user's yes/no on the decide
+	// prompt; RefRepos accumulates as the user picks each ref (Branch is
+	// filled later in the per-ref branch loop). RefBranchIdx steps the
+	// per-ref branch picker forward. BranchTargetRepo is the transient
+	// "which repo are we asking branches for right now" — set before each
+	// branch select phase (primary OR ref) so BranchSelectedRepo can stay
+	// a single-method interface (workflow.BranchStateReader) that doesn't
+	// need to know about phases.
+	AddRefs          bool
+	RefRepos         []queue.RefRepo
+	RefBranchIdx     int
+	BranchTargetRepo string
 }
 
 // BranchSelectedRepo satisfies workflow.BranchStateReader so app/bot can
 // read the repo off a Pending.State without depending on askState.
+//
+// Reads BranchTargetRepo (transient, set before each branch select phase)
+// rather than SelectedRepo directly — for primary branch select we set
+// BranchTargetRepo = SelectedRepo; for per-ref branch select we set it to
+// the current ref's repo. This way BranchStateReader stays phase-agnostic.
 func (s *askState) BranchSelectedRepo() string {
 	if s == nil {
 		return ""
 	}
-	return s.SelectedRepo
+	return s.BranchTargetRepo
+}
+
+// RefExclusions returns the repos that should NOT appear as ref candidates:
+// the primary plus any refs already picked. Used by HandleRefRepoSuggestion
+// to filter type-ahead results when the channel has no static repo list.
+func (s *askState) RefExclusions() []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, 0, 1+len(s.RefRepos))
+	if s.SelectedRepo != "" {
+		out = append(out, s.SelectedRepo)
+	}
+	for _, r := range s.RefRepos {
+		out = append(out, r.Repo)
+	}
+	return out
 }
 
 // NewAskWorkflow constructs a workflow instance.
@@ -194,7 +229,48 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 			return NextStep{Kind: NextStepCancel}, nil
 		}
 		st.SelectedBranch = value
-		return w.priorAnswerOrDescriptionStep(p), nil
+		return w.maybeAskRefStep(p), nil
+
+	case "ask_ref_decide":
+		if value == "skip" {
+			st.AddRefs = false
+			return w.priorAnswerOrDescriptionStep(p), nil
+		}
+		// "add" → enter the ref-pick loop.
+		st.AddRefs = true
+		return w.refPickStep(p), nil
+
+	case "ask_ref_pick":
+		// Cancellation (returning to attach prompt etc.) — bail out of refs
+		// entirely and proceed to prior-answer/description.
+		if value == "back_to_decide" || value == "ask_ref_back" {
+			st.AddRefs = false
+			return w.priorAnswerOrDescriptionStep(p), nil
+		}
+		st.RefRepos = append(st.RefRepos, queue.RefRepo{
+			Repo:     value,
+			CloneURL: cleanCloneURL(value),
+		})
+		return w.refContinueStep(p), nil
+
+	case "ask_ref_continue":
+		switch value {
+		case "more":
+			return w.refPickStep(p), nil
+		case "done":
+			st.RefBranchIdx = 0
+			return w.nextRefBranchStep(p), nil
+		default:
+			return NextStep{Kind: NextStepError, ErrorText: fmt.Sprintf(":x: unexpected ref_continue value: %q", value)}, nil
+		}
+
+	case "ask_ref_branch":
+		if value == "取消" {
+			return NextStep{Kind: NextStepCancel}, nil
+		}
+		st.RefRepos[st.RefBranchIdx].Branch = value
+		st.RefBranchIdx++
+		return w.nextRefBranchStep(p), nil
 
 	case "ask_prior_answer_prompt":
 		// Standalone yes/no on whether to carry the bot's last substantive
@@ -282,9 +358,10 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 		if len(branches) == 1 {
 			st.SelectedBranch = branches[0]
 		}
-		return w.priorAnswerOrDescriptionStep(p)
+		return w.maybeAskRefStep(p)
 	}
 
+	st.BranchTargetRepo = st.SelectedRepo
 	p.Phase = "ask_branch_select"
 	options := make([]SelectorOption, 0, len(branches)+1)
 	for _, b := range branches {
@@ -348,6 +425,189 @@ func (w *AskWorkflow) priorAnswerOrDescriptionStep(p *Pending) NextStep {
 	return w.descriptionPromptStep(p)
 }
 
+// refCandidates returns the channel-allowed repo list minus primary and
+// already-picked refs. Returns useExternalSearch=true when the channel uses
+// type-ahead repo search instead of a static list — caller dispatches to
+// the search-style selector with HandleRefRepoSuggestion as the suggestion
+// handler.
+func (w *AskWorkflow) refCandidates(p *Pending) (list []string, useExternalSearch bool) {
+	st, _ := p.State.(*askState)
+	cc := w.cfg.ChannelDefaults
+	if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+		cc = c
+	}
+	repos := cc.GetRepos()
+	if len(repos) == 0 {
+		// External search: filtering happens in HandleRefRepoSuggestion.
+		return nil, true
+	}
+	picked := make(map[string]bool, len(st.RefRepos))
+	for _, r := range st.RefRepos {
+		picked[r.Repo] = true
+	}
+	for _, r := range repos {
+		if r == st.SelectedRepo || picked[r] {
+			continue
+		}
+		list = append(list, r)
+	}
+	return list, false
+}
+
+// maybeAskRefStep is the single entry into the ref flow. Skips entirely
+// when no candidate repos exist (channel has only primary) — keeps the
+// thread free of the "加入參考 repo？" message in that case (spec AC-12).
+func (w *AskWorkflow) maybeAskRefStep(p *Pending) NextStep {
+	list, useExternalSearch := w.refCandidates(p)
+	if !useExternalSearch && len(list) == 0 {
+		return w.priorAnswerOrDescriptionStep(p)
+	}
+	p.Phase = "ask_ref_decide"
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":books: 加入參考 repo 嗎？(唯讀脈絡)",
+			ActionID: "ask_ref_decide",
+			Options: []SelectorOption{
+				{Label: "加入", Value: "add"},
+				{Label: "不用", Value: "skip"},
+			},
+		},
+		Pending: p,
+	}
+}
+
+// refPickStep posts the single-select picker for "next ref repo". Re-uses
+// the existing selector infrastructure (button row / static_select /
+// external_select auto-dispatch) — when the channel has no static list,
+// falls back to type-ahead search via the ask_ref action_id which app/app.go
+// routes to HandleRefRepoSuggestion (filters primary + already-picked).
+func (w *AskWorkflow) refPickStep(p *Pending) NextStep {
+	st := p.State.(*askState)
+	list, useExternalSearch := w.refCandidates(p)
+	p.Phase = "ask_ref_pick"
+	prompt := ":point_right: 選參考 repo:"
+	if len(st.RefRepos) > 0 {
+		prompt = fmt.Sprintf(":point_right: 選下一個參考 repo（已加 %d 個）:", len(st.RefRepos))
+	}
+	if useExternalSearch {
+		return NextStep{
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:         prompt,
+				ActionID:       "ask_ref",
+				Searchable:     true,
+				Placeholder:    "Type to search repos...",
+				CancelActionID: "ask_ref_back",
+				CancelLabel:    "← 不加 ref",
+			},
+			Pending: p,
+		}
+	}
+	options := make([]SelectorOption, 0, len(list)+1)
+	for _, r := range list {
+		options = append(options, SelectorOption{Label: r, Value: r})
+	}
+	options = append(options, SelectorOption{Label: "← 不加 ref", Value: "back_to_decide"})
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   prompt,
+			ActionID: "ask_ref",
+			Options:  options,
+		},
+		Pending: p,
+	}
+}
+
+// refContinueStep is the loop pivot after each ref pick: "再加一個 / 開始問問題".
+// When the candidate pool is exhausted (static list and all picked), the
+// "再加一個" option drops so the user can only proceed to the question.
+func (w *AskWorkflow) refContinueStep(p *Pending) NextStep {
+	st := p.State.(*askState)
+	p.Phase = "ask_ref_continue"
+	list, useExternalSearch := w.refCandidates(p)
+	options := []SelectorOption{
+		{Label: "開始問問題", Value: "done"},
+	}
+	// Allow another ref unless the static-list pool is fully consumed.
+	// External search is unbounded so always offer "再加一個" there.
+	if useExternalSearch || len(list) > 0 {
+		options = append([]SelectorOption{{Label: "再加一個 ref", Value: "more"}}, options...)
+	}
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   fmt.Sprintf(":heavy_plus_sign: 已加 %d 個 ref。", len(st.RefRepos)),
+			ActionID: "ask_ref_continue",
+			Options:  options,
+		},
+		Pending: p,
+	}
+}
+
+// nextRefBranchStep advances the per-ref branch picker. Mirrors the
+// primary's afterRepoSelectedStep skip rules: branch_select disabled OR
+// ≤ 1 branch resolved → use the (sole or default) branch and move on.
+// Otherwise show a type-ahead branch picker. When idx exhausts the ref
+// list, drops out of the ref flow into the prior-answer/description path.
+func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
+	st := p.State.(*askState)
+	if st.RefBranchIdx >= len(st.RefRepos) {
+		return w.priorAnswerOrDescriptionStep(p)
+	}
+	target := st.RefRepos[st.RefBranchIdx].Repo
+
+	cc := w.cfg.ChannelDefaults
+	if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+		cc = c
+	}
+	if !cc.IsBranchSelectEnabled() {
+		// All refs use default branch (Branch stays empty).
+		st.RefBranchIdx++
+		return w.nextRefBranchStep(p)
+	}
+
+	var branches []string
+	if len(cc.Branches) > 0 {
+		branches = cc.Branches
+	} else if w.repoCache != nil {
+		ghToken := ""
+		if w.cfg.Secrets != nil {
+			ghToken = w.cfg.Secrets["GH_TOKEN"]
+		}
+		if rp, err := w.repoCache.EnsureRepo(target, ghToken); err == nil {
+			if lb, lerr := w.repoCache.ListBranches(rp); lerr == nil {
+				branches = lb
+			}
+		}
+	}
+	if len(branches) <= 1 {
+		if len(branches) == 1 {
+			st.RefRepos[st.RefBranchIdx].Branch = branches[0]
+		}
+		st.RefBranchIdx++
+		return w.nextRefBranchStep(p)
+	}
+
+	st.BranchTargetRepo = target
+	p.Phase = "ask_ref_branch"
+	options := make([]SelectorOption, 0, len(branches)+1)
+	for _, b := range branches {
+		options = append(options, SelectorOption{Label: b, Value: b})
+	}
+	options = append(options, SelectorOption{Label: "取消", Value: "取消"})
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   fmt.Sprintf(":point_right: Which branch of ref `%s`?", target),
+			ActionID: "ask_ref_branch",
+			Options:  options,
+		},
+		Pending: p,
+	}
+}
+
 // descriptionPromptStep returns the 補充說明 / 跳過 selector. The opt-in
 // 帶上次回覆 button used to live here but was promoted to its own phase —
 // see priorAnswerOrDescriptionStep for the routing wrapper. ActionID mirrors
@@ -392,6 +652,19 @@ func (w *AskWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, str
 		priorAnswer = []queue.ThreadMessage{*st.PriorAnswer}
 	}
 
+	// Output rules injection: when refs are attached, append two hard rules
+	// (spec §4.6 Layer 2). Read-only enforcement + critical-fail-fast match
+	// SKILL.md §5's Reference repos section. Inject regardless of whether
+	// the refs successfully cloned — user intent was ref-aware ask, so the
+	// rules are relevant even if all refs end up unavailable.
+	outputRules := w.cfg.Workflows.Ask.Prompt.OutputRules
+	if len(st.RefRepos) > 0 {
+		outputRules = append(outputRules,
+			"不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。",
+			"若 <unavailable_refs> 含關鍵 ref，必須在答案開頭聲明「無法取得 X repo 脈絡，無法回答」並停手；不要 best-effort 拼湊。",
+		)
+	}
+
 	job := &queue.Job{
 		ID:          reqID,
 		RequestID:   reqID,
@@ -402,11 +675,12 @@ func (w *AskWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, str
 		Repo:        st.SelectedRepo,
 		Branch:      st.SelectedBranch,
 		CloneURL:    cloneURL,
+		RefRepos:    st.RefRepos,
 		SubmittedAt: time.Now(),
 		PromptContext: &queue.PromptContext{
 			Goal:             w.cfg.Workflows.Ask.Prompt.Goal,
 			ResponseSchema:   w.cfg.Workflows.Ask.Prompt.ResponseSchema,
-			OutputRules:      w.cfg.Workflows.Ask.Prompt.OutputRules,
+			OutputRules:      outputRules,
 			Language:         w.cfg.PromptDefaults.Language,
 			ExtraDescription: st.Question,
 			Branch:           st.SelectedBranch,
@@ -414,7 +688,10 @@ func (w *AskWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, str
 			Reporter:         p.Reporter,
 			AllowWorkerRules: w.cfg.PromptDefaults.IsWorkerRulesAllowed(),
 			PriorAnswer:      priorAnswer,
-			// ThreadMessages, Attachments filled by downstream submit-helper.
+			// ThreadMessages, Attachments, RefRepos, UnavailableRefs filled
+			// by downstream — ThreadMessages/Attachments by submit-helper,
+			// RefRepos/UnavailableRefs by worker after PrepareAt resolves
+			// per-ref absolute paths.
 		},
 		// Skills is populated by submitJob via loadSkills(); leaving it unset
 		// here (instead of Skills: nil) avoids the misleading impression that

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -242,8 +242,11 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 
 	case "ask_ref_pick":
 		// Cancellation (returning to attach prompt etc.) — bail out of refs
-		// entirely and proceed to prior-answer/description.
-		if value == "back_to_decide" || value == "ask_ref_back" {
+		// entirely and proceed to prior-answer/description. Match both the
+		// static-button value ("back_to_decide") and the external-select
+		// cancel button's label ("← 不加 ref"), since the slack adapter sends
+		// the label as the action value for cancel buttons.
+		if value == "back_to_decide" || value == "ask_ref_back" || value == "← 不加 ref" {
 			st.AddRefs = false
 			return w.priorAnswerOrDescriptionStep(p), nil
 		}
@@ -251,15 +254,20 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 			Repo:     value,
 			CloneURL: cleanCloneURL(value),
 		})
-		return w.refContinueStep(p), nil
+		// Inline branch pick — ask THIS ref's branch immediately so the
+		// repo+branch decision is one coherent step from the user's view.
+		// Earlier design separated all picks from all branches, but that
+		// asks the user to remember "did I want main for frontend, or for
+		// backend?" 3 refs later. Inline matches primary's flow shape.
+		st.RefBranchIdx = len(st.RefRepos) - 1
+		return w.nextRefBranchStep(p), nil
 
 	case "ask_ref_continue":
 		switch value {
 		case "more":
 			return w.refPickStep(p), nil
 		case "done":
-			st.RefBranchIdx = 0
-			return w.nextRefBranchStep(p), nil
+			return w.priorAnswerOrDescriptionStep(p), nil
 		default:
 			return NextStep{Kind: NextStepError, ErrorText: fmt.Sprintf(":x: unexpected ref_continue value: %q", value)}, nil
 		}
@@ -269,8 +277,8 @@ func (w *AskWorkflow) Selection(ctx context.Context, p *Pending, value string) (
 			return NextStep{Kind: NextStepCancel}, nil
 		}
 		st.RefRepos[st.RefBranchIdx].Branch = value
-		st.RefBranchIdx++
-		return w.nextRefBranchStep(p), nil
+		// Branch picked → loop pivot ("再加一個 / 完成").
+		return w.refContinueStep(p), nil
 
 	case "ask_prior_answer_prompt":
 		// Standalone yes/no on whether to carry the bot's last substantive
@@ -371,9 +379,10 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 	return NextStep{
 		Kind: NextStepSelector,
 		Selector: &SelectorSpec{
-			Prompt:   fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
-			ActionID: "ask_branch",
-			Options:  options,
+			Prompt:           fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
+			ActionID:         "ask_branch",
+			Options:          options,
+			MergeWithLastAck: true, // collapse "✅ repo" + "✅ branch" → "✅ repo, branch"
 		},
 		Pending: p,
 	}
@@ -546,16 +555,18 @@ func (w *AskWorkflow) refContinueStep(p *Pending) NextStep {
 	}
 }
 
-// nextRefBranchStep advances the per-ref branch picker. Mirrors the
-// primary's afterRepoSelectedStep skip rules: branch_select disabled OR
-// ≤ 1 branch resolved → use the (sole or default) branch and move on.
-// Otherwise show a type-ahead branch picker. When idx exhausts the ref
-// list, drops out of the ref flow into the prior-answer/description path.
+// nextRefBranchStep handles the branch decision for the just-picked ref
+// (st.RefRepos[RefBranchIdx]). Same skip rules as primary:
+//   - branch_select disabled  → no picker, leave Branch empty
+//   - ≤ 1 branch resolved     → auto-fill (or leave empty), no picker
+//   - otherwise               → show picker
+//
+// In all "no picker" cases the next step is refContinueStep (loop pivot),
+// not priorAnswerOrDescriptionStep — the user is always given a chance to
+// add another ref or end the loop, even when individual branch choices
+// are skipped.
 func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
 	st := p.State.(*askState)
-	if st.RefBranchIdx >= len(st.RefRepos) {
-		return w.priorAnswerOrDescriptionStep(p)
-	}
 	target := st.RefRepos[st.RefBranchIdx].Repo
 
 	cc := w.cfg.ChannelDefaults
@@ -563,9 +574,7 @@ func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
 		cc = c
 	}
 	if !cc.IsBranchSelectEnabled() {
-		// All refs use default branch (Branch stays empty).
-		st.RefBranchIdx++
-		return w.nextRefBranchStep(p)
+		return w.refContinueStep(p)
 	}
 
 	var branches []string
@@ -586,8 +595,7 @@ func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
 		if len(branches) == 1 {
 			st.RefRepos[st.RefBranchIdx].Branch = branches[0]
 		}
-		st.RefBranchIdx++
-		return w.nextRefBranchStep(p)
+		return w.refContinueStep(p)
 	}
 
 	st.BranchTargetRepo = target
@@ -600,9 +608,10 @@ func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
 	return NextStep{
 		Kind: NextStepSelector,
 		Selector: &SelectorSpec{
-			Prompt:   fmt.Sprintf(":point_right: Which branch of ref `%s`?", target),
-			ActionID: "ask_ref_branch",
-			Options:  options,
+			Prompt:           fmt.Sprintf(":point_right: Which branch of ref `%s`?", target),
+			ActionID:         "ask_ref_branch",
+			Options:          options,
+			MergeWithLastAck: true, // collapse ref's "✅ repo" + "✅ branch" → "✅ repo, branch"
 		},
 		Pending: p,
 	}

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -236,6 +236,12 @@ func TestAskWorkflow_Selection_AttachExternalSearchIncludesCancel(t *testing.T) 
 
 func TestAskWorkflow_Selection_BranchPickGoesToDescriptionPrompt(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
+	// Channel has just one repo (== the primary about to be picked), so
+	// after branch pick maybeAskRefStep finds 0 ref candidates and falls
+	// through to the description prompt without showing ref_decide. Without
+	// this static list, the channel would default to external search and
+	// the new ref flow would always offer a decide step.
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar"}
 	p := &Pending{Phase: "ask_branch_select", State: &askState{Question: "Q", AttachRepo: true, SelectedRepo: "foo/bar"}, ChannelID: "C1", ThreadTS: "1.0"}
 	step, err := w.Selection(context.Background(), p, "feature/xyz")
 	if err != nil {
@@ -260,6 +266,9 @@ func TestAskWorkflow_Selection_SingleBranchSkipsSelector(t *testing.T) {
 	trueVal := true
 	w.cfg.ChannelDefaults.BranchSelect = &trueVal
 	w.cfg.ChannelDefaults.Branches = []string{"main"}
+	// Same single-repo channel setup as the branch-pick test — keeps this
+	// test focused on the branch-skip behaviour, not on the ref flow.
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar"}
 	p := &Pending{Phase: "ask_repo_select", State: &askState{Question: "Q", AttachRepo: true}, ChannelID: "C1", ThreadTS: "1.0"}
 	step, err := w.Selection(context.Background(), p, "foo/bar")
 	if err != nil {
@@ -852,4 +861,462 @@ func TestAskWorkflow_HandleResult_SchemaPathHasNoBanner(t *testing.T) {
 	if !strings.Contains(last, "the answer is 42") {
 		t.Errorf("schema path must post the parsed answer; posted: %q", last)
 	}
+}
+
+// ── Multi-repo (ref) tests ───────────────────────────────────────────────────
+
+// TestAskWorkflow_RefFlow_DecidePromptOffered covers the entry to the ref
+// flow after primary branch is picked: ref candidates exist (channel has
+// extra repos beyond primary) so ask_ref_decide fires.
+func TestAskWorkflow_RefFlow_DecidePromptOffered(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
+	p := &Pending{
+		Phase:     "ask_branch_select",
+		State:     &askState{Question: "Q", AttachRepo: true, SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_decide" {
+		t.Fatalf("Phase = %q, want ask_ref_decide", p.Phase)
+	}
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("decide selector should have 2 options (加入/不用), got %d", len(step.Selector.Options))
+	}
+}
+
+// TestAskWorkflow_RefFlow_ZeroCandidatesSkipsDecide covers AC-12: when the
+// channel's static repo list contains only primary, the ref decide phase
+// is skipped entirely so the thread doesn't see "加入參考 repo？".
+func TestAskWorkflow_RefFlow_ZeroCandidatesSkipsDecide(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar"} // primary == only repo
+	p := &Pending{
+		Phase:     "ask_branch_select",
+		State:     &askState{Question: "Q", AttachRepo: true, SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase == "ask_ref_decide" {
+		t.Errorf("Phase = ask_ref_decide; want it skipped (0 candidates)")
+	}
+	if p.Phase != "ask_description_prompt" {
+		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
+	}
+}
+
+// TestAskWorkflow_RefFlow_DecideAddRoutesToPick covers the "加入" → ref pick
+// transition. AddRefs flips true and the picker phase appears.
+func TestAskWorkflow_RefFlow_DecideAddRoutesToPick(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
+	p := &Pending{
+		Phase:     "ask_ref_decide",
+		State:     &askState{Question: "Q", AttachRepo: true, SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "add")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_pick" {
+		t.Errorf("Phase = %q, want ask_ref_pick", p.Phase)
+	}
+	st := p.State.(*askState)
+	if !st.AddRefs {
+		t.Error("AddRefs should be true after 加入")
+	}
+}
+
+// TestAskWorkflow_RefFlow_DecideSkipRoutesToPriorAnswer covers the "不用"
+// path — AddRefs stays false and we proceed to the existing prior-answer/
+// description flow without touching ref state.
+func TestAskWorkflow_RefFlow_DecideSkipRoutesToPriorAnswer(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
+	p := &Pending{
+		Phase:     "ask_ref_decide",
+		State:     &askState{Question: "Q", AttachRepo: true, SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_description_prompt" {
+		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
+	}
+	st := p.State.(*askState)
+	if st.AddRefs {
+		t.Error("AddRefs should remain false after skip")
+	}
+	if len(st.RefRepos) != 0 {
+		t.Errorf("RefRepos should be empty, got %v", st.RefRepos)
+	}
+}
+
+// TestAskWorkflow_RefFlow_PickFiltersPrimary covers AC-10: primary must not
+// appear in the ref candidate list.
+func TestAskWorkflow_RefFlow_PickFiltersPrimary(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
+	p := &Pending{
+		Phase:     "ask_ref_decide",
+		State:     &askState{AttachRepo: true, SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "add")
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "foo/bar" {
+			t.Errorf("primary foo/bar must not appear in ref candidates; got %v", values)
+		}
+	}
+	// Should contain the two non-primary repos + the back option.
+	wantSet := map[string]bool{"baz/qux": true, "third/repo": true, "back_to_decide": true}
+	for _, v := range values {
+		if !wantSet[v] {
+			t.Errorf("unexpected ref candidate value: %q (got %v)", v, values)
+		}
+	}
+}
+
+// TestAskWorkflow_RefFlow_PickAccumulatesAndContinues covers the loop
+// pivot: pick a ref → ref_continue selector with "再加一個 / 開始問問題".
+func TestAskWorkflow_RefFlow_PickAccumulatesAndContinues(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
+	p := &Pending{
+		Phase:     "ask_ref_pick",
+		State:     &askState{AttachRepo: true, SelectedRepo: "foo/bar", AddRefs: true},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_continue" {
+		t.Errorf("Phase = %q, want ask_ref_continue", p.Phase)
+	}
+	st := p.State.(*askState)
+	if len(st.RefRepos) != 1 || st.RefRepos[0].Repo != "baz/qux" {
+		t.Errorf("RefRepos = %v, want one entry of baz/qux", st.RefRepos)
+	}
+	if st.RefRepos[0].CloneURL == "" {
+		t.Error("RefRepos[0].CloneURL should be populated by cleanCloneURL")
+	}
+	values := selectorValues(step.Selector.Options)
+	wantSet := map[string]bool{"more": true, "done": true}
+	for _, v := range values {
+		if !wantSet[v] {
+			t.Errorf("unexpected continue option %q (got %v)", v, values)
+		}
+	}
+}
+
+// TestAskWorkflow_RefFlow_PickDedupAlreadyPicked covers AC-11: same repo
+// can't appear twice in the candidate list.
+func TestAskWorkflow_RefFlow_PickDedupAlreadyPicked(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
+	p := &Pending{
+		Phase: "ask_ref_continue",
+		State: &askState{
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+			RefRepos:     []queue.RefRepo{{Repo: "baz/qux", CloneURL: "https://github.com/baz/qux.git"}},
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	// Click "再加一個" → should show pick selector with baz/qux excluded.
+	step, err := w.Selection(context.Background(), p, "more")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_pick" {
+		t.Errorf("Phase = %q, want ask_ref_pick", p.Phase)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "baz/qux" {
+			t.Errorf("already-picked baz/qux must not appear in candidates; got %v", values)
+		}
+	}
+	// third/repo must still be available.
+	found := false
+	for _, v := range values {
+		if v == "third/repo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("third/repo missing from candidates: %v", values)
+	}
+}
+
+// TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore covers a UX detail:
+// when the static candidate pool is fully consumed, "再加一個" drops from
+// the continue selector since there's nothing to pick.
+func TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
+	p := &Pending{
+		Phase: "ask_ref_pick",
+		State: &askState{
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "more" {
+			t.Errorf("'more' option should be hidden when pool is exhausted; got %v", values)
+		}
+	}
+	if len(values) != 1 || values[0] != "done" {
+		t.Errorf("expected only 'done' option, got %v", values)
+	}
+}
+
+// TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop covers transition
+// from ref_continue "done" into per-ref branch selection. When branch_select
+// is disabled, the loop should drain instantly into prior-answer/description.
+func TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	// branch_select default is nil/false, so refs use default branch.
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
+	p := &Pending{
+		Phase: "ask_ref_continue",
+		State: &askState{
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+			RefRepos: []queue.RefRepo{
+				{Repo: "baz/qux", CloneURL: "https://github.com/baz/qux.git"},
+			},
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// branch_select disabled → branch loop drains, lands on description.
+	if p.Phase != "ask_description_prompt" {
+		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
+	}
+	st := p.State.(*askState)
+	if st.RefRepos[0].Branch != "" {
+		t.Errorf("ref branch should remain empty (default branch), got %q", st.RefRepos[0].Branch)
+	}
+}
+
+// TestAskWorkflow_RefFlow_PerRefBranchPicker covers per-ref branch
+// selection with multiple branches available — verifies BranchTargetRepo
+// is set to the current ref so HandleBranchSuggestion picks the right
+// repo, and that each ref gets its own decision.
+func TestAskWorkflow_RefFlow_PerRefBranchPicker(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	trueVal := true
+	w.cfg.ChannelDefaults.BranchSelect = &trueVal
+	w.cfg.ChannelDefaults.Branches = []string{"main", "release"}
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "frontend/web", "backend/api"}
+	p := &Pending{
+		Phase: "ask_ref_continue",
+		State: &askState{
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+			RefRepos: []queue.RefRepo{
+				{Repo: "frontend/web", CloneURL: "u1"},
+				{Repo: "backend/api", CloneURL: "u2"},
+			},
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	// "done" → enter ref branch loop, first ref picker shows.
+	step, err := w.Selection(context.Background(), p, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_branch" {
+		t.Fatalf("Phase = %q, want ask_ref_branch", p.Phase)
+	}
+	st := p.State.(*askState)
+	if st.BranchTargetRepo != "frontend/web" {
+		t.Errorf("BranchTargetRepo = %q, want frontend/web (first ref)", st.BranchTargetRepo)
+	}
+	if !strings.Contains(step.Selector.Prompt, "frontend/web") {
+		t.Errorf("prompt should reference frontend/web; got %q", step.Selector.Prompt)
+	}
+
+	// Pick branch for first ref → advance to second ref's branch picker.
+	step, err = w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.RefRepos[0].Branch != "main" {
+		t.Errorf("ref[0].Branch = %q, want main", st.RefRepos[0].Branch)
+	}
+	if p.Phase != "ask_ref_branch" {
+		t.Fatalf("Phase = %q, want still ask_ref_branch (next ref)", p.Phase)
+	}
+	if st.BranchTargetRepo != "backend/api" {
+		t.Errorf("BranchTargetRepo = %q, want backend/api (second ref)", st.BranchTargetRepo)
+	}
+
+	// Pick branch for second ref → drain into prior-answer/description.
+	_, err = w.Selection(context.Background(), p, "release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.RefRepos[1].Branch != "release" {
+		t.Errorf("ref[1].Branch = %q, want release", st.RefRepos[1].Branch)
+	}
+	if p.Phase != "ask_description_prompt" {
+		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
+	}
+}
+
+// TestAskWorkflow_BuildJob_WithRefs_PopulatesJobAndRules covers Task 8:
+// Job.RefRepos passthrough + dynamic output_rules injection. When refs are
+// present, the two hard rules from spec §4.6 must be appended to the
+// configured OutputRules — preserving any rules already set on the
+// workflow's prompt config.
+func TestAskWorkflow_BuildJob_WithRefs_PopulatesJobAndRules(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.Workflows.Ask.Prompt.Goal = "ask"
+	w.cfg.Workflows.Ask.Prompt.OutputRules = []string{"existing rule"}
+	p := &Pending{
+		ChannelID:   "C1",
+		ThreadTS:    "1.0",
+		Reporter:    "Alice",
+		ChannelName: "general",
+		State: &askState{
+			Question:     "x",
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+			RefRepos: []queue.RefRepo{
+				{Repo: "frontend/web", CloneURL: "https://github.com/frontend/web.git", Branch: "main"},
+				{Repo: "backend/api", CloneURL: "https://github.com/backend/api.git"},
+			},
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(job.RefRepos) != 2 {
+		t.Errorf("Job.RefRepos len = %d, want 2", len(job.RefRepos))
+	}
+	rules := job.PromptContext.OutputRules
+	if len(rules) != 3 {
+		t.Fatalf("OutputRules len = %d, want 3 (existing + 2 injected); got %v", len(rules), rules)
+	}
+	if rules[0] != "existing rule" {
+		t.Errorf("existing rule should remain at index 0; got %q", rules[0])
+	}
+	if !strings.Contains(rules[1], "不可寫入") {
+		t.Errorf("first injected rule should be read-only enforcement; got %q", rules[1])
+	}
+	if !strings.Contains(rules[2], "critical") && !strings.Contains(rules[2], "關鍵 ref") {
+		t.Errorf("second injected rule should be critical-fail-fast; got %q", rules[2])
+	}
+}
+
+// TestAskWorkflow_BuildJob_NoRefs_NoRulesInjected covers the regression
+// case: when no refs are picked, output_rules is exactly the configured
+// list (no injection).
+func TestAskWorkflow_BuildJob_NoRefs_NoRulesInjected(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	w.cfg.Workflows.Ask.Prompt.Goal = "ask"
+	w.cfg.Workflows.Ask.Prompt.OutputRules = []string{"existing rule"}
+	p := &Pending{
+		ChannelID:   "C1",
+		ThreadTS:    "1.0",
+		Reporter:    "Alice",
+		ChannelName: "general",
+		State: &askState{
+			Question:     "x",
+			AttachRepo:   true,
+			SelectedRepo: "foo/bar",
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(job.RefRepos) != 0 {
+		t.Errorf("Job.RefRepos = %v, want empty", job.RefRepos)
+	}
+	rules := job.PromptContext.OutputRules
+	if len(rules) != 1 || rules[0] != "existing rule" {
+		t.Errorf("OutputRules = %v, want only 'existing rule'", rules)
+	}
+}
+
+// TestAskState_RefExclusions_PrimaryAndPicked covers the RefExclusionReader
+// implementation used by HandleRefRepoSuggestion to filter type-ahead
+// results in external-search channels.
+func TestAskState_RefExclusions_PrimaryAndPicked(t *testing.T) {
+	st := &askState{
+		SelectedRepo: "foo/bar",
+		RefRepos: []queue.RefRepo{
+			{Repo: "frontend/web"},
+			{Repo: "backend/api"},
+		},
+	}
+	excl := st.RefExclusions()
+	if len(excl) != 3 {
+		t.Fatalf("RefExclusions len = %d, want 3 (primary + 2 picked)", len(excl))
+	}
+	want := map[string]bool{"foo/bar": true, "frontend/web": true, "backend/api": true}
+	for _, r := range excl {
+		if !want[r] {
+			t.Errorf("unexpected exclusion: %q", r)
+		}
+	}
+}
+
+// TestAskState_BranchSelectedRepo_FollowsBranchTarget asserts the
+// transient field swap that lets a single BranchStateReader interface
+// serve both primary and per-ref branch picking.
+func TestAskState_BranchSelectedRepo_FollowsBranchTarget(t *testing.T) {
+	st := &askState{
+		SelectedRepo:     "foo/bar",
+		BranchTargetRepo: "foo/bar",
+	}
+	if got := st.BranchSelectedRepo(); got != "foo/bar" {
+		t.Errorf("primary phase: BranchSelectedRepo = %q, want foo/bar", got)
+	}
+	st.BranchTargetRepo = "frontend/web"
+	if got := st.BranchSelectedRepo(); got != "frontend/web" {
+		t.Errorf("ref phase: BranchSelectedRepo = %q, want frontend/web", got)
+	}
+}
+
+// selectorValues extracts Value strings from a SelectorOption slice for
+// quick assertions in tests.
+func selectorValues(opts []SelectorOption) []string {
+	out := make([]string, 0, len(opts))
+	for _, o := range opts {
+		out = append(out, o.Value)
+	}
+	return out
 }

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -990,10 +990,13 @@ func TestAskWorkflow_RefFlow_PickFiltersPrimary(t *testing.T) {
 	}
 }
 
-// TestAskWorkflow_RefFlow_PickAccumulatesAndContinues covers the loop
-// pivot: pick a ref → ref_continue selector with "再加一個 / 開始問問題".
-func TestAskWorkflow_RefFlow_PickAccumulatesAndContinues(t *testing.T) {
+// TestAskWorkflow_RefFlow_PickGoesToContinueWhenNoBranchSelect covers
+// the inline flow: pick a ref → branch_select disabled → branch loop
+// drains instantly → land on continue ("再加一個 / 開始問問題"). Without
+// branch_select, this is the natural shape.
+func TestAskWorkflow_RefFlow_PickGoesToContinueWhenNoBranchSelect(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
+	// branch_select default false → ref branch picker skipped per ref.
 	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
 	p := &Pending{
 		Phase:     "ask_ref_pick",
@@ -1020,6 +1023,38 @@ func TestAskWorkflow_RefFlow_PickAccumulatesAndContinues(t *testing.T) {
 		if !wantSet[v] {
 			t.Errorf("unexpected continue option %q (got %v)", v, values)
 		}
+	}
+}
+
+// TestAskWorkflow_RefFlow_PickGoesToBranchWhenBranchSelect covers the
+// inline interleaved flow: pick a ref → ask_ref_branch fires for THAT ref
+// (not all refs collected first). User-reported UX bug: collecting all
+// refs before any branches asks "did I want main for frontend or backend?"
+// 3 refs later, which is wrong. Inline matches primary's flow shape.
+func TestAskWorkflow_RefFlow_PickGoesToBranchWhenBranchSelect(t *testing.T) {
+	w, _ := newTestAskWorkflow(t)
+	trueVal := true
+	w.cfg.ChannelDefaults.BranchSelect = &trueVal
+	w.cfg.ChannelDefaults.Branches = []string{"main", "release"}
+	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux", "third/repo"}
+	p := &Pending{
+		Phase:     "ask_ref_pick",
+		State:     &askState{AttachRepo: true, SelectedRepo: "foo/bar", AddRefs: true},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_branch" {
+		t.Fatalf("Phase = %q, want ask_ref_branch (inline branch pick)", p.Phase)
+	}
+	st := p.State.(*askState)
+	if st.BranchTargetRepo != "baz/qux" {
+		t.Errorf("BranchTargetRepo = %q, want baz/qux (the just-picked ref)", st.BranchTargetRepo)
+	}
+	if !strings.Contains(step.Selector.Prompt, "baz/qux") {
+		t.Errorf("prompt should reference baz/qux; got %q", step.Selector.Prompt)
 	}
 }
 
@@ -1066,7 +1101,9 @@ func TestAskWorkflow_RefFlow_PickDedupAlreadyPicked(t *testing.T) {
 
 // TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore covers a UX detail:
 // when the static candidate pool is fully consumed, "再加一個" drops from
-// the continue selector since there's nothing to pick.
+// the continue selector since there's nothing to pick. Picks the only
+// remaining ref (baz/qux); branch_select disabled so we land directly on
+// the continue selector with the exhausted pool.
 func TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
 	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
@@ -1083,6 +1120,9 @@ func TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if p.Phase != "ask_ref_continue" {
+		t.Fatalf("Phase = %q, want ask_ref_continue (no branch_select → straight to continue)", p.Phase)
+	}
 	values := selectorValues(step.Selector.Options)
 	for _, v := range values {
 		if v == "more" {
@@ -1094,12 +1134,12 @@ func TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore(t *testing.T) {
 	}
 }
 
-// TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop covers transition
-// from ref_continue "done" into per-ref branch selection. When branch_select
-// is disabled, the loop should drain instantly into prior-answer/description.
-func TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop(t *testing.T) {
+// TestAskWorkflow_RefFlow_ContinueDoneRoutesToDescription covers
+// "開始問問題" — exits the ref loop entirely. Branches are already filled
+// per-ref during pick (inline flow), so done has no branch loop to enter;
+// it goes straight to prior-answer/description.
+func TestAskWorkflow_RefFlow_ContinueDoneRoutesToDescription(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
-	// branch_select default is nil/false, so refs use default branch.
 	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "baz/qux"}
 	p := &Pending{
 		Phase: "ask_ref_continue",
@@ -1117,80 +1157,99 @@ func TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// branch_select disabled → branch loop drains, lands on description.
 	if p.Phase != "ask_description_prompt" {
 		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
 	}
-	st := p.State.(*askState)
-	if st.RefRepos[0].Branch != "" {
-		t.Errorf("ref branch should remain empty (default branch), got %q", st.RefRepos[0].Branch)
-	}
 }
 
-// TestAskWorkflow_RefFlow_PerRefBranchPicker covers per-ref branch
-// selection with multiple branches available — verifies BranchTargetRepo
-// is set to the current ref so HandleBranchSuggestion picks the right
-// repo, and that each ref gets its own decision.
-func TestAskWorkflow_RefFlow_PerRefBranchPicker(t *testing.T) {
+// TestAskWorkflow_RefFlow_InlineBranchPickerPerRef covers the full inline
+// flow: pick ref1 → branch1 → continue → pick ref2 → branch2 → done. Each
+// ref's branch is asked immediately after picking that ref, not deferred
+// to a separate end-of-flow loop. RefBranchIdx tracks which ref we're
+// branch-picking for so RefRepos[idx].Branch lands on the right ref.
+func TestAskWorkflow_RefFlow_InlineBranchPickerPerRef(t *testing.T) {
 	w, _ := newTestAskWorkflow(t)
 	trueVal := true
 	w.cfg.ChannelDefaults.BranchSelect = &trueVal
 	w.cfg.ChannelDefaults.Branches = []string{"main", "release"}
 	w.cfg.ChannelDefaults.Repos = []string{"foo/bar", "frontend/web", "backend/api"}
 	p := &Pending{
-		Phase: "ask_ref_continue",
+		Phase: "ask_ref_pick",
 		State: &askState{
 			AttachRepo:   true,
 			SelectedRepo: "foo/bar",
 			AddRefs:      true,
-			RefRepos: []queue.RefRepo{
-				{Repo: "frontend/web", CloneURL: "u1"},
-				{Repo: "backend/api", CloneURL: "u2"},
-			},
 		},
 		ChannelID: "C1", ThreadTS: "1.0",
 	}
-	// "done" → enter ref branch loop, first ref picker shows.
-	step, err := w.Selection(context.Background(), p, "done")
+
+	// Pick ref1 → branch picker fires for ref1 immediately.
+	step, err := w.Selection(context.Background(), p, "frontend/web")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if p.Phase != "ask_ref_branch" {
-		t.Fatalf("Phase = %q, want ask_ref_branch", p.Phase)
+		t.Fatalf("after ref1 pick, Phase = %q, want ask_ref_branch", p.Phase)
 	}
 	st := p.State.(*askState)
 	if st.BranchTargetRepo != "frontend/web" {
-		t.Errorf("BranchTargetRepo = %q, want frontend/web (first ref)", st.BranchTargetRepo)
+		t.Errorf("BranchTargetRepo = %q, want frontend/web", st.BranchTargetRepo)
 	}
 	if !strings.Contains(step.Selector.Prompt, "frontend/web") {
 		t.Errorf("prompt should reference frontend/web; got %q", step.Selector.Prompt)
 	}
 
-	// Pick branch for first ref → advance to second ref's branch picker.
-	step, err = w.Selection(context.Background(), p, "main")
+	// Pick ref1's branch → loop pivot (continue selector).
+	_, err = w.Selection(context.Background(), p, "main")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_continue" {
+		t.Fatalf("after ref1 branch pick, Phase = %q, want ask_ref_continue", p.Phase)
 	}
 	if st.RefRepos[0].Branch != "main" {
 		t.Errorf("ref[0].Branch = %q, want main", st.RefRepos[0].Branch)
 	}
-	if p.Phase != "ask_ref_branch" {
-		t.Fatalf("Phase = %q, want still ask_ref_branch (next ref)", p.Phase)
+
+	// "再加一個" → back to pick.
+	_, err = w.Selection(context.Background(), p, "more")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if st.BranchTargetRepo != "backend/api" {
-		t.Errorf("BranchTargetRepo = %q, want backend/api (second ref)", st.BranchTargetRepo)
+	if p.Phase != "ask_ref_pick" {
+		t.Fatalf("after 'more', Phase = %q, want ask_ref_pick", p.Phase)
 	}
 
-	// Pick branch for second ref → drain into prior-answer/description.
+	// Pick ref2 → its branch picker fires.
+	_, err = w.Selection(context.Background(), p, "backend/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "ask_ref_branch" {
+		t.Fatalf("after ref2 pick, Phase = %q, want ask_ref_branch", p.Phase)
+	}
+	if st.BranchTargetRepo != "backend/api" {
+		t.Errorf("BranchTargetRepo = %q, want backend/api", st.BranchTargetRepo)
+	}
+
+	// Pick ref2's branch → continue → done.
 	_, err = w.Selection(context.Background(), p, "release")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if p.Phase != "ask_ref_continue" {
+		t.Fatalf("after ref2 branch pick, Phase = %q, want ask_ref_continue", p.Phase)
+	}
 	if st.RefRepos[1].Branch != "release" {
 		t.Errorf("ref[1].Branch = %q, want release", st.RefRepos[1].Branch)
 	}
+
+	_, err = w.Selection(context.Background(), p, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if p.Phase != "ask_description_prompt" {
-		t.Errorf("Phase = %q, want ask_description_prompt", p.Phase)
+		t.Errorf("after 'done', Phase = %q, want ask_description_prompt", p.Phase)
 	}
 }
 

--- a/app/workflow/issue.go
+++ b/app/workflow/issue.go
@@ -556,12 +556,13 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 	return NextStep{
 		Kind: NextStepSelector,
 		Selector: &SelectorSpec{
-			Prompt:       fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
-			ActionID:     "branch_select",
-			Options:      labelsToOptions(branches),
-			Placeholder:  "選擇 branch...",
-			BackActionID: backAction,
-			BackLabel:    backLabel,
+			Prompt:           fmt.Sprintf(":point_right: Which branch of `%s`?", st.SelectedRepo),
+			ActionID:         "branch_select",
+			Options:          labelsToOptions(branches),
+			Placeholder:      "選擇 branch...",
+			BackActionID:     backAction,
+			BackLabel:        backLabel,
+			MergeWithLastAck: true, // collapse "✅ repo" + "✅ branch" → "✅ repo, branch"
 		},
 		Pending: p,
 	}

--- a/app/workflow/ports.go
+++ b/app/workflow/ports.go
@@ -52,6 +52,18 @@ type BranchStateReader interface {
 	BranchSelectedRepo() string
 }
 
+// RefExclusionReader is implemented by workflow states that participate in
+// the multi-repo (ref) flow. RefExclusions returns the repo names that
+// should NOT appear in ref-pick type-ahead results — typically primary +
+// already-picked refs. Used by HandleRefRepoSuggestion to filter results
+// when a channel uses external_select for ref repos (no static list).
+//
+// Same concurrency contract as BranchStateReader: implementations must be
+// safe to read on the BlockSuggestion hot path without the workflow lock.
+type RefExclusionReader interface {
+	RefExclusions() []string
+}
+
 // GitHubPR abstracts the PR endpoints PR Review needs for URL validation.
 // PRReviewWorkflow uses this to verify a URL references a real, accessible PR
 // before submitting work. The concrete type (shared/github.Client) lives in

--- a/app/workflow/workflow.go
+++ b/app/workflow/workflow.go
@@ -63,6 +63,20 @@ type Pending struct {
 	// keeping every abandoned step around.
 	SessionMsgTSs []string
 
+	// LastAckTS / LastAckValue track the most recent ":white_check_mark: X"
+	// breadcrumb so a follow-on selector with MergeWithLastAck can append
+	// itself ("repo, branch") into one breadcrumb instead of leaving two.
+	// Updated by the bot ack path on every non-transitional click.
+	LastAckTS    string
+	LastAckValue string
+
+	// NextAckMerges is set when the most recently posted selector had
+	// SelectorSpec.MergeWithLastAck. The next click will merge its ack into
+	// LastAckTS (updating LastAckValue) and delete its own selector message
+	// rather than leaving a separate breadcrumb. Reset to false after every
+	// click. Lifetime: posted-true → click consumes → reset.
+	NextAckMerges bool
+
 	// invalidated is set by HandleBackToRepo when the user abandons this pending
 	// generation. An in-flight repo-prep goroutine that completes after the
 	// back-button was clicked must observe this flag and skip posting the
@@ -170,6 +184,19 @@ type SelectorSpec struct {
 	BackLabel      string
 	CancelActionID string
 	CancelLabel    string
+
+	// MergeWithLastAck causes this selector's eventual ack to merge with
+	// the previous breadcrumb (Pending.LastAckTS) rather than leave its own
+	// "✅ value" line. Used to collapse repo + branch into a single
+	// "✅ owner/name, branch" breadcrumb so a 5-step flow doesn't leave 5
+	// breadcrumb messages in the thread.
+	//
+	// Sequencing: workflow sets this on the SelectorSpec for selectors
+	// whose pick is a continuation of the previous (e.g. branch picker
+	// after repo picker). The bot records it on Pending.NextAckMerges at
+	// post time; on click, the ack path consumes the flag, merges, and
+	// resets.
+	MergeWithLastAck bool
 }
 
 // Workflow is the polymorphic contract each workflow type implements.

--- a/worker/pool/executor_test.go
+++ b/worker/pool/executor_test.go
@@ -428,9 +428,10 @@ func TestExecuteJob_MultiRepo_EndToEnd(t *testing.T) {
 
 	// dirtyingRunner writes into the successful ref's worktree before
 	// returning so the post-execute guard sees a non-empty `git status` and
-	// fires the lenient callback. Path is deterministic from refDirName.
+	// fires the lenient callback. Path is deterministic from refsRootPath +
+	// refDirName.
 	runner := &dirtyingRunner{
-		dirtyPath: filepath.Join(primaryPath+"-refs", "frontend__web", "agent-wrote-here.txt"),
+		dirtyPath: filepath.Join(primaryPath, ".refs", "frontend__web", "agent-wrote-here.txt"),
 		output:    "answer body",
 	}
 
@@ -503,7 +504,7 @@ func TestExecuteJob_MultiRepo_EndToEnd(t *testing.T) {
 		t.Errorf("RemoveWorktree path = %q, want suffix frontend__web",
 			repo.removedWorktrees[0])
 	}
-	refsRoot := primaryPath + "-refs"
+	refsRoot := filepath.Join(primaryPath, ".refs")
 	if _, err := os.Stat(refsRoot); !os.IsNotExist(err) {
 		t.Errorf("refs root should be cleaned up; stat err = %v", err)
 	}

--- a/worker/pool/workdir.go
+++ b/worker/pool/workdir.go
@@ -69,10 +69,26 @@ func selectProvider(job *queue.Job, repo RepoProvider, token string) WorkDirProv
 }
 
 // refsRootPath returns the directory in which ref worktrees live, derived
-// from the primary worktree path. The "-refs" suffix keeps ref dirs in the
-// same parent (the cache's worktrees/) so existing cleanup paths cover them.
+// from the primary worktree path.
+//
+// Refs sit INSIDE primary's worktree at `.refs/`. This contradicts the
+// original spec §1 design (refs outside primary cwd), which the spec
+// justified by avoiding `.gitignore` inheritance and cleanup nesting. That
+// design was reversed during initial e2e testing because opencode's
+// sandbox blocks any path outside cwd as `external_directory` — the
+// agent literally cannot READ refs that live outside its working
+// directory. The whole multi-repo feature collapses without inside-cwd
+// access. The earlier `-refs` sibling layout left agents staring at
+// "讓我檢查允許存取的目錄" before falling through to schema-fallback with
+// a 154-byte truncated answer.
+//
+// `.gitignore` inheritance is a much smaller risk in practice: primary's
+// `.gitignore` is unlikely to match `.refs/` (no real project uses that
+// path), and ripgrep traverses subdirs by default. The original "spike to
+// validate" assumption from spec §6 turned out to be the wrong
+// assumption — sandbox boundaries dominate `.gitignore` propagation.
 func refsRootPath(primaryPath string) string {
-	return primaryPath + "-refs"
+	return filepath.Join(primaryPath, ".refs")
 }
 
 // refDirName flattens owner/name → owner__name. GitHub disallows __ in repo

--- a/worker/pool/workdir_test.go
+++ b/worker/pool/workdir_test.go
@@ -234,8 +234,12 @@ func TestPrepareRefs_PartialSuccess(t *testing.T) {
 	if len(successfulPaths) != 2 {
 		t.Errorf("successfulPaths len = %d, want 2", len(successfulPaths))
 	}
-	if !strings.HasSuffix(refsRoot, "-refs") {
-		t.Errorf("refs root naming wrong: %s", refsRoot)
+	if filepath.Base(refsRoot) != ".refs" {
+		t.Errorf("refs root naming wrong: %s (want trailing .refs)", refsRoot)
+	}
+	if filepath.Dir(refsRoot) != primary {
+		t.Errorf("refs root parent should be primary worktree; got parent=%s want=%s",
+			filepath.Dir(refsRoot), primary)
 	}
 	if !strings.HasSuffix(successful[0].Path, "frontend__web") {
 		t.Errorf("ref dir naming wrong for ref[0]: %s", successful[0].Path)


### PR DESCRIPTION
## Summary

Frontend half of #216 (Ask multi-repo). Pairs with #220 (already merged) — together they enable end-to-end ref support.

User flow: picks N ref repos in Slack → worker prepares them at \`<primary>-refs/<owner>__<repo>/\` → agent grep/reads under read-only contract enforced by three layers (SKILL.md soft → output_rules hard → worker post-execute guard observability).

Spec: \`docs/superpowers/specs/2026-04-29-ask-multi-repo-design.md\`
Plan: \`docs/superpowers/plans/2026-04-29-ask-multi-repo.md\`

## What's in here

**App workflow (\`app/workflow/ask.go\`)**

\`askState\` gains four fields:
- \`AddRefs bool\` — user's yes/no on the decide prompt
- \`RefRepos []queue.RefRepo\` — accumulates as user picks (Branch filled later in per-ref loop)
- \`RefBranchIdx int\` — per-ref branch loop cursor
- \`BranchTargetRepo string\` — transient, set before each branch select phase so \`BranchStateReader.BranchSelectedRepo()\` returns the right repo for both primary and per-ref branch picking. Keeps the interface phase-agnostic (no leaking ref concepts to other workflows).

Four new phases, all using \`chat.update\` on the **same selector message ts**:

| Phase | Purpose | Selector |
|---|---|---|
| \`ask_ref_decide\` | "加入參考 repo？" | 加入 / 不用 |
| \`ask_ref_pick\` | single-select ref repo (excludes primary + already-picked) | button row OR external_select |
| \`ask_ref_continue\` | loop pivot | 再加一個 ref / 開始問問題 |
| \`ask_ref_branch\` | per-ref branch (same skip rules as primary) | static button OR external_select |

**0-candidate skip** (AC-12): when the channel's static list contains only primary, \`ask_ref_decide\` is skipped entirely so the thread doesn't see "加入參考 repo？" — fixes the awkward "asking the question, then realising no answer is possible".

**\`BuildJob\` injection (spec §4.6 Layer 2)**

When \`len(st.RefRepos) > 0\`, two hard output rules are appended to \`PromptContext.OutputRules\`:

1. \`不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。\`
2. \`若 <unavailable_refs> 含關鍵 ref，必須在答案開頭聲明「無法取得 X repo 脈絡，無法回答」並停手；不要 best-effort 拼湊。\`

These complement SKILL.md's soft guidance — \`output_rules\` are the hard prompt-end constraint that survives even if the agent ignores the skill.

**Slack adapter wiring**

- New \`workflow.RefExclusionReader\` interface (in \`ports.go\`) — askState implements it; returns primary + already-picked refs.
- \`HandleRefRepoSuggestion\` in \`app/bot/workflow.go\` — runs same \`repoDiscovery.SearchRepos\` as primary, then filters out the exclusion list. Used when channel has no static repo allowlist (external search).
- \`app/app.go\` BlockSuggestion router: new cases \`ask_ref\` + \`ask_ref_branch\` (the latter reuses \`HandleBranchSuggestion\` since \`BranchTargetRepo\` switches under it).

**SKILL.md**

New "Reference repos (absolute paths in \`<ref_repos>\`)" subsection in §5 (Action boundaries):

- Read-only contract: CAN grep/read; CANNOT write/commit/edit/mv/rm.
- Refs are physically OUTSIDE cwd (PR #220's design choice) — uses absolute paths from the prompt block, not relative paths.
- Citations should reference repo+path (\`backend/api: src/foo.ts:42\`), not absolute path (machine-only context).
- \`<unavailable_refs>\` handling:
  - **Critical** ref unavailable → state at answer opening, stop. Don't patchwork.
  - **Non-critical** → mention in answer ("以下回答僅基於 Y 與 Z"), continue.

## Tests

| Test | Coverage |
|---|---|
| \`TestAskWorkflow_RefFlow_DecidePromptOffered\` | Entry to ref flow when candidates exist |
| \`TestAskWorkflow_RefFlow_ZeroCandidatesSkipsDecide\` | **AC-12** — single-repo channel auto-skips |
| \`TestAskWorkflow_RefFlow_DecideAddRoutesToPick\` | "加入" → ask_ref_pick |
| \`TestAskWorkflow_RefFlow_DecideSkipRoutesToPriorAnswer\` | "不用" → existing flow, no ref state set |
| \`TestAskWorkflow_RefFlow_PickFiltersPrimary\` | **AC-10** — primary excluded from candidates |
| \`TestAskWorkflow_RefFlow_PickAccumulatesAndContinues\` | Loop pivot transition + cleanCloneURL passthrough |
| \`TestAskWorkflow_RefFlow_PickDedupAlreadyPicked\` | **AC-11** — same repo can't appear twice |
| \`TestAskWorkflow_RefFlow_ContinueExhaustedPoolHidesMore\` | UX detail — "再加一個" drops when pool empty |
| \`TestAskWorkflow_RefFlow_ContinueDoneEnterBranchLoop\` | branch_select disabled drains loop instantly |
| \`TestAskWorkflow_RefFlow_PerRefBranchPicker\` | Multi-ref branch picker w/ BranchTargetRepo handoff per ref |
| \`TestAskWorkflow_BuildJob_WithRefs_PopulatesJobAndRules\` | **AC-9** — output_rules injection (existing rules preserved + 2 appended) |
| \`TestAskWorkflow_BuildJob_NoRefs_NoRulesInjected\` | Regression: no refs → no injection |
| \`TestAskState_RefExclusions_PrimaryAndPicked\` | RefExclusionReader impl |
| \`TestAskState_BranchSelectedRepo_FollowsBranchTarget\` | BranchTargetRepo swap covers primary + ref phases |
| (2 existing tests updated) | Single-repo channel config so 0-candidate skip preserves the "branch pick → description" semantic |

All app + worker + shared module tests pass; \`test/import_direction_test.go\` passes.

## Manual e2e test plan (your job — see PR memory note from earlier)

This is the half you can actually walk in Slack. Suggested flow:

\`\`\`bash
gh pr checkout 221  # this PR
# Make sure both app and worker rebuild & deploy with the new branch.
# Both binaries needed: PR 1 (worker) merged into main, PR 2 (app) on this branch.
\`\`\`

In your test channel (\`ai_trigger_issue_bot\`):

- **0-ref baseline (regression)** — \`@bot ask\` with attach=skip → existing flow unchanged.
- **1 ref, single-repo channel** — channel with one configured repo. Primary picked, \`ask_ref_decide\` should NOT appear (AC-12).
- **1 ref, multi-repo channel** — channel with 2-3 repos. Walk through decide → pick → continue → done → primary branch → ref branch (if applicable). Verify thread shows \`chat.update\` reuse: only one selector message ts changes content, not new messages each step.
- **3 refs** — pick 3 different repos. **Count permanent message rows** in the thread after the ask completes — should be ≤ 2 (AC-5).
- **Force ref clone failure** — pick a ref the PAT can't access. Verify:
  - Job completes (no failure banner)
  - Answer mentions "無法取得 X repo 脈絡" (driven by SKILL.md + output_rules)
  - Worker log shows \`ref clone failed; continuing with partial context\`
- **Force write violation** — ask "Write \`x\` to \`<absolute path of ref>/foo.txt\`". Verify:
  - You still get an answer (lenient — AC-8)
  - Worker log shows \`agent wrote into ref repo (lenient: not failing job)\`
  - \`ask_ref_write_violations_total{repo="..."} > 0\` on /metrics
- **Critical-ref fail-fast** — make a ref clone fail in a question that fundamentally needs it ("how does ref X handle Y?" with X failing). Verify answer opens with "無法取得 X repo 脈絡，這題我答不了..." and stops. Tests output_rules layer 2 + SKILL.md guidance combined.

Issues to flag if you see them: extra message rows beyond ≤ 2, selector resetting state on chat.update, ref dirs lingering after job completes.

## Out of scope

- #217 Issue workflow ref support — separate PR, will reuse this schema/UX with a strict post-execute guard callback.
- modal-based multi-select fallback — sequential single-select ships per spec §1.
- ref count hard cap — N≥5 only info-logs (spec Q10).

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)