### PR TITLE
feat(worker): Issue multi-repo backend prep — JobResult.RefViolations + ref-guard simplify (#217 PR 1)

### DIFF
--- a/app/bot/result_listener.go
+++ b/app/bot/result_listener.go
@@ -167,6 +167,14 @@ func (r *ResultListener) recordMetrics(state *queue.JobState, result *queue.JobR
 		metrics.QueueWait.Observe(state.WaitTime.Seconds())
 	}
 
+	// Ref-write violations: worker is task-agnostic and reports any ref
+	// worktree dirty bits via JobResult.RefViolations. App side is where the
+	// metric lives — Ask path is lenient (count, do not block); Issue path
+	// fail-fasts at createAndPostIssue s1 in addition to this metric.
+	for _, repo := range result.RefViolations {
+		metrics.RefWriteViolationsTotal.WithLabelValues(workflowLabel(job), repo).Inc()
+	}
+
 	// Agent metrics from StatusReport (relayed by StatusListener from worker's StatusBus).
 	if as := state.AgentStatus; as != nil {
 		provider := as.AgentCmd

--- a/app/bot/result_listener_test.go
+++ b/app/bot/result_listener_test.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	"github.com/Ivantseng123/agentdock/app/workflow"
+	"github.com/Ivantseng123/agentdock/shared/metrics"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 	"github.com/Ivantseng123/agentdock/shared/queue/queuetest"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type updateCall struct{ ChannelID, MessageTS, Text string }
@@ -822,5 +825,61 @@ func TestResultListener_UnknownTaskType_FailsSafely(t *testing.T) {
 	state, _ := store.Get(ctx, "junk")
 	if state.Status == queue.JobCompleted || state.Status == queue.JobFailed {
 		t.Errorf("store status should not be completed/failed for unknown task_type, got %q", state.Status)
+	}
+}
+
+// TestResultListener_RefViolations_EmitsMetricPerWorkflow asserts that
+// recordMetrics fires ref_write_violations_total{workflow,repo} once per
+// ref-violation entry. Worker is task-agnostic — it just reports; this app
+// hook is where the metric label gets populated. Both Ask and Issue paths
+// flow through the same code, so one shared test verifies labelling for
+// both workflows in a table.
+func TestResultListener_RefViolations_EmitsMetricPerWorkflow(t *testing.T) {
+	cases := []struct {
+		workflow   string
+		repo       string
+	}{
+		{"ask", "frontend/web"},
+		{"issue", "backend/api"},
+	}
+	r := &ResultListener{logger: slog.Default()}
+	for _, tc := range cases {
+		t.Run(tc.workflow+"/"+tc.repo, func(t *testing.T) {
+			before := testutil.ToFloat64(metrics.RefWriteViolationsTotal.WithLabelValues(tc.workflow, tc.repo))
+
+			state := &queue.JobState{
+				Job: &queue.Job{ID: "j", TaskType: tc.workflow},
+			}
+			result := &queue.JobResult{
+				JobID:         "j",
+				Status:        "completed",
+				RefViolations: []string{tc.repo},
+			}
+			r.recordMetrics(state, result)
+
+			after := testutil.ToFloat64(metrics.RefWriteViolationsTotal.WithLabelValues(tc.workflow, tc.repo))
+			if got := after - before; got != 1 {
+				t.Fatalf("RefWriteViolationsTotal{%s,%s} delta = %v, want 1", tc.workflow, tc.repo, got)
+			}
+		})
+	}
+}
+
+// TestResultListener_RefViolations_EmptySliceNoop asserts that a result with
+// no violations does not touch the counter (preserves baseline for Grafana
+// rate() queries — a zero violation should not register as a sample).
+func TestResultListener_RefViolations_EmptySliceNoop(t *testing.T) {
+	r := &ResultListener{logger: slog.Default()}
+	state := &queue.JobState{Job: &queue.Job{ID: "j", TaskType: "ask"}}
+	result := &queue.JobResult{JobID: "j", Status: "completed"}
+
+	// Pull a "should not be touched" sample value — any unique label combo
+	// works; we just need a stable reading before/after.
+	before := testutil.ToFloat64(metrics.RefWriteViolationsTotal.WithLabelValues("ask", "no-such/repo"))
+	r.recordMetrics(state, result)
+	after := testutil.ToFloat64(metrics.RefWriteViolationsTotal.WithLabelValues("ask", "no-such/repo"))
+
+	if after != before {
+		t.Fatalf("counter should not have moved on empty RefViolations: before=%v after=%v", before, after)
 	}
 }

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -80,18 +80,12 @@ func (s *askState) BranchSelectedRepo() string {
 // RefExclusions returns the repos that should NOT appear as ref candidates:
 // the primary plus any refs already picked. Used by HandleRefRepoSuggestion
 // to filter type-ahead results when the channel has no static repo list.
+// Body delegates to shared refExclusionsFor (also used by issueState).
 func (s *askState) RefExclusions() []string {
 	if s == nil {
 		return nil
 	}
-	out := make([]string, 0, 1+len(s.RefRepos))
-	if s.SelectedRepo != "" {
-		out = append(out, s.SelectedRepo)
-	}
-	for _, r := range s.RefRepos {
-		out = append(out, r.Repo)
-	}
-	return out
+	return refExclusionsFor(s.SelectedRepo, s.RefRepos)
 }
 
 // NewAskWorkflow constructs a workflow instance.

--- a/app/workflow/refstate.go
+++ b/app/workflow/refstate.go
@@ -1,0 +1,19 @@
+package workflow
+
+import "github.com/Ivantseng123/agentdock/shared/queue"
+
+// refExclusionsFor returns repos that should NOT appear as ref candidates
+// when the user is picking refs: the primary plus any refs already picked.
+// Shared between AskWorkflow and IssueWorkflow — both states call this from
+// their RefExclusions() method, which app/bot uses to filter repo-suggestion
+// type-ahead results.
+func refExclusionsFor(primary string, refs []queue.RefRepo) []string {
+	out := make([]string, 0, 1+len(refs))
+	if primary != "" {
+		out = append(out, primary)
+	}
+	for _, r := range refs {
+		out = append(out, r.Repo)
+	}
+	return out
+}

--- a/app/workflow/refstate_test.go
+++ b/app/workflow/refstate_test.go
@@ -1,0 +1,55 @@
+package workflow
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+func TestRefExclusionsFor(t *testing.T) {
+	cases := []struct {
+		name     string
+		primary  string
+		refs     []queue.RefRepo
+		expected []string
+	}{
+		{
+			name:     "both populated",
+			primary:  "foo/bar",
+			refs:     []queue.RefRepo{{Repo: "a/b"}, {Repo: "c/d"}},
+			expected: []string{"foo/bar", "a/b", "c/d"},
+		},
+		{
+			name:     "empty primary",
+			primary:  "",
+			refs:     []queue.RefRepo{{Repo: "a/b"}},
+			expected: []string{"a/b"},
+		},
+		{
+			name:     "empty refs",
+			primary:  "foo/bar",
+			refs:     nil,
+			expected: []string{"foo/bar"},
+		},
+		{
+			name:     "both empty",
+			primary:  "",
+			refs:     nil,
+			expected: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := refExclusionsFor(tc.primary, tc.refs)
+			// Treat nil and []string{} as equivalent for the empty case —
+			// both have len 0; reflect.DeepEqual would distinguish them.
+			if len(got) == 0 && len(tc.expected) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Fatalf("got %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/docs/superpowers/plans/2026-04-29-issue-multi-repo.md
+++ b/docs/superpowers/plans/2026-04-29-issue-multi-repo.md
@@ -1,0 +1,975 @@
+# Issue Multi-Repo Reference Support — Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. Implement task-by-task; verify each task's verification block before moving on.
+
+**Goal:** Implement Issue workflow multi-repo reference support per spec — agent sees N read-only ref repos as cross-repo context; produced issue body must contain a `## Related repos` section; ref write violations and critical-unavailable conditions are caught and prevent issue creation.
+
+**Architecture:** Two-PR delivery, mirroring Ask plan structure.
+- **PR 1 (backend + Ask path migration, ~120 lines):** `JobResult.RefViolations` schema, metric unification, `runRefGuard` simplification (callback abstraction removed), shared `refExclusionsFor` helper, Ask path metric reporting moved from worker to `result_listener`. Lands without user-facing impact for Issue; Ask behaviour byte-for-byte unchanged.
+- **PR 2 (frontend + e2e, ~900 lines):** `issueState` extensions, 4 new ref-flow phases, `BuildJob` `output_rules` injection (3 rules), `createAndPostIssue` 5-step body normalization pipeline (strict guard / sentinel / auto-fill), `triage-issue/SKILL.md` update, full test coverage, Slack e2e + GitHub real issue verification.
+
+**Tech Stack:** Go 1.25, three modules (`shared/`, `app/`, `worker/`), slack-go. Test framework: stdlib `testing`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md`
+
+**Sibling reference:** Ask plan `docs/superpowers/plans/2026-04-29-ask-multi-repo.md` (already shipped via PR #220 + #222) — many tasks here mirror that work; cross-reference noted per task.
+
+---
+
+## File Structure
+
+| Path | Module | PR | Responsibility |
+|---|---|---|---|
+| `shared/queue/job.go` | shared | 1 | `JobResult.RefViolations []string` (omitempty) |
+| `shared/queue/job_test.go` | shared | 1 | Round-trip / omitempty regression for `RefViolations` |
+| `shared/metrics/metrics.go` | shared | 1 | Drop `AskRefWriteViolationsTotal`; add `RefWriteViolationsTotal{workflow,repo}` |
+| `worker/pool/executor.go` | worker | 1 | Drop `RefViolationCallback` type + `askLenientRefViolation` func; rewrite `runRefGuard(refs, logger) []string`; `executeJob` writes violations into `JobResult` |
+| `worker/pool/executor_test.go` | worker | 1 | Drop callback-related tests; rewrite three guard cases (detect / clean / empty) |
+| `app/workflow/refstate.go` | app | 1 | NEW — `refExclusionsFor(primary string, refs []queue.RefRepo) []string` helper |
+| `app/workflow/refstate_test.go` | app | 1 | NEW — three table cases for the helper |
+| `app/workflow/ask.go` | app | 1 | `RefExclusions()` body shrinks to one-line `refExclusionsFor` call |
+| `app/bot/result_listener.go` | app | 1 | Read `r.RefViolations`, emit `RefWriteViolationsTotal{workflow,repo}` per repo (Ask + Issue paths handled here, no fail-fast for Ask) |
+| `app/bot/result_listener_test.go` | app | 1 | Verify metric emission on completed result with `RefViolations`; Ask path does not fail |
+| `app/workflow/issue.go` | app | 2 | `issueState` 4 ref fields, `BranchSelectedRepo` / `RefExclusions` methods, 4 ref-flow phase methods, `BuildJob` 3 ref `output_rules` rules, `createAndPostIssue` 5-step pipeline (s1 RefViolations / s2 sentinel / s3 ensureRelatedRepos / regex helper) |
+| `app/workflow/issue_test.go` | app | 2 | Phase tests mirroring `ask_test.go`; pipeline tests for s1/s2/s3; regex variants |
+| `app/app.go` | app | 2 | `BlockSuggestion` routes `issue_ref` (HandleRefRepoSuggestion) and `issue_ref_branch` (HandleBranchSuggestion); mirrors PR #222's Ask wiring |
+| `app/agents/skills/triage-issue/SKILL.md` | app | 2 | NEW "Reference repos" section: read-only contract, `## Related repos` H2 spelling rule, sentinel teaching, role hybrid description |
+
+---
+
+## PR 1 — Backend + Ask Path Migration
+
+### Task 1: `JobResult.RefViolations` schema field
+
+**Files:**
+- Modify: `shared/queue/job.go`
+- Test: `shared/queue/job_test.go`
+
+**Background:**
+
+Worker emits violations as `[]string` (owner/name list) into the result envelope. App side decides what to do — Ask uses it for metric only, Issue uses it for fail-fast (PR 2). `omitempty` is mandatory so old jobs / non-ref jobs serialize byte-for-byte unchanged.
+
+Spec ref: §4.1, grill Q7.
+
+**Steps:**
+
+- [ ] **1.1 Add `RefViolations` to `JobResult`.**
+
+  In `shared/queue/job.go::JobResult`, append after `OutputTokens`:
+
+  ```go
+  // RefViolations lists ref repos (owner/name) where post-execute guard
+  // detected agent writes. App side decides how to react — Ask logs metric
+  // only; Issue treats non-empty as a fail-fast signal (no GitHub push).
+  RefViolations []string `json:"ref_violations,omitempty"`
+  ```
+
+- [ ] **1.2 Round-trip test.**
+
+  In `shared/queue/job_test.go`:
+
+  ```go
+  func TestJobResult_RefViolations_RoundTrip(t *testing.T) {
+      in := JobResult{JobID: "j1", Status: "completed", RefViolations: []string{"foo/bar", "baz/qux"}}
+      raw, err := json.Marshal(in)
+      if err != nil { t.Fatal(err) }
+      var out JobResult
+      if err := json.Unmarshal(raw, &out); err != nil { t.Fatal(err) }
+      if !reflect.DeepEqual(in.RefViolations, out.RefViolations) {
+          t.Fatalf("RefViolations mismatch: in=%v out=%v", in.RefViolations, out.RefViolations)
+      }
+  }
+
+  func TestJobResult_NoRefViolations_OmitEmpty(t *testing.T) {
+      raw, err := json.Marshal(JobResult{JobID: "j1", Status: "completed"})
+      if err != nil { t.Fatal(err) }
+      if strings.Contains(string(raw), "ref_violations") {
+          t.Fatalf("expected ref_violations omitted, got: %s", raw)
+      }
+  }
+  ```
+
+**Verification:**
+- [ ] `go test ./shared/queue/...` passes.
+- [ ] Existing `JobResult` tests still green (no break).
+
+**Estimated scope:** XS (1 file + test, ~30 LOC).
+
+---
+
+### Task 2: Metric unification
+
+**Files:**
+- Modify: `shared/metrics/metrics.go`
+
+**Background:**
+
+PR #220 introduced `AskRefWriteViolationsTotal{repo}` (workflow not in label set). Issue grill Q7 unified metric to `RefWriteViolationsTotal{workflow, repo}` so both workflows report through the same counter. User memory confirms pre-launch state — backwards-incompatible metric rename is acceptable.
+
+Spec ref: §1 condition 6, grill Q7.
+
+**Steps:**
+
+- [ ] **2.1 Drop `AskRefWriteViolationsTotal` declaration + registry.**
+
+  In `shared/metrics/metrics.go` near line 119-126: remove the var block and its `AskRefWriteViolationsTotal,` entry in the registry list at line ~214.
+
+- [ ] **2.2 Add `RefWriteViolationsTotal{workflow,repo}`.**
+
+  In the same file, in the same area:
+
+  ```go
+  // RefWriteViolationsTotal counts post-execute guard violations: an
+  // agent that wrote into a ref worktree. Labelled by workflow ("ask"
+  // or "issue") and repo. Ask path increments without failing the job;
+  // Issue path increments and fails (no GitHub push).
+  var RefWriteViolationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+      Namespace: "agentdock",
+      Subsystem: "worker",
+      Name:      "ref_write_violations_total",
+      Help:      "Post-execute guard detected agent writing into ref worktree.",
+  }, []string{"workflow", "repo"})
+  ```
+
+  Add `RefWriteViolationsTotal,` to the registry list.
+
+**Verification:**
+- [ ] `go build ./shared/metrics/...` succeeds.
+- [ ] `grep -r AskRefWriteViolationsTotal` returns no hits other than git history.
+
+**Estimated scope:** XS (1 file, ~15 LOC net).
+
+---
+
+### Task 3: Worker `runRefGuard` refactor (callback abstraction removed)
+
+**Files:**
+- Modify: `worker/pool/executor.go`
+- Test: `worker/pool/executor_test.go`
+
+**Background:**
+
+PR #220's `RefViolationCallback` abstraction was designed for a strict-injection point that grill Q2 moved to app side. With strict logic gone from worker, the callback's only job is "warn log" — the abstraction has nothing to abstract. Q9 ratified the cut. `runRefGuard` becomes inline-log + return `[]string` of violations; `executeJob` writes the slice into `JobResult.RefViolations`.
+
+Note worker is now task-agnostic about ref violations (does not look at `Job.TaskType`); metric emission moves to app side (Task 5).
+
+Spec ref: §4.3, grill Q2 + Q9.
+
+**Steps:**
+
+- [ ] **3.1 Drop the callback abstraction.**
+
+  In `worker/pool/executor.go`, remove:
+  - `RefViolationCallback` type declaration (around line 217-223)
+  - `askLenientRefViolation` func (around line 225-235)
+  - The `metrics.AskRefWriteViolationsTotal.WithLabelValues(...).Inc()` call inside it
+
+- [ ] **3.2 Rewrite `runRefGuard` to return violations.**
+
+  Replace the existing `runRefGuard` (around line 247-266):
+
+  ```go
+  // runRefGuard walks successful ref worktrees, runs `git status --porcelain`
+  // in each, warn-logs on dirty bits, and returns the owner/name list of
+  // violating refs. Caller writes the slice into JobResult.RefViolations;
+  // app side decides how to react. `git status` failure is debug-logged and
+  // skipped (a corrupt worktree shouldn't escalate; cleanup runs anyway).
+  func runRefGuard(refs []queue.RefRepoContext, logger *slog.Logger) []string {
+      if len(refs) == 0 {
+          return nil
+      }
+      var violations []string
+      for _, ref := range refs {
+          out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
+          if err != nil {
+              logger.Debug("ref guard: git status failed; skipping",
+                  "phase", "處理中", "ref", ref.Repo, "error", err)
+              continue
+          }
+          if diff := strings.TrimSpace(string(out)); diff != "" {
+              logger.Warn("agent wrote into ref repo",
+                  "phase", "處理中", "ref", ref.Repo,
+                  "diff_preview", truncateRefDiff(diff))
+              violations = append(violations, ref.Repo)
+          }
+      }
+      return violations
+  }
+  ```
+
+- [ ] **3.3 Wire the slice into `JobResult` from `executeJob`.**
+
+  Around line 200-214 of `executor.go`:
+
+  ```go
+  // BEFORE:
+  // runRefGuard(refContexts, askLenientRefViolation, logger)
+  // return &queue.JobResult{... }
+
+  // AFTER:
+  violations := runRefGuard(refContexts, logger)
+  return &queue.JobResult{
+      JobID:          job.ID,
+      Status:         "completed",
+      RawOutput:      output,
+      RepoPath:       repoPath,
+      StartedAt:      startedAt,
+      FinishedAt:     time.Now(),
+      PrepareSeconds: prepareSeconds,
+      RefViolations:  violations,
+  }
+  ```
+
+- [ ] **3.4 Drop `truncateRefDiff` if it becomes unused — keep otherwise.**
+
+  Verify: `grep truncateRefDiff worker/pool/` after edits. Still referenced inside `runRefGuard`, so keep.
+
+- [ ] **3.5 Rewrite tests.**
+
+  In `worker/pool/executor_test.go`:
+  - Delete `TestRunRefGuard_NilCallback_NoOp` (callback is gone).
+  - Rewrite `TestRunRefGuard_DetectsViolation` to assert returned slice equals `[]string{"foo/bar"}` and a warn log was emitted (use `slogtest` or capture via `slog.NewTextHandler` to a buffer).
+  - Rewrite `TestRunRefGuard_CleanWorktree_NoCallback` → `TestRunRefGuard_CleanWorktree_NoNoise`: assert returned slice is nil and no warn-level log emitted.
+  - Rewrite `TestRunRefGuard_EmptyRefs_NoOp`: assert returned slice is nil.
+
+**Verification:**
+- [ ] `go test ./worker/pool/...` passes.
+- [ ] `grep RefViolationCallback worker/` returns no hits.
+- [ ] `grep askLenientRefViolation worker/` returns no hits.
+- [ ] Existing `TestExecuteJob_MultiRepo_EndToEnd` still green (now also validates `RefViolations` slice on result).
+
+**Estimated scope:** S (2 files, ~80 LOC net change including test rewrite).
+
+---
+
+### Task 4: Shared `refExclusionsFor` helper
+
+**Files:**
+- Create: `app/workflow/refstate.go`
+- Create: `app/workflow/refstate_test.go`
+- Modify: `app/workflow/ask.go`
+
+**Background:**
+
+Grill Q8 ratified DRY boundary: the only piece of ref-state logic worth extracting between Ask and Issue is the candidate-exclusion calculation (primary + already-picked refs). Phase methods, struct fields, and `BranchSelectedRepo` mirror as duplicates because shared abstraction would force generics or hoisting more painful than the duplication itself.
+
+Spec ref: §4.4, grill Q8.
+
+**Steps:**
+
+- [ ] **4.1 Create `app/workflow/refstate.go`.**
+
+  ```go
+  package workflow
+
+  import "github.com/Ivantseng123/agentdock/shared/queue"
+
+  // refExclusionsFor returns repos that should NOT appear as ref candidates:
+  // the primary plus any refs already picked. Shared between Ask and Issue
+  // workflows; both states call this from their RefExclusions() method.
+  func refExclusionsFor(primary string, refs []queue.RefRepo) []string {
+      out := make([]string, 0, 1+len(refs))
+      if primary != "" {
+          out = append(out, primary)
+      }
+      for _, r := range refs {
+          out = append(out, r.Repo)
+      }
+      return out
+  }
+  ```
+
+- [ ] **4.2 Create `app/workflow/refstate_test.go` with three table cases.**
+
+  ```go
+  package workflow
+
+  import (
+      "reflect"
+      "testing"
+
+      "github.com/Ivantseng123/agentdock/shared/queue"
+  )
+
+  func TestRefExclusionsFor(t *testing.T) {
+      cases := []struct {
+          name     string
+          primary  string
+          refs     []queue.RefRepo
+          expected []string
+      }{
+          {"both populated", "foo/bar", []queue.RefRepo{{Repo: "a/b"}, {Repo: "c/d"}}, []string{"foo/bar", "a/b", "c/d"}},
+          {"empty primary", "", []queue.RefRepo{{Repo: "a/b"}}, []string{"a/b"}},
+          {"empty refs", "foo/bar", nil, []string{"foo/bar"}},
+          {"both empty", "", nil, []string{}},
+      }
+      for _, tc := range cases {
+          t.Run(tc.name, func(t *testing.T) {
+              got := refExclusionsFor(tc.primary, tc.refs)
+              if !reflect.DeepEqual(got, tc.expected) && !(len(got) == 0 && len(tc.expected) == 0) {
+                  t.Fatalf("got %v, want %v", got, tc.expected)
+              }
+          })
+      }
+  }
+  ```
+
+- [ ] **4.3 Inline-call from `askState.RefExclusions()`.**
+
+  In `app/workflow/ask.go`, replace the existing `RefExclusions()` body (around line 80-95) with:
+
+  ```go
+  func (s *askState) RefExclusions() []string {
+      if s == nil {
+          return nil
+      }
+      return refExclusionsFor(s.SelectedRepo, s.RefRepos)
+  }
+  ```
+
+  Drop the inline loop and slice construction.
+
+**Verification:**
+- [ ] `go test ./app/workflow/...` passes (Ask ref-state tests still green).
+- [ ] Helper round-trips three table cases.
+
+**Estimated scope:** XS (3 files, ~50 LOC including test).
+
+---
+
+### Task 5: Ask path metric migration to `result_listener`
+
+**Files:**
+- Modify: `app/bot/result_listener.go`
+- Test: `app/bot/result_listener_test.go`
+
+**Background:**
+
+Worker no longer emits the metric (Task 3 dropped `askLenientRefViolation`). App side `result_listener` now reads `r.RefViolations` and emits `RefWriteViolationsTotal{workflow, repo}` for each entry. For Ask, this is purely observability — no fail-fast. For Issue (handled later in PR 2 inside `createAndPostIssue`), the same data triggers fail-fast at step s1 of the body normalization pipeline.
+
+Spec ref: §1 condition 6, AC-I13, grill Q7.
+
+**Steps:**
+
+- [ ] **5.1 Identify the dispatch point.**
+
+  In `app/bot/result_listener.go`, locate where a `completed` `JobResult` is dispatched to its workflow (likely a `switch state.Job.TaskType` block or equivalent). Confirm the result envelope (`r *queue.JobResult`) is in scope at that point.
+
+- [ ] **5.2 Add metric emission before dispatch.**
+
+  Once per result, for any non-empty `r.RefViolations`, emit one counter increment per repo:
+
+  ```go
+  if len(r.RefViolations) > 0 {
+      for _, repo := range r.RefViolations {
+          metrics.RefWriteViolationsTotal.WithLabelValues(state.Job.TaskType, repo).Inc()
+      }
+  }
+  ```
+
+  Place this emission **before** the workflow dispatch — it should fire for both Ask (lenient, continues to dispatch) and Issue (strict, dispatches to `createAndPostIssue` which then fail-fasts in PR 2's s1).
+
+- [ ] **5.3 Test Ask path: metric emitted, no fail.**
+
+  In `app/bot/result_listener_test.go`, add:
+
+  ```go
+  func TestResultListener_AskRefViolations_EmitsMetricNoFail(t *testing.T) {
+      // Setup: Ask job with completed result, RefViolations=["foo/bar"]
+      // Assert: counter ref_write_violations_total{workflow="ask",repo="foo/bar"} == 1
+      // Assert: workflow.HandleCompletedResult was called (Ask still dispatches)
+  }
+  ```
+
+  Use the existing fakes in `result_listener_test.go` for the workflow/metric assertions.
+
+- [ ] **5.4 Test Issue path: metric emitted, dispatch reaches createAndPostIssue.**
+
+  Same shape, `state.Job.TaskType == "issue"`. Issue's actual fail-fast is tested in PR 2's Task 10; this test only verifies the metric fires before dispatch.
+
+**Verification:**
+- [ ] `go test ./app/bot/...` passes.
+- [ ] Manually confirm metric label values via test (`workflow="ask"` not `workflow="askLenient"` etc.).
+
+**Estimated scope:** S (2 files, ~60 LOC including tests).
+
+---
+
+### Checkpoint: PR 1 Ready
+
+- [ ] `go test ./...` passes for `shared/`, `worker/`, `app/`.
+- [ ] `go build ./cmd/agentdock/` succeeds.
+- [ ] `test/import_direction_test.go` passes (no module-boundary violation).
+- [ ] `grep -r AskRefWriteViolationsTotal\|RefViolationCallback\|askLenientRefViolation .` returns 0 hits in code (only git history).
+- [ ] Ask flow regression: tests in `app/workflow/ask_test.go` for ref-violation paths still green.
+- [ ] Manual sanity: send an Ask job with `RefRepos`, confirm `ref_write_violations_total{workflow="ask"}` increments on violation.
+- [ ] Open PR 1; await human review + CI green before starting PR 2.
+
+---
+
+## PR 2 — Issue Frontend + e2e
+
+### Task 6: `issueState` extensions + helper methods
+
+**Files:**
+- Modify: `app/workflow/issue.go`
+
+**Background:**
+
+`issueState` mirrors `askState` for the four ref fields and the two interface methods. The phase methods themselves are Task 7. This task is the type / state / interface plumbing only.
+
+Spec ref: §4.4, grill Q8.
+
+**Steps:**
+
+- [ ] **6.1 Extend `issueState` with 4 ref fields.**
+
+  In `app/workflow/issue.go::issueState` (around line 30-35), append:
+
+  ```go
+  // Multi-repo (ref) state. Mirrors askState's same fields exactly — see
+  // ask.go for full doc. AddRefs is the user's yes/no on the decide prompt;
+  // RefRepos accumulates as each ref is picked (Branch is filled in the per-
+  // ref branch loop). RefBranchIdx steps the per-ref branch picker forward.
+  // BranchTargetRepo is the transient "which repo are we asking branches
+  // for right now" — set before each branch select phase (primary OR ref).
+  AddRefs          bool
+  RefRepos         []queue.RefRepo
+  RefBranchIdx     int
+  BranchTargetRepo string
+  ```
+
+- [ ] **6.2 Update `BranchSelectedRepo` to read `BranchTargetRepo`.**
+
+  Replace the existing one-liner:
+
+  ```go
+  func (s *issueState) BranchSelectedRepo() string {
+      if s == nil {
+          return ""
+      }
+      return s.BranchTargetRepo
+  }
+  ```
+
+  Note: existing primary-only paths set `BranchTargetRepo = SelectedRepo` (Task 7 wires this).
+
+- [ ] **6.3 Add `RefExclusions()`.**
+
+  ```go
+  // RefExclusions satisfies workflow.RefExclusionReader. Mirrors askState.
+  func (s *issueState) RefExclusions() []string {
+      if s == nil {
+          return nil
+      }
+      return refExclusionsFor(s.SelectedRepo, s.RefRepos)
+  }
+  ```
+
+**Verification:**
+- [ ] `go build ./app/workflow/...` succeeds.
+- [ ] `go test ./app/workflow/...` still green (issueState tests pass; new methods covered in Task 12).
+
+**Estimated scope:** S (1 file, ~30 LOC).
+
+---
+
+### Task 7: 4 ref-flow phase methods + state machine wiring
+
+**Files:**
+- Modify: `app/workflow/issue.go`
+
+**Background:**
+
+This is the bulk of PR 2. Each method mirrors the Ask equivalent in shape — only string differences (phase names, prompt text "建 issue" vs "問問題") plus the state-machine transitions hooked into `issue.go`'s existing `Selection` switch. Spec §4.4 explicitly: "phase methods directly mirror; only phase names + prompt text differ".
+
+The state machine entry into the ref flow happens after primary branch is picked (or skipped). The `maybeAskRefStep` gate decides whether to enter or skip based on candidate-pool size (mirrors Ask AC-12 zero-candidate skip).
+
+Spec ref: §4.4, grill Q8 (mirror, not abstract).
+
+**Steps:**
+
+- [ ] **7.1 Add `maybeAskRefStep`.**
+
+  Mirror `app/workflow/ask.go::maybeAskRefStep`. Drop one in `issue.go`:
+
+  ```go
+  func (w *IssueWorkflow) maybeAskRefStep(p *Pending) NextStep {
+      list, useExternalSearch := w.refCandidates(p)
+      if !useExternalSearch && len(list) == 0 {
+          return w.descriptionPromptStep(p)  // Issue's post-branch step
+      }
+      p.Phase = "issue_ref_decide"
+      return NextStep{
+          Kind: NextStepSelector,
+          Selector: &SelectorSpec{
+              Prompt:   ":books: 加入參考 repo 嗎？(唯讀脈絡)",
+              ActionID: "issue_ref_decide",
+              Options: []SelectorOption{
+                  {Label: "加入", Value: "add"},
+                  {Label: "不用", Value: "skip"},
+              },
+          },
+          Pending: p,
+      }
+  }
+  ```
+
+  Note: `descriptionPromptStep` is Issue's post-branch step. Replaces Ask's `priorAnswerOrDescriptionStep` (Issue has no prior-answer flow). Verify that name in `issue.go` before stamping.
+
+- [ ] **7.2 Add `refCandidates`.**
+
+  Direct mirror — same code as `ask.go::refCandidates`, just the closure receiver changes. The candidate filter logic is workflow-agnostic.
+
+- [ ] **7.3 Add `refPickStep` / `refContinueStep` / `nextRefBranchStep`.**
+
+  Each is a near-byte-for-byte port of the Ask version with `ask_ref_*` action IDs renamed to `issue_ref_*`. The branch-select fallback logic (skip when `branch_select` disabled, auto-fill when ≤ 1 branch) is identical to Ask's primary-branch handling.
+
+- [ ] **7.4 Wire `Selection` switch.**
+
+  In `issue.go::Selection`, add cases for the four new actions. The shape mirrors `ask.go`'s newer cases (PR #222):
+
+  ```go
+  case "issue_ref_decide":
+      if value == "skip" {
+          st.AddRefs = false
+          return w.descriptionPromptStep(p), nil
+      }
+      st.AddRefs = true
+      return w.refPickStep(p), nil
+
+  case "issue_ref_pick":
+      if value == "back_to_decide" || value == "issue_ref_back" || value == "← 不加 ref" {
+          st.AddRefs = false
+          return w.descriptionPromptStep(p), nil
+      }
+      st.RefRepos = append(st.RefRepos, queue.RefRepo{
+          Repo:     value,
+          CloneURL: cleanCloneURL(value),
+      })
+      st.RefBranchIdx = len(st.RefRepos) - 1
+      return w.nextRefBranchStep(p), nil
+
+  case "issue_ref_continue":
+      switch value {
+      case "more":
+          return w.refPickStep(p), nil
+      case "done":
+          return w.descriptionPromptStep(p), nil
+      default:
+          return NextStep{Kind: NextStepError, ErrorText: fmt.Sprintf(":x: unexpected ref_continue value: %q", value)}, nil
+      }
+
+  case "issue_ref_branch":
+      if value == "取消" {
+          return NextStep{Kind: NextStepCancel}, nil
+      }
+      st.RefRepos[st.RefBranchIdx].Branch = value
+      return w.refContinueStep(p), nil
+  ```
+
+- [ ] **7.5 Hook `maybeAskRefStep` into the post-primary-branch path.**
+
+  Wherever Issue's existing flow currently calls `descriptionPromptStep(p)` after primary repo+branch settle (search `issue.go::Selection` for `branch_select` and `descriptionPromptStep`), replace those calls with `w.maybeAskRefStep(p)`. The gate skips back to `descriptionPromptStep` when there are no ref candidates, so behaviour for single-repo channels is preserved (AC-I11 / Ask AC-12 equivalent).
+
+- [ ] **7.6 Set `BranchTargetRepo` before each branch picker.**
+
+  Before posting the primary branch picker, set `st.BranchTargetRepo = st.SelectedRepo`. Inside `nextRefBranchStep`, set `st.BranchTargetRepo = st.RefRepos[st.RefBranchIdx].Repo` before posting. Without this, `BranchSelectedRepo()` returns the wrong repo for the type-ahead branch suggestion handler.
+
+**Verification:**
+- [ ] `go build ./app/workflow/...` succeeds.
+- [ ] Behaviour-level tests in Task 12.
+
+**Estimated scope:** M (1 file, ~280 LOC).
+
+---
+
+### Task 8: `BuildJob` ref-aware `output_rules` injection
+
+**Files:**
+- Modify: `app/workflow/issue.go`
+
+**Background:**
+
+When `RefRepos` is non-empty, three rules are appended to `OutputRules`. Two pair with SKILL.md guidance (Layer 1) for double-defence; one is Issue-only (the `## Related repos` H2 spelling lock).
+
+Spec ref: §4.6 Layer 2, grill Q3 + Q6.
+
+**Steps:**
+
+- [ ] **8.1 Locate `BuildJob` and the existing `OutputRules` source.**
+
+  In `issue.go::BuildJob` (around line ~530-600 — verify exact line), find where `Workflows.Issue.Prompt.OutputRules` is read into a local `outputRules` var.
+
+- [ ] **8.2 Append three rules when `len(st.RefRepos) > 0`.**
+
+  ```go
+  outputRules := w.cfg.Workflows.Issue.Prompt.OutputRules
+  if len(st.RefRepos) > 0 {
+      outputRules = append(outputRules,
+          "不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。",
+          "若 <unavailable_refs> 含關鍵 ref，必須在 issue body 中加入 HTML comment：<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE --> （位置不限，存在即 fail-fast）；worker 偵測到此 marker 即不送 issue 到 GitHub。不要 best-effort 拼湊內容。",
+          "Issue body 必須包含 `## Related repos` 段，heading spelling 為 `## Related repos`（lowercase repos），列出 <ref_repos> 中每個 repo 與其角色（含 primary）。Role 不確定時寫 `reference context`。",
+      )
+  }
+  ```
+
+  Pass `outputRules` into the `Job.PromptContext.OutputRules` field as already done.
+
+- [ ] **8.3 Wire `Job.RefRepos` from `st.RefRepos`.**
+
+  Same place — set `Job.RefRepos = st.RefRepos` in the assembled job. Mirror `ask.go::BuildJob`.
+
+**Verification:**
+- [ ] `go build ./app/workflow/...` succeeds.
+- [ ] Behaviour test in Task 12 covers AC-I9.
+
+**Estimated scope:** S (1 file, ~20 LOC).
+
+---
+
+### Task 9: `app/app.go` BlockSuggestion routing for ref + ref-branch
+
+**Files:**
+- Modify: `app/app.go`
+
+**Background:**
+
+PR #222 added `ask_ref` (handled by `HandleRefRepoSuggestion`) and `ask_ref_branch` (reuses `HandleBranchSuggestion`). Issue mirrors with `issue_ref` and `issue_ref_branch`. Both handlers are workflow-agnostic at this layer — they read state via the `RefExclusionReader` / `BranchStateReader` interfaces, which `issueState` now implements (Task 6).
+
+Spec ref: §4.4.
+
+**Steps:**
+
+- [ ] **9.1 Add cases.**
+
+  In `app/app.go::handleSocketEvent`'s `BlockSuggestion` switch (around line ~580-600 — find the existing `ask_ref` case from PR #222):
+
+  ```go
+  case "ask_ref", "issue_ref":
+      ackSuggestions("Ref repo 搜尋結果", wf.HandleRefRepoSuggestion(cb.Container.MessageTs, cb.Value))
+  case "branch_select", "ask_branch", "ask_ref_branch", "issue_branch", "issue_ref_branch":
+      ackSuggestions("Branch 搜尋結果", wf.HandleBranchSuggestion(cb.Container.MessageTs, cb.Value))
+  ```
+
+  Note `issue_branch` may also need adding if the existing primary-branch picker for Issue uses a different action_id — verify in `issue.go`. If primary path already uses `branch_select` (the catch-all), only add `issue_ref_branch`.
+
+**Verification:**
+- [ ] `go build ./cmd/agentdock/` succeeds.
+- [ ] e2e in Task 13 confirms the routing wires up.
+
+**Estimated scope:** XS (1 file, ~5 LOC).
+
+---
+
+### Task 10: `createAndPostIssue` 5-step body normalization pipeline
+
+**Files:**
+- Modify: `app/workflow/issue.go`
+- Test: `app/workflow/issue_test.go` (deferred to Task 12; this task is impl only)
+
+**Background:**
+
+The pipeline runs inside the existing `createAndPostIssue` function, between `parsed.Body` extraction and the `w.github.CreateIssue` call. Order is fixed (grill Q4): s1 RefViolations → s2 sentinel → existing stripTriageSection → s3 prepend → existing Redact → CreateIssue. Each new step is short; the function grows by ~80 LOC.
+
+Spec ref: §4.7, grill Q1/Q3/Q4/Q5/Q6.
+
+**Steps:**
+
+- [ ] **10.1 Add the regex helper for `## Related repos` detection.**
+
+  At package level in `issue.go`:
+
+  ```go
+  // relatedReposHeadingRE matches H1-H4 markdown headings whose text starts
+  // "Related rep…" (singular, plural, or Repositories), case-insensitive.
+  // Spec §4.7 / grill Q3 — loose enough to cover normal LLM variation,
+  // strict enough to refuse non-heading mentions (bold inline / Chinese).
+  var relatedReposHeadingRE = regexp.MustCompile(`(?im)^#{1,4}\s+related\s+rep`)
+
+  func hasRelatedReposSection(body string) bool {
+      return relatedReposHeadingRE.MatchString(body)
+  }
+  ```
+
+- [ ] **10.2 Add the sentinel constant.**
+
+  ```go
+  // criticalSentinel is the HTML-comment marker the agent emits when it
+  // judges that a critical ref is unavailable and the issue should not
+  // be created. Detection is plain Contains; format is fixed (no repo
+  // name) — the worker reads UnavailableRefs for the actual list.
+  // Spec §4.7 / grill Q6.
+  const criticalSentinel = "<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->"
+  ```
+
+- [ ] **10.3 Add `prependRelatedRepos` helper.**
+
+  ```go
+  func prependRelatedRepos(body string, job *queue.Job) string {
+      var sb strings.Builder
+      sb.WriteString("## Related repos\n\n")
+      sb.WriteString(formatRefLine(job.Repo, job.Branch, "primary（issue 開立目標）"))
+      for _, ref := range job.RefRepos {
+          sb.WriteString(formatRefLine(ref.Repo, ref.Branch, "reference context"))
+      }
+      sb.WriteString("\n---\n\n")
+      sb.WriteString(body)
+      return sb.String()
+  }
+
+  func formatRefLine(repo, branch, role string) string {
+      if branch == "" {
+          return fmt.Sprintf("- `%s` — %s\n", repo, role)
+      }
+      return fmt.Sprintf("- `%s@%s` — %s\n", repo, branch, role)
+  }
+  ```
+
+- [ ] **10.4 Insert the 5-step pipeline into `createAndPostIssue`.**
+
+  In `issue.go::createAndPostIssue`, immediately after `body := parsed.Body` (currently around line 390):
+
+  ```go
+  // [s1] strict guard: ref violations from worker → fail, no push.
+  if len(r.RefViolations) > 0 {
+      msg := fmt.Sprintf(
+          ":no_entry: 無法建立 issue：agent 違規寫入 ref repo `%s`，job 結果不可信。請重 trigger。",
+          strings.Join(r.RefViolations, ", "))
+      w.updateStatus(job, msg)
+      metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_ref_violation").Inc()
+      return nil
+  }
+
+  // [s2] critical sentinel: agent flagged unrecoverable critical-ref
+  // missing context → fail, no push, list UnavailableRefs in banner.
+  if strings.Contains(body, criticalSentinel) {
+      repoList := strings.Join(job.PromptContext.UnavailableRefs, ", ")
+      msg := fmt.Sprintf(
+          ":no_entry: 無法建立 issue：以下 ref repo 不可達，agent 判定關鍵脈絡缺失\n- %s\n\n請確認 worker GH_TOKEN 對這些 repo 有讀權後重 trigger。",
+          repoList)
+      w.updateStatus(job, msg)
+      metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_critical_ref").Inc()
+      return nil
+  }
+
+  // [s4 — existing] degraded triage strip (already in code below).
+
+  // ... existing degraded-mode stripTriageSection block stays put ...
+
+  // [s3] auto-fill `## Related repos` if agent didn't write it.
+  // Runs after stripTriageSection so degraded mode can't strip the prepend.
+  if len(job.RefRepos) > 0 && !hasRelatedReposSection(body) {
+      body = prependRelatedRepos(body, job)
+  }
+
+  // [s5 — existing] Redact secrets — runs after prepend so worker-added
+  // content is also redacted (defense in depth).
+
+  // ... existing Redact / CreateIssue calls stay put ...
+  ```
+
+  Verify the order in the rendered diff matches s1 → s2 → s4 → s3 → s5 → s6. The guard for s3 is **`len(job.RefRepos) > 0`** — not `RefRepos != nil` — to handle empty-but-non-nil slices safely.
+
+- [ ] **10.5 Add the `regexp` and (if missing) `strings` imports to `issue.go`.**
+
+**Verification:**
+- [ ] `go build ./app/workflow/...` succeeds.
+- [ ] Tests in Task 12.
+
+**Estimated scope:** M (1 file + helpers, ~120 LOC).
+
+---
+
+### Task 11: `triage-issue/SKILL.md` update
+
+**Files:**
+- Modify: `app/agents/skills/triage-issue/SKILL.md`
+
+**Background:**
+
+SKILL.md is Layer 1 (soft guidance). Three rule blocks added under a new "Reference repos" section: read-only contract (mirrors ask-assistant), `## Related repos` H2 spelling rule with role-hybrid description, critical-unavailable sentinel teaching. Output_rules (Task 8) is Layer 2 hard constraint; SKILL is the agent's first read.
+
+Spec ref: §4.6 Layer 1, grill Q3/Q5/Q6.
+
+**Steps:**
+
+- [ ] **11.1 Append a "Reference repos" section** in the appropriate SKILL.md location.
+
+  Use the spec §4.6 Layer 1 verbatim block as the source of truth (already finalized during grill). Three sub-blocks:
+  1. Read-only contract: CAN grep/read; CANNOT write/commit/edit/mv/rm; absolute paths from `<ref_repos>`; citation format.
+  2. `## Related repos` is hard requirement: H2 spelling exact (`## Related repos`, lowercase repos); per-entry format `- `<owner/name>@<branch>` — <role>``; role hybrid (agent picks if confident, `reference context` if not).
+  3. Critical-unavailable sentinel: when `<unavailable_refs>` contains a critical repo, insert `<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->` (anywhere in body); do not best-effort patchwork. Non-critical → mark role as `unavailable` in `## Related repos`.
+
+- [ ] **11.2 Cross-check section numbering in `triage-issue/SKILL.md`.**
+
+  Where this section lands depends on existing structure (probably after action-boundaries / before output-format sections). Match the placement style used in `ask-assistant/SKILL.md`'s "Reference repos" subsection (which is in the action-boundaries block).
+
+**Verification:**
+- [ ] Spec §4.6 Layer 1 instructions appear verbatim in the file.
+- [ ] No conflict with existing SKILL guidance (e.g. don't accidentally contradict an earlier "you may modify any file" rule — search first).
+- [ ] e2e (Task 13) confirms agent honours the rules.
+
+**Estimated scope:** S (1 markdown file, ~80 LOC).
+
+---
+
+### Task 12: Tests — phase flow + pipeline coverage
+
+**Files:**
+- Test: `app/workflow/issue_test.go`
+
+**Background:**
+
+Direct port of `ask_test.go`'s ref-flow test suite, plus pipeline-specific cases for the s1/s2/s3 normalization. Split into two halves to keep each commit reviewable.
+
+Spec ref: §6, AC-I1 through AC-I12.
+
+**Steps:**
+
+- [ ] **12.1 Phase-flow tests (mirror ask_test.go).**
+
+  Port these tests, swapping `ask_*` names and prompts to `issue_*`:
+  - `TestIssueWorkflow_RefFlow_DecidePromptOffered`
+  - `TestIssueWorkflow_RefFlow_ZeroCandidatesSkipsDecide` (AC-I11 zero-candidate)
+  - `TestIssueWorkflow_RefFlow_DecideAddRoutesToPick`
+  - `TestIssueWorkflow_RefFlow_DecideSkipRoutesToDescription` (Issue's post-skip step is description, not prior-answer)
+  - `TestIssueWorkflow_RefFlow_PickFiltersPrimary`
+  - `TestIssueWorkflow_RefFlow_PickAccumulatesAndContinues`
+  - `TestIssueWorkflow_RefFlow_PickDedupAlreadyPicked`
+  - `TestIssueWorkflow_RefFlow_ContinueExhaustedPoolHidesMore`
+  - `TestIssueWorkflow_RefFlow_ContinueDoneEntersDescriptionStep`
+  - `TestIssueWorkflow_RefFlow_PerRefBranchPicker`
+  - `TestIssueWorkflow_BuildJob_WithRefs_PopulatesJobAndRules` (AC-I9 — three rules appended)
+  - `TestIssueWorkflow_BuildJob_NoRefs_NoRulesInjected` (regression)
+  - `TestIssueState_RefExclusions_PrimaryAndPicked`
+  - `TestIssueState_BranchSelectedRepo_FollowsBranchTarget`
+
+- [ ] **12.2 Pipeline-specific tests for `createAndPostIssue`.**
+
+  Use a fake `IssueCreator` to capture `CreateIssue(...)` arguments (or assert it isn't called). Cases:
+
+  - `TestCreateAndPostIssue_S1_RefViolations_FailsAndDoesNotPush` (AC-I7) — JobResult with `RefViolations: ["foo/bar"]`, assert `IssueCreator.CreateIssue` not called, `WorkflowCompletionsTotal{outcome="rejected_ref_violation"}` += 1, Slack banner contains "foo/bar".
+  - `TestCreateAndPostIssue_S2_CriticalSentinel_FailsAndDoesNotPush` (AC-I12) — body contains `<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->`, `Job.PromptContext.UnavailableRefs = ["broken/repo"]`, assert `CreateIssue` not called, banner lists `broken/repo`, metric `outcome="rejected_critical_ref"`.
+  - `TestCreateAndPostIssue_S3_AgentWroteRelatedRepos_NotPrepended` (AC-I4) — body already contains `## Related repos`, assert `CreateIssue` called with body unchanged (apart from Redact).
+  - `TestCreateAndPostIssue_S3_AgentMissed_PrependsMinimal` (AC-I5) — body without the heading, `Job.RefRepos` non-empty; assert pushed body starts with `## Related repos\n\n- `<primary>@<branch>` — primary（issue 開立目標）\n…`.
+  - `TestCreateAndPostIssue_S3_NoRefs_NoOp` (AC-I6) — empty `RefRepos`, body lacks heading; assert no prepend; pushed body equals input.
+  - `TestHasRelatedReposSection_RegexVariants` (AC-I10) — table-test asserting regex hits all of: `## Related repos`, `## Related Repos`, `## Related Repositories`, `### Related Repo`, `# RELATED REPOS`; misses: `## 相關 repos`, `**Related repos:**`, plain-text mention in a paragraph.
+
+- [ ] **12.3 Sanity: order of pipeline steps.**
+
+  Add one integration-style test:
+
+  ```go
+  func TestCreateAndPostIssue_PipelineOrder_S1BeforeS2BeforeS3(t *testing.T) {
+      // 1. RefViolations + sentinel both present → s1 wins (rejected_ref_violation, not rejected_critical_ref).
+      // 2. Sentinel present + s4 strip-target absent + Related-repos missing → s2 fires before s3 attempts to prepend (s3 should never run on a fail path).
+  }
+  ```
+
+**Verification:**
+- [ ] `go test ./app/workflow/...` all green.
+- [ ] Coverage for AC-I1 through AC-I12 traceable to a test.
+
+**Estimated scope:** L (1 file, ~600 LOC including phase mirror + pipeline cases). If the agent finds this too large in one session, split 12.1 and 12.2 into separate commits.
+
+---
+
+### Task 13: Slack e2e + GitHub real-issue verification
+
+**Files:**
+- None (manual procedure; outputs go to PR description)
+
+**Background:**
+
+Final smoke test before review. Run against the `ai_trigger_issue_bot` test channel (per user memory `project_slack_bot_identities.md`). Spec §6 Slack UX manual verification.
+
+**Steps:**
+
+- [ ] **13.1 Build and deploy locally.**
+
+  Build app+worker; run worker against the test channel.
+
+- [ ] **13.2 0-ref regression.**
+
+  Trigger `@bot issue` in a single-repo channel (or skip ref decide via channel config); assert flow is unchanged from main; issue body contains no `## Related repos` (AC-I6).
+
+- [ ] **13.3 1-ref happy path, multi-repo channel.**
+
+  In a channel with 2-3 configured repos: decide-add → pick a ref → continue done → primary branch → ref branch (if applicable) → description → submit. Assert:
+  - Permanent thread message rows from ref flow ≤ 2 (AC-I11; selector uses `chat.update`).
+  - GitHub issue body has `## Related repos` H2 with primary + 1 ref.
+
+- [ ] **13.4 3-ref full flow.**
+
+  Same channel; pick 3 refs. Assert AC-I11 still ≤ 2 rows; issue body lists 4 entries (1 primary + 3 ref); each row matches `` `<owner/name>@<branch>` — <role> `` where roles are agent-judged (or `reference context` if agent omitted).
+
+- [ ] **13.5 Strict guard: force ref write violation.**
+
+  Use a worker hook or a contrived skill prompt that writes a file under one of the ref worktrees during agent execution. Trigger an issue request. Assert:
+  - Issue **not** pushed to GitHub (verify via `gh`).
+  - Slack banner: `:no_entry: 無法建立 issue：agent 違規寫入 ref repo \`<repo>\`…`.
+  - Metric: `ref_write_violations_total{workflow="issue", repo="<repo>"} > 0`.
+  - Metric: `workflow_completions_total{workflow="issue", outcome="rejected_ref_violation"} += 1`.
+
+- [ ] **13.6 Critical sentinel: force ref clone failure.**
+
+  Pick a ref the worker's PAT can't read. Phrase the question so the agent considers the ref critical and emits the sentinel. Assert:
+  - Issue **not** pushed.
+  - Slack banner lists the unavailable ref's owner/name.
+  - Metric: `workflow_completions_total{workflow="issue", outcome="rejected_critical_ref"} += 1`.
+
+- [ ] **13.7 Capture screenshots.**
+
+  Slack thread + GitHub issue body shots; paste into PR 2 description.
+
+**Verification:**
+- [ ] All 5 manual flows above complete with expected outcomes.
+- [ ] Screenshots in PR description (≥ 4 — happy path, 3-ref, strict fail, sentinel fail).
+
+**Estimated scope:** XS LOC (no code), high wall-clock (~1-2 hours real-time validation).
+
+---
+
+### Checkpoint: PR 2 Ready
+
+- [ ] `go test ./...` green.
+- [ ] `test/import_direction_test.go` green.
+- [ ] AC-I1 through AC-I13 each traceable to a test or e2e step.
+- [ ] PR 2 description has Slack + GitHub screenshots.
+- [ ] Open PR 2; await human review.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Strict guard false-positive (agent's read-only ops dirty `git status`) | Med — would block legit issue creation | `git status --porcelain` ignores `.git/` internals; `git fetch` / `git log` won't trip it. Verify in T13.5; if observed, narrow to working-tree-only via explicit pathspec. |
+| Heading regex misses LLM variant (Chinese, bold inline) | Low — worker prepends a duplicate, slightly ugly issue | Spec §4.7 deliberately accepts the duplicate as "agent format violation"; SKILL.md + output_rules pin the spelling. Track real-world variants post-launch. |
+| Sentinel substring false-positive (agent quotes the sentinel in a code block as an example) | Low — would erroneously block issue creation | Sentinel is sufficiently unique (`AGENTDOCK:` prefix + brackets). SKILL.md adds an explicit "do not quote the sentinel" warning. If observed, switch to a nonce-suffixed sentinel. |
+| `BranchTargetRepo` not set in some Task 7 path → branch picker shows wrong candidates | Med — bad UX, type-ahead lists wrong branches | Cover in T12 (`TestIssueState_BranchSelectedRepo_FollowsBranchTarget` — variant for primary AND each ref). |
+| Ask metric migration (T5) breaks Grafana dashboards | Pre-launch → no live dashboards. | User memory `project_deployment_status.md` confirms pre-launch; dashboard rebuild is post-launch concern. |
+| Spec creep — someone adds "auto cross-link in ref repo" mid-implementation | High — violates §3 hard constraint (write only to primary) | Spec §7 "Never do" is explicit; reject mid-flight. |
+
+---
+
+## Open Questions
+
+- T9.1: does Issue's existing primary-branch picker use `branch_select` (catch-all in `app/app.go`) or a workflow-specific action_id? Confirm before stamping the routing change. If specific (`issue_branch`), add it to the case list.
+- T11.2: where exactly in `triage-issue/SKILL.md` should "Reference repos" land? Mirror `ask-assistant/SKILL.md` placement (under §5 action boundaries) — confirm during implementation.
+- T13.5: best mechanism to forcibly write into a ref worktree from the agent — does the test channel allow custom skill prompts, or do we need a dedicated debug harness?
+
+---
+
+## Decision trail to grill-me Q&A
+
+- Q1 + Q6 → T8.2 (rule 2 wording) + T10.2 (constant) + T10.4 (s2) + T11 (SKILL block 3) + T12.2 (sentinel test) + T13.6 (e2e).
+- Q2 → T1 (`JobResult.RefViolations` field) + T3 (worker just reports) + T10 (app decides).
+- Q3 → T8.2 (rule 3 wording) + T10.1 (regex helper) + T11 (SKILL block 2) + T12.2 (regex variants).
+- Q4 → T10.4 (pipeline order s1→s2→s4→s3→s5→s6).
+- Q5 → T10.3 (`reference context` placeholder) + T11 (SKILL block 2 role hybrid).
+- Q7 → T1 + T2 + T3 (worker task-agnostic) + T5 (Ask metric path migration) + T13.5 (e2e metric label assertion).
+- Q8 → T4 (`refExclusionsFor` shared) + T6 (`issueState` mirror, no struct extraction) + T7 (phase methods mirror, not abstracted).
+- Q9 → T3 (`RefViolationCallback` removed).
+- Q10 → entire 2-PR structure of this plan.

--- a/docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md
+++ b/docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md
@@ -1,0 +1,484 @@
+# Issue Workflow: Multi-Repo Reference Support (1 Primary + N Refs)
+
+**Date:** 2026-04-29
+**Status:** Design ratified after grill-me iteration, ready for impl
+**Issue:** #217 (Issue scope)
+**Parent:** #215 (umbrella, 1 primary + N refs model)
+**Sibling, shipped:** #216 / PR #220 + PR #222（Ask 已上線；本 spec 大量引用 Ask spec `2026-04-29-ask-multi-repo-design.md`，以下簡稱 *Ask spec*）
+
+---
+
+## 1. Premise Check
+
+接受 *Ask spec* §1 的全部前提：1 primary + N refs、寫權限只給 primary、加法式 schema、`<primary>-refs/<owner>__<repo>/` sibling 布局、序列 single-select UX、SKILL.md → output_rules → post-execute guard 三層防線。
+
+**Issue 對 Ask 的關鍵差異點與 grill 收斂結論**（後三條為 grill-me 過程中發現的 spec hole 反轉）：
+
+1. **Post-execute guard 採 strict 策略**（推翻 Ask 的 lenient）。理由：Issue 的 output 是要 push 到 GitHub 留永久 trace 的 ticket，cost-of-error 比 Ask 答案高一個量級。ref 違規 = prompt 不可信 = body 內容不可信，整 job fail 比建錯 issue 好。
+2. **砍掉「LLM 自我判斷 root cause 在 ref」+「警示應改在 X 開立」的設計**（推翻 #217 issue 草案）。理由：「issue 該開哪個 repo」是 routing 決策，由 LLM 拍板會製造 false confidence；不確定時 agent 偏向亂標，比沒標還糟。
+3. **Worker 在 push issue 之前自動補 `## Related repos`**（NEW，Ask 沒有對應機制）。理由：「issue body 必須含 ref 引用」這個約束不能依賴 LLM 紀律。
+4. **Worker 純回報、App 決策**（grill Q2 反轉）。原 spec 把 strict guard / sentinel 偵測 / auto-fill 三件事都放 worker——但 codebase verify 顯示 `IssueCreator.CreateIssue` 在 app side（`app/workflow/issue.go:410`），worker 不送 issue。Strict 觸發點、sentinel 偵測、auto-fill 全部移到 app `createAndPostIssue`。Worker 只透過新增的 `JobResult.RefViolations []string` 回報事實。
+5. **砍 PR #220 的 `RefViolationCallback` 抽象**（grill Q9 反轉）。Q2 把 strict 行為移走後，callback 唯一責任剩 warn-log，已不構成抽象的合理性。`runRefGuard` 簡化為 inline log + return slice，相關 type / func 全砍。Pre-launch 階段，無 production 衝擊。
+6. **Metric 遷移為 unified label-based**（grill Q7）。`AskRefWriteViolationsTotal{repo}` 砍，新增 `RefWriteViolationsTotal{workflow, repo}`。**上報點從 worker 搬到 app side `result_listener`**——worker 不認 task semantics。
+
+## 2. Problem
+
+跨 repo bug 的 issue 假裝是 single-repo：前端報錯 issue 開在 frontend repo，但 root cause 在 backend schema 變動。Assignee 拿到 issue 看不到 backend 線索，只能猜或自己重新 trigger。Issue body 不暴露 ref repo 等於白給。
+
+## 3. Goals / Non-Goals
+
+### Goals
+
+1. Issue 可在 primary 之外掛 N 個 ref repo 作為唯讀脈絡（mirror Ask AC-3、AC-4）。
+2. 產出的 issue body 必含 `## Related repos` 段，列出每個 ref repo（worker 反推時用 `reference context` placeholder；agent 可在 body 中改寫成更精確的 role 描述，例如「schema 變動疑似關聯」）。
+3. ref 寫入違規 → app 不送 issue 到 GitHub，回 Slack 失敗 banner（strict guard，由 app side 觸發）。
+4. 不掛 ref 時行為與現在 byte-for-byte 一致（regression-free）。
+5. 共用 Ask 已驗證的 schema / workdir / Slack UX / prompt 機制，不為 Issue 重新發明。
+
+### Non-Goals (本 spec 不做)
+
+- LLM 自我判斷「root cause 在哪個 ref」並警示應改開 issue 在 X repo（→ §1 反轉理由）。
+- Slack 端讓 user 標 ref 角色的多選 phase（會打掉 AC-I11 訊息行數約束；role 由 agent 在 body 中描述、worker 漏寫時補 `reference context` placeholder）。
+- 跨 repo 自動 cross-link（在 ref repo 也開個輕量 issue 互指）— 寫權限約束直接擋。
+- 多 primary（一次建 N 個 issue 在不同 repo）— 違反 "1 primary" 模型。
+- Issue body 結構化驗證做到 schema 強度（如 yaml frontmatter）— `## Related repos` heading 字面 regex 比對就夠。
+- per-ref token / 獨立 auth scope — 沿用 worker 級 PAT。
+- ref repo 共享 cache 優化 — 與 Ask 共命運。
+- PR Review 多 repo — #215 已決議砍。
+- 保留 PR #220 的 `RefViolationCallback` 抽象 — Q9 已決議砍。
+
+## 4. Design
+
+### 4.1 Job Schema 與 JobResult
+
+**Job 端**完全 reuse Ask spec §4.1（已 land：`Job.RefRepos`、`PromptContext.RefRepos`、`PromptContext.UnavailableRefs`）。
+
+**JobResult 端新增**（grill Q7 落實）：
+
+```go
+type JobResult struct {
+    // ...existing fields unchanged...
+    RefViolations []string `json:"ref_violations,omitempty"`  // owner/name list
+}
+```
+
+`omitempty` → 不掛 ref 的 job 結果序列化形狀完全不變。Worker task-agnostic 寫入；Ask 路徑只用來上 metric（lenient），Issue 路徑用來 fail-fast（strict）。
+
+### 4.2 Workdir Layout
+
+完全 reuse Ask spec §4.2。`<primary>-refs/<owner>__<repo>/` sibling worktree、`prepareRefs` / `cleanupRefs` 已 land 在 `worker/pool/workdir.go`。Issue 路徑零差異。
+
+### 4.3 Worker Prepare Flow
+
+Reuse Ask spec §4.3 的 prepare / cleanup 流程。**唯一差異在 post-execute guard 改寫**（grill Q9 落實）。
+
+#### `runRefGuard` 退化為純回報（callback 抽象砍除）
+
+```go
+// worker/pool/executor.go (after refactor)
+func runRefGuard(refs []queue.RefRepoContext, logger *slog.Logger) []string {
+    if len(refs) == 0 {
+        return nil
+    }
+    var violations []string
+    for _, ref := range refs {
+        out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
+        if err != nil {
+            logger.Debug("ref guard: git status failed; skipping",
+                "phase", "處理中", "ref", ref.Repo, "error", err)
+            continue
+        }
+        if diff := strings.TrimSpace(string(out)); diff != "" {
+            logger.Warn("agent wrote into ref repo",
+                "phase", "處理中", "ref", ref.Repo,
+                "diff_preview", truncateRefDiff(diff))
+            violations = append(violations, ref.Repo)
+        }
+    }
+    return violations
+}
+
+// executeJob (after refactor):
+violations := runRefGuard(refContexts, logger)
+return &queue.JobResult{
+    // ...
+    RefViolations: violations,
+}
+```
+
+砍除：
+- `RefViolationCallback` type
+- `askLenientRefViolation` func
+- `runRefGuard` 既有的 `onViolation` 參數
+
+理由：`worker` 不認 task semantics（user memory「App/Worker 區分」精神延伸）；callback 抽象唯一合理性是 strict 注入點，已挪到 app side（§4.7）。
+
+### 4.4 Slack UX
+
+完全 mirror Ask spec §4.4 的序列 single-select + chat.update 模式。**phase action_id 全部換成 `issue_*` 前綴**：
+
+```
+issue_repo_select          → 原有
+issue_branch_select        → 原有
+
+issue_ref_decide           → NEW   "加入參考 repo？" 是 / 否
+issue_ref_pick             → NEW   單選 ref repo
+issue_ref_continue         → NEW   "再加一個 / 開始建 issue"
+issue_ref_branch           → NEW   per-ref branch（跳過規則同 primary）
+
+issue_description_prompt   → 原有
+```
+
+`issueState` 加四個欄位 mirror `askState`：
+
+```go
+type issueState struct {
+    // ...existing fields unchanged...
+
+    AddRefs          bool
+    RefRepos         []queue.RefRepo
+    RefBranchIdx     int
+    BranchTargetRepo string
+}
+```
+
+DRY refactor（grill Q8 落實）：抽 `app/workflow/refstate.go::refExclusionsFor(primary, refs) []string` 共用 helper；其他全部 mirror duplicate（state fields、phase methods、`BuildJob` output_rules append、`BranchSelectedRepo`）。理由：`refExclusionsFor` 是純函數合理 helper；其餘抽出來會引入 hoisting / generics 抽象，比 duplicate 更難維護。
+
+`refExclusionsFor` 簽章：
+
+```go
+// app/workflow/refstate.go
+package workflow
+
+import "github.com/Ivantseng123/agentdock/shared/queue"
+
+func refExclusionsFor(primary string, refs []queue.RefRepo) []string {
+    out := make([]string, 0, 1+len(refs))
+    if primary != "" {
+        out = append(out, primary)
+    }
+    for _, r := range refs {
+        out = append(out, r.Repo)
+    }
+    return out
+}
+```
+
+兩 state struct 各自實作 `RefExclusions()` 一行 inline call、`BranchSelectedRepo()` 各自實作 `return s.BranchTargetRepo`。
+
+`app/app.go BlockSuggestion` 路由加 `issue_ref` / `issue_ref_branch` cases — 與 PR #222 加入的 `ask_ref` / `ask_ref_branch` 對稱，handler reuse `HandleRefRepoSuggestion` / `HandleBranchSuggestion`（已支援 ref pending）。
+
+`maybeAskRefStep` / `refPickStep` / `refContinueStep` / `nextRefBranchStep` 四個 helper 從 `ask.go` 對應方法直接 mirror，phase 名稱換 `issue_ref_*`、prompt 字串改成 issue 語境（"建 issue" 替 "問問題"），其餘邏輯零差異。
+
+候選 0 跳過、dedup、`BranchTargetRepo` 切換邏輯與 Ask AC-10/AC-11/AC-12/AC-13 完全等價，本 spec 不重列。
+
+### 4.5 Prompt Context
+
+完全 reuse Ask spec §4.5。`<ref_repos>` / `<unavailable_refs>` block 已 land 在 `worker/prompt/builder.go`，Issue 路徑零差異。
+
+### 4.6 Skill + Output Rules（三層防線，Issue 版）
+
+#### Layer 1（軟引導）：`app/agents/skills/triage-issue/SKILL.md`
+
+新增 "Reference repos" 段（內容**結構同 Ask 的 ask-assistant SKILL.md** 的 read-only contract、絕對路徑、citation 格式），但加上 Issue 獨有規則（grill Q3、Q5、Q6 落實）：
+
+```markdown
+**Issue body 對 ref 的硬規則**
+
+1. **`## Related repos` 段是 hard requirement**
+
+   When `<ref_repos>` is non-empty, your generated issue body MUST contain
+   a `## Related repos` H2 section. Heading spelling must be exactly
+   `## Related repos` (lowercase repos, no plural). Format:
+
+   ```
+   ## Related repos
+
+   - `frontend/web@main` — primary（issue 開立目標）
+   - `backend/api@release-2026q2` — schema 變動疑似關聯
+   ```
+
+   Each ref entry follows: `` `<owner/name>@<branch>` — <role> ``. The
+   `<role>` field is your judgment based on the question (e.g. "schema
+   變動疑似關聯"). If you don't have a confident role, write
+   `reference context` instead of guessing.
+
+   If you forget this section, the worker will auto-generate a minimal
+   version. Prefer writing your own — you have richer context.
+
+2. **Critical-unavailable sentinel**
+
+   If `<unavailable_refs>` lists a repo that is **critical** to producing
+   a meaningful issue (i.e. you fundamentally need its code to write a
+   useful body), insert this single-line HTML comment anywhere in the
+   body (位置不限):
+
+   ```
+   <!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->
+   ```
+
+   The worker detects this marker and refuses to push the issue to
+   GitHub — the user gets a Slack notification instead. Do not best-
+   effort patchwork an issue body when a critical ref is missing.
+
+3. **Non-critical unavailable**
+
+   If the unavailable ref is non-critical, still produce a complete body,
+   and mark the unavailable ref's role as `unavailable` in `## Related
+   repos`. Do not insert the sentinel.
+```
+
+#### Layer 2（硬約束）：`output_rules` 動態注入
+
+`app/workflow/issue.go::BuildJob` 在 `RefRepos` 非空時 append 三條 `output_rules`（前兩條與 Ask 結構相似但 Issue 版指令不同；第三條為 Issue 獨有）：
+
+```
+不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。
+若 <unavailable_refs> 含關鍵 ref，必須在 issue body 中加入 HTML comment：<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE --> （位置不限，存在即 fail-fast）；worker 偵測到此 marker 即不送 issue 到 GitHub。不要 best-effort 拼湊內容。
+Issue body 必須包含 `## Related repos` 段，heading spelling 為 `## Related repos`（lowercase repos），列出 <ref_repos> 中每個 repo 與其角色（含 primary）。Role 不確定時寫 `reference context`。
+```
+
+第二、三條與 Layer 1 SKILL.md 對應規則做雙保險——`output_rules` 是 prompt 末端的硬約束，即使 SKILL.md 被忽略也能擋。
+
+#### Layer 3（觀察）：Worker post-execute guard
+
+`worker/pool/executor.go::runRefGuard` 對每個成功 prepare 的 ref worktree 跑 `git status --porcelain`：
+- 輸出空 → 不做任何事
+- 輸出非空 → warn log（含 ref + diff preview）+ 累積 repo name 到 violations slice
+- `git status` 自身失敗 → debug log 跳過
+
+Function 返回 violations slice，由 `executeJob` 寫入 `JobResult.RefViolations` 回 app。**Workflow 語義（Ask lenient warn-only / Issue strict fail-fast）的差異全在 app side 處理**（§4.7）。
+
+不再有 callback 抽象——PR #220 既有的 `RefViolationCallback` type 與 `askLenientRefViolation` 在本 spec 砍除。
+
+### 4.7 App-side Body Normalization Pipeline（Layer 4，Issue 獨有）
+
+**位置**：`app/workflow/issue.go::createAndPostIssue`，在現有 `stripTriageSection` / `Redact` / `CreateIssue` 三步之間加四個新步驟。完整 pipeline 順序（grill Q4 落實）：
+
+```
+parsed.Body
+  ↓
+[s1] check result.RefViolations 非空 → fail Slack, return
+  ↓
+[s2] detect critical sentinel → fail Slack, return
+  ↓
+[s4] (existing) stripTriageSection (degraded mode)
+  ↓
+[s3] hasRelatedReposSection? 否 → prepend
+  ↓
+[s5] (existing) logging.Redact (secrets)
+  ↓
+[s6] (existing) w.github.CreateIssue
+```
+
+Step 順序的設計理由（grill Q4）：
+- **s1 first**：RefViolations 是 worker 客觀回報的 fact，與 body 內容無關。早 fail 早收工。
+- **s2 在 s4 之前**：sentinel 在 body 上偵測，必須先於任何改寫。如果 stripTriageSection 跑在前、agent 把 sentinel 寫在 advanced triage section 裡 + degraded 把那段 strip 掉 → sentinel 消失 → push 廢 issue。
+- **s3 在 s4 之後**：避免 stripTriageSection 邏輯誤打到 prepend 加進的 `## Related repos` heading。先讓既有 strip 跑完再 prepend。
+- **s5 Redact 在 s3 之後**：worker prepend 的內容也過一道 secret redaction（defense in depth）。
+
+#### s1: RefViolations 偵測（strict guard 觸發點）
+
+```go
+if len(r.RefViolations) > 0 {
+    for _, repo := range r.RefViolations {
+        metrics.RefWriteViolationsTotal.WithLabelValues("issue", repo).Inc()
+    }
+    msg := fmt.Sprintf(
+        ":no_entry: 無法建立 issue：agent 違規寫入 ref repo `%s`，job 結果不可信。請重 trigger。",
+        strings.Join(r.RefViolations, ", "))
+    w.updateStatus(job, msg)
+    metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_ref_violation").Inc()
+    return nil
+}
+```
+
+#### s2: Critical sentinel 偵測（grill Q6 落實）
+
+```go
+const criticalSentinel = "<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->"
+
+if strings.Contains(body, criticalSentinel) {
+    repoList := strings.Join(job.PromptContext.UnavailableRefs, ", ")
+    msg := fmt.Sprintf(
+        ":no_entry: 無法建立 issue：以下 ref repo 不可達，agent 判定關鍵脈絡缺失\n- %s\n\n請確認 worker GH_TOKEN 對這些 repo 有讀權後重 trigger。",
+        repoList)
+    w.updateStatus(job, msg)
+    metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_critical_ref").Inc()
+    return nil
+}
+```
+
+Sentinel 規格：`<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->`，固定字串、不帶 repo name、位置不限。Repo 列表從 `Job.PromptContext.UnavailableRefs` 取（事實 of record），sentinel 不負責列舉。Detection = `strings.Contains`，dead simple。
+
+#### s3: `## Related repos` auto-fill（grill Q3、Q5 落實）
+
+```go
+var relatedReposHeadingRE = regexp.MustCompile(`(?im)^#{1,4}\s+related\s+rep`)
+
+func hasRelatedReposSection(body string) bool {
+    return relatedReposHeadingRE.MatchString(body)
+}
+
+func ensureRelatedRepos(body string, job *queue.Job) string {
+    if len(job.RefRepos) == 0 {
+        return body  // 不掛 ref → 不作為
+    }
+    if hasRelatedReposSection(body) {
+        return body  // agent 已寫 → 尊重 agent 版
+    }
+    return prependRelatedRepos(body, job)
+}
+
+func prependRelatedRepos(body string, job *queue.Job) string {
+    var sb strings.Builder
+    sb.WriteString("## Related repos\n\n")
+    sb.WriteString(formatRefLine(job.Repo, job.Branch, "primary（issue 開立目標）"))
+    for _, ref := range job.RefRepos {
+        sb.WriteString(formatRefLine(ref.Repo, ref.Branch, "reference context"))
+    }
+    sb.WriteString("\n---\n\n")
+    sb.WriteString(body)
+    return sb.String()
+}
+
+func formatRefLine(repo, branch, role string) string {
+    if branch == "" {
+        return fmt.Sprintf("- `%s` — %s\n", repo, role)
+    }
+    return fmt.Sprintf("- `%s@%s` — %s\n", repo, branch, role)
+}
+```
+
+Detection regex 設計（grill Q3）：
+- `(?im)` — case-insensitive + multi-line
+- `^#{1,4}\s+` — H1 到 H4 markdown heading
+- `related\s+rep` — 抓 `Related repos` / `Related Repos` / `Related Repositories` / `Related repo`（單複數通吃）
+- 故意不抓中文 heading / `**bold**` inline / 純文字無 `#` prefix —— 那些 case 視為「agent 違規格式」，重複 prepend 把 agent 拉回 spec 寫死 spelling
+
+Role 邏輯（grill Q5）：
+- agent 寫對 → 用 agent 版（含精確 role 描述）
+- agent 漏寫 → worker prepend：primary 標 `primary（issue 開立目標）`、ref 標 `reference context`（誠實 placeholder，不假裝知道 role）
+
+### 4.8 ref repo 候選來源
+
+完全 reuse Ask spec §4.7。同邏輯：channel 配置決定 static button vs external_select；濾 primary；dedup 已選 ref；候選 0 跳過 `issue_ref_decide`。`refExclusionsFor` helper 兩 workflow 共用（§4.4）。
+
+## 5. Acceptance Criteria
+
+繼承 Ask spec AC-1 ~ AC-14（換 issue 路徑），新增 Issue 獨有：
+
+- [ ] **AC-I1（Schema regression）** Job 不帶 `RefRepos` 時，Issue 行為與現在 byte-for-byte 一致；`JobResult.RefViolations` omitempty 序列化無破壞。
+- [ ] **AC-I2（單 ref e2e）** 帶 1 ref 走完 Slack flow → worker prepare → agent 出 body → push GitHub。GitHub issue body 含 `## Related repos` 段，列出 primary + ref。
+- [ ] **AC-I3（多 ref e2e）** N=3 ref，AC-I2 對所有 ref 成立；issue body `## Related repos` 段列出全部 4 個 repo（1 primary + 3 ref）。
+- [ ] **AC-I4（agent 寫了 Related repos）** Mock agent 出帶 `## Related repos` 的 body，worker 不修改、原樣 push。
+- [ ] **AC-I5（agent 漏寫 Related repos）** Mock agent 出不含 `## Related repos` 的 body，worker prepend minimal 段（含正確 primary + refs + branches，role 為 `reference context`）。
+- [ ] **AC-I6（不掛 ref 時零作為）** Job 無 `RefRepos`，body normalization 完全略過，body byte-for-byte 不變。
+- [ ] **AC-I7（strict guard，app side）** e2e 故意叫 agent 寫進 ref，job 走 `worker → JobResult.RefViolations 非空 → app s1 fail-fast → 不 push、不送 IssueCreator → Slack 失敗 banner 列出違規 repo`、metric `ref_write_violations_total{workflow="issue", repo=...}` += 1、`workflow_completions_total{workflow="issue", outcome="rejected_ref_violation"}` += 1。
+- [ ] **AC-I8（partial fail，non-critical）** 故意給壞 CloneURL ref 但非 critical，agent 在 `## Related repos` 段把該 ref 標 `unavailable` role，body 仍完整，issue push 成功。
+- [ ] **AC-I9（output_rules 三條注入）** Issue 帶 ref 時 prompt 末端 output_rules 含三條規則；不帶 ref 時零注入。
+- [ ] **AC-I10（heading 偵測 case-insensitive + 變體）** Body 含 `## Related Repos` / `## Related Repositories` / `### Related repo` / `# RELATED REPOS` 任一變體，worker 不重複 prepend。
+- [ ] **AC-I11（Slack UX 行數）** 同 Ask AC-5：N ≥ 3 時 ref 流程在 thread 永久新增訊息行數 ≤ 2。
+- [ ] **AC-I12（critical sentinel fail-fast）** Mock agent 在 body 中放 `<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->`，issue **沒**被 push 到 GitHub、Slack banner 列出 `Job.PromptContext.UnavailableRefs`、metric `workflow_completions_total{workflow="issue", outcome="rejected_critical_ref"}` += 1。
+- [ ] **AC-I13（Ask metric 遷移）** `AskRefWriteViolationsTotal` 砍除後，Ask 路徑的違規透過 `result_listener` 上 `RefWriteViolationsTotal{workflow="ask", repo=...}`，行為等價（Ask 不 fail，metric 仍上）。
+
+## 6. Testing Strategy
+
+### Unit tests
+
+- `app/workflow/issue_test.go` — 新 phase 流轉（mirror `ask_test.go`）：`issue_ref_decide` / pick / continue / branch、`BranchTargetRepo` 切換、候選 0 skip、dedup、`BuildJob` 三條 output_rules 注入、`refExclusionsFor` helper 行為。
+- `app/workflow/issue_test.go` — `createAndPostIssue` 五步 pipeline 各 case：
+  - s1: `result.RefViolations` 非空 → 不呼叫 `IssueCreator.CreateIssue`、Slack banner 內含違規 repo
+  - s2: body 含 sentinel → 不呼叫 `CreateIssue`、Slack banner 列 `UnavailableRefs`
+  - s3: agent 寫對 / agent 漏寫 / regex 各種變體（H2/H3/單複數/case 變體）
+  - s6: 不掛 ref 時 pipeline 完全略過所有新步驟
+- `app/workflow/refstate_test.go` — `refExclusionsFor` 三組 case：empty primary、empty refs、both populated。
+- `worker/pool/executor_test.go` — `runRefGuard` 改寫後行為：detect-violation（return non-nil + warn log）、clean-worktree（return nil + 無 warn）、empty-refs（return nil）、git-status-fail（debug log + 跳過）。原 callback-related test（`*_NilCallback_NoOp`）刪除。
+- `app/bot/result_listener_test.go` — Ask 路徑 RefViolations 上 metric 不 fail；Issue 路徑 RefViolations 觸發 fail path。
+
+### Integration tests
+
+- `worker/integration/queue_redis_integration_test.go` — submit 帶 `RefRepos` 的 Issue job：
+  - Happy path：agent 寫對 body，issue push 含 `## Related repos`。
+  - Strict guard：fake agent 在 ref 寫檔，job result `RefViolations` 非空、app s1 fail、issue 沒 push、metric 上報。
+  - Critical sentinel：fake agent 出帶 sentinel body，app s2 fail、issue 沒 push、metric 上報。
+  - Auto-fill：fake agent 出不含 Related repos 的 body，push 到（fake）GitHub 的 body 含 worker prepend 段。
+
+### Slack UX 手動驗收
+
+開測試 channel 配 3 個 repo，跑 issue flow 三次：(0 ref, 1 ref, 3 ref)。重點：
+- 截圖訊息序列，驗 AC-I11 永久訊息數量。
+- 真開到 GitHub 的 issue 截圖，驗 AC-I2 / AC-I3 body 格式。
+- 故意給壞 ref 觸發 AC-I7 strict fail / AC-I12 critical sentinel，驗 Slack banner 文案與 metric。
+
+## 7. Boundaries
+
+### Always do
+
+- Issue 走的所有 schema / workdir / prompt / Slack UX 模式都直接引用 Ask spec，不重發明。
+- Worker 完全 task-agnostic：`runRefGuard` 純回報、`JobResult.RefViolations` 由 app 決定怎麼用。
+- Strict guard 觸發點、sentinel 偵測、auto-fill 全部在 app `createAndPostIssue` 五步 pipeline 中執行。
+- Auto-fill heading regex 雙保險：output_rules 寫死 `## Related repos` spelling、worker 用 loose regex 偵測變體。
+- Slack 失敗 banner 點明原因（ref 違規 vs critical-unavailable）：user 知道為什麼 fail。
+- ref 候選 mirror primary 來源、濾 primary、dedup；候選 0 跳過 ref decide。
+- DRY 邊界：抽 `refExclusionsFor` 共用 helper，其餘 mirror duplicate。
+
+### Ask first
+
+- 是否要把 strict guard 範圍縮小到「`.git/` 之外的 working tree changes」（例如 agent 跑 `git fetch` 修改 `.git/refs/` 不算違規）— 等 PR 1 發出來看實際 false-positive rate 再決定。
+- 「reference context」placeholder 文案要不要 i18n / 改成更精準的詞 — 等使用者第一次看到 GitHub 上的成品再 review。
+- Sentinel false-positive（agent 在 markdown 範例中包含 sentinel 字串會被誤判）— 預期極低頻，先靠 SKILL.md 警告處理；若 e2e 觀察到再加 escape 機制。
+
+### Never do
+
+- 用 LLM 自我判斷 "root cause 在 X repo" 並建議 routing — §1 已禁。
+- 在 ref repo 自動建 cross-link issue — 寫權限只在 primary，硬約束。
+- 砍 §4.7 s3（worker auto-fill）退回靠 prompt 紀律 — 那是治本機制。
+- 把 §4.7 s1 從 strict 退回 lenient — Issue 的 cost-of-error 不允許。
+- 在 push 後再 update issue body — 一次到位，避免 race 與 audit 混亂。
+- 復活 `RefViolationCallback` 抽象 — Q9 已決議砍，重啟需要新 issue 評估。
+- 用 LLM 標 ref role 為硬約束 — Q5 已決議 hybrid，agent 寫對用 agent 版、漏寫用 placeholder。
+
+## 8. Assumptions to Validate (during impl)
+
+| 假設 | 驗法 | 不成立時的退路 |
+| --- | --- | --- |
+| Strict guard 不會誤殺合法 case（agent 跑 `git log` / `git fetch` 等讀操作不會在 working tree 留 dirty bit） | `runRefGuard` 既有的 `git status --porcelain` 行為確認；e2e 跑 agent 真的讀 ref，看會不會有 false positive | 縮小判定到 working tree changes，排除 `.git/` 內變動 |
+| Worker auto-fill 的 prepend 位置（body 最前）不會打架 issue templates / agent 自己加的 frontmatter | `parsed.Body` 已 codebase verify 是純 markdown 無 frontmatter；mock 各種 body 形狀測；e2e 看 GitHub 上呈現 | 改成 append 到 body 末（assignee 滑下面也看得到，但 routing hint 弱化） |
+| LLM 漏寫 `## Related repos` 的頻率夠低，s3 是少見保底而非常態 | 上線後觀察一段：worker 補 vs agent 寫的比例（可加 metric） | 比例倒過來時加強 SKILL.md 範例、考慮在 prompt 直接給格式範本 |
+| Heading regex 抓得住 LLM 95% 的變體 | unit test 覆蓋常見變體；e2e 觀察 false-negative 率 | 擴 regex 加中文 / bold inline / 純文字 prefix |
+| Sentinel `strings.Contains` 不被 agent 範例內容誤觸發 | unit test mock agent 在 markdown code block 中包含 sentinel 字串；e2e 看是否觀察到 | SKILL.md 警告 agent 「不要在範例 / quote 中複製這個 sentinel」；極端 case 改用更獨特的字串（加 nonce） |
+
+## 9. Out of Scope (本 spec 不做)
+
+- **PR Review 多 repo** — #215 已決議砍。
+- **LLM 自我判斷 root-cause routing** — §1、§3、§7 三處皆禁。
+- **跨 repo cross-link**（在 ref repo 也開輕量 issue）— 寫權限約束擋掉。
+- **多 primary**（一次建 N 個 issue）— 違反模型。
+- **ref repo 共享 cache 優化** — 與 Ask 同步推遲。
+- **per-ref token / 獨立 auth scope** — 沿用 worker 級 PAT。
+- **Issue body schema 強制驗證**（yaml frontmatter 等）— heading regex 比對足矣。
+- **同 repo 不同 branch 同時當 ref** — 禁止。
+- **Slack 端 user 標 ref role phase** — Q5 已決議砍，role 由 agent 在 body 中描述。
+- **保留 `RefViolationCallback` 抽象** — Q9 已決議砍。
+- **保留 `AskRefWriteViolationsTotal` metric 名稱** — Q7 已決議遷移到 unified label-based metric。
+
+## 10. Implementation Order
+
+**2 顆 PR**（mirror Ask spec PR 拆分模式）：
+
+| PR | 範圍 | 中間態 |
+|---|---|---|
+| **PR 1 — backend + Ask 路徑遷移** | (1) `shared/queue/job.go`：`JobResult.RefViolations []string` (omitempty) <br> (2) `shared/metrics/metrics.go`：砍 `AskRefWriteViolationsTotal`、新增 `RefWriteViolationsTotal{workflow, repo}` <br> (3) `worker/pool/executor.go`：砍 `RefViolationCallback` type、`askLenientRefViolation` func；`runRefGuard(refs, logger) []string` 簽章改、inline warn log；`executeJob` 把 violations 寫入 `JobResult` <br> (4) `worker/pool/executor_test.go`：刪除 callback-related test（`*_NilCallback_NoOp`），改寫 detect/clean/empty 三 case <br> (5) `app/workflow/refstate.go`：新增 `refExclusionsFor` helper <br> (6) `app/workflow/ask.go::RefExclusions()` 改 1 行 inline call <br> (7) Ask 路徑 metric 上報點搬到 `app/bot/result_listener.go`（讀 `RefViolations` 上 metric，**不 fail**） | Ask 行為 byte-for-byte 不變（lenient 仍 lenient、metric 仍上、只是上報點搬家）。Issue 沒 user-facing 改動。Worker 已準備好接 Issue ref-aware job，但 app 還沒產出 → safe to land alone. |
+| **PR 2 — Issue frontend + body normalization + e2e** | (1) `app/workflow/issue.go`：issueState 4 個 ref 欄位、`RefExclusions` / `BranchSelectedRepo` 各 1 行 method、4 個 ref-flow phase method（mirror `ask.go`）、`BuildJob` 三條 ref output_rules append <br> (2) `app/workflow/issue.go::createAndPostIssue` 五步 pipeline（s1 RefViolations、s2 sentinel、s3 ensureRelatedRepos、既有 stripTriageSection / Redact / CreateIssue 順序調整） <br> (3) `app/app.go`：BlockSuggestion 路由加 `issue_ref` / `issue_ref_branch` cases <br> (4) `app/agents/skills/triage-issue/SKILL.md`：Reference repos + Related repos 段 + sentinel 教學 <br> (5) `app/workflow/issue_test.go` mirror `ask_test.go` ref 那批 + 五步 pipeline 各 case test <br> (6) Slack 手動 e2e + GitHub 真開 issue 截圖到 PR description | 完整 Issue ref e2e 可跑，AC-I1 ~ AC-I13 全部可驗。 |
+
+**為什麼 2 顆而不是 1 顆**：
+- PR 1 改動全在 worker / shared / Ask 既有路徑，跟 Issue UX 解耦。Reviewer 焦點：worker 行為 + Ask regression test 仍綠。
+- PR 2 改動集中在 app / Issue 路徑與 prompt。Reviewer 焦點：UX + body 格式 + prompt 行為。
+- 中間態乾淨：PR 1 land 後沒有 user-facing 改動；PR 2 land 後 e2e 可跑。
+
+**PR 大小估**：PR 1 ~120 行（含 tests）、PR 2 ~900 行（含 tests + SKILL.md）。
+
+**Land 後驗收順序**：
+1. PR 1：`go test ./...` 全綠；Ask regression test 對 ref violation 走新 metric 上報路徑通過；`test/import_direction_test.go` 通過。
+2. PR 2：`go test ./...` 全綠；Slack 手動 3 ref e2e + strict fail + critical sentinel 各跑一次，截圖到 PR description；真 GitHub 開一個帶 ref 的 issue，截圖 body 格式。

--- a/shared/metrics/metrics.go
+++ b/shared/metrics/metrics.go
@@ -116,16 +116,17 @@ var WorkflowRetryTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Count of workflow retry attempts and exhaustions.",
 }, []string{"workflow", "outcome"})
 
-// AskRefWriteViolationsTotal counts post-execute guard violations: an Ask
-// agent wrote into a ref worktree despite the read-only contract. Lenient
-// strategy — increment + warn-log, do NOT fail the job. Surfaces prompt
-// drift; if this counter trends up, the SKILL.md / output_rules need
-// strengthening, not the runtime guard.
-var AskRefWriteViolationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+// RefWriteViolationsTotal counts post-execute guard violations: an agent
+// wrote into a ref worktree despite the read-only contract. Labelled by
+// workflow ("ask"|"issue") and repo. Worker is task-agnostic — it always
+// reports via JobResult.RefViolations; app side increments this metric
+// on each violation. Ask path is lenient (increment, do not fail). Issue
+// path is strict (increment + fail-fast at createAndPostIssue s1).
+var RefWriteViolationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: namespace,
-	Name:      "ask_ref_write_violations_total",
-	Help:      "Number of times an Ask-workflow agent wrote into a ref repo (lenient: violation does not fail the job).",
-}, []string{"repo"})
+	Name:      "ref_write_violations_total",
+	Help:      "Post-execute guard detected agent writing into a ref worktree.",
+}, []string{"workflow", "repo"})
 
 // ---- Handler ----
 
@@ -211,7 +212,7 @@ func Register(reg prometheus.Registerer, q queue.JobQueue, store queue.JobStore)
 		AgentTokensTotal,
 		WorkflowCompletionsTotal,
 		WorkflowRetryTotal,
-		AskRefWriteViolationsTotal,
+		RefWriteViolationsTotal,
 		HandlerDedupRejectionsTotal,
 		HandlerRateLimitTotal,
 		WatchdogKillsTotal,

--- a/shared/queue/job.go
+++ b/shared/queue/job.go
@@ -113,6 +113,11 @@ type JobResult struct {
 	CostUSD        float64   `json:"cost_usd,omitempty"`
 	InputTokens    int       `json:"input_tokens,omitempty"`
 	OutputTokens   int       `json:"output_tokens,omitempty"`
+	// RefViolations lists ref repos (owner/name) where the post-execute
+	// guard detected agent writes. Worker is task-agnostic — it always
+	// reports; app side decides how to react (Ask: metric only; Issue:
+	// fail-fast at createAndPostIssue s1).
+	RefViolations  []string  `json:"ref_violations,omitempty"`
 	RepoPath       string    `json:"-"` // local only, not serialized over Redis
 	PrepareSeconds float64   `json:"-"` // local only, not serialized over Redis
 }

--- a/shared/queue/job_test.go
+++ b/shared/queue/job_test.go
@@ -258,3 +258,35 @@ func TestPromptContext_RefFields_OmitEmpty(t *testing.T) {
 		t.Errorf("empty UnavailableRefs should be omitted: %s", buf)
 	}
 }
+
+// TestJobResult_RefViolations_RoundTrip ensures the RefViolations field
+// (added for #217) marshals and unmarshals losslessly. Worker writes the
+// slice; app reads it on the other side of Redis.
+func TestJobResult_RefViolations_RoundTrip(t *testing.T) {
+	in := JobResult{JobID: "j1", Status: "completed", RefViolations: []string{"foo/bar", "baz/qux"}}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"ref_violations":[`) {
+		t.Errorf("expected ref_violations array in JSON, got: %s", raw)
+	}
+	var out JobResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in.RefViolations, out.RefViolations) {
+		t.Fatalf("RefViolations mismatch:\n in=%v\nout=%v", in.RefViolations, out.RefViolations)
+	}
+}
+
+// TestJobResult_RefViolations_OmitEmpty asserts a result with no violations
+// serializes without the ref_violations key — keeps the wire shape minimal
+// for the common no-ref / clean-guard case.
+func TestJobResult_RefViolations_OmitEmpty(t *testing.T) {
+	r := JobResult{JobID: "j1", Status: "completed"}
+	buf, _ := json.Marshal(r)
+	if strings.Contains(string(buf), "ref_violations") {
+		t.Errorf("empty RefViolations should be omitted: %s", buf)
+	}
+}

--- a/worker/pool/executor.go
+++ b/worker/pool/executor.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/Ivantseng123/agentdock/shared/crypto"
-	"github.com/Ivantseng123/agentdock/shared/metrics"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 	"github.com/Ivantseng123/agentdock/worker/agent"
 	"github.com/Ivantseng123/agentdock/worker/prompt"
@@ -194,11 +193,11 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 	logger.Info("Agent 執行完成", "phase", "完成", "output_len", len(output))
 	logger.Debug("Agent output 內容", "phase", "完成", "output", output)
 
-	// Post-execute ref guard. Only fires when refs were prepared; lenient
-	// callback for Ask (warn + metric, do NOT fail). #217 will route Issue
-	// jobs through a strict callback. Today Ask is the only multi-repo
-	// workflow, so the callback selection is hardcoded.
-	runRefGuard(refContexts, askLenientRefViolation, logger)
+	// Post-execute ref guard. Worker is task-agnostic — accumulates violations
+	// into JobResult.RefViolations and warn-logs locally. App side decides what
+	// to do (Ask: metric only via result_listener; Issue: fail-fast at
+	// createAndPostIssue s1).
+	violations := runRefGuard(refContexts, logger)
 
 	// Ship the raw agent output to the app. Parsing and REJECTED/ERROR/parse-failed
 	// classification live in the app-side result listener — worker has no
@@ -211,27 +210,38 @@ func executeJob(ctx context.Context, job *queue.Job, deps executionDeps, opts ag
 		StartedAt:      startedAt,
 		FinishedAt:     time.Now(),
 		PrepareSeconds: prepareSeconds,
+		RefViolations:  violations,
 	}
 }
 
-// RefViolationCallback is invoked when post-execute guard finds modifications
-// in a ref worktree. Ask installs a lenient impl (warn + metric); Issue (#217)
-// will install a strict impl that fails the job. The two-arg shape lets a
-// future strict impl record violations, then the caller decides whether to
-// continue — this spec only ships the lenient flavour, but the abstraction
-// is a callback so the strict impl can drop in without restructuring.
-type RefViolationCallback func(refContext queue.RefRepoContext, diffPreview string, logger *slog.Logger)
-
-// askLenientRefViolation is the Ask-workflow callback: warn-log + metric.
-// Worktree cleanup happens regardless, so writes have no persistent effect —
-// the guard is observability, not enforcement (spec §4.6 Layer 3, Q8).
-func askLenientRefViolation(ref queue.RefRepoContext, diff string, logger *slog.Logger) {
-	logger.Warn("agent wrote into ref repo (lenient: not failing job)",
-		"phase", "處理中",
-		"ref", ref.Repo,
-		"diff_preview", truncateRefDiff(diff),
-	)
-	metrics.AskRefWriteViolationsTotal.WithLabelValues(ref.Repo).Inc()
+// runRefGuard walks successful ref worktrees and runs `git status --porcelain`
+// in each, warn-logs on dirty bits, and returns the owner/name list of violating
+// refs. Caller writes the slice into JobResult.RefViolations; app side decides
+// how to react (Ask: metric only; Issue: fail-fast at createAndPostIssue s1).
+// `git status` failure is debug-logged and skipped — a corrupt worktree
+// shouldn't escalate, cleanup runs regardless. Empty refs → returns nil.
+func runRefGuard(refs []queue.RefRepoContext, logger *slog.Logger) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	var violations []string
+	for _, ref := range refs {
+		out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
+		if err != nil {
+			logger.Debug("ref guard: git status failed; skipping",
+				"phase", "處理中", "ref", ref.Repo, "error", err)
+			continue
+		}
+		if diff := strings.TrimSpace(string(out)); diff != "" {
+			logger.Warn("agent wrote into ref repo",
+				"phase", "處理中",
+				"ref", ref.Repo,
+				"diff_preview", truncateRefDiff(diff),
+			)
+			violations = append(violations, ref.Repo)
+		}
+	}
+	return violations
 }
 
 // truncateRefDiff caps the log preview at 200 chars so a multi-MB diff can't
@@ -242,27 +252,6 @@ func truncateRefDiff(s string) string {
 		return s[:200] + "…(truncated)"
 	}
 	return s
-}
-
-// runRefGuard walks successful ref worktrees and runs `git status --porcelain`
-// in each. Non-empty output → invoke callback. `git status` failure is logged
-// at debug and skipped (a corrupt worktree shouldn't escalate; cleanup runs
-// regardless). When refs is empty or onViolation is nil, this is a no-op.
-func runRefGuard(refs []queue.RefRepoContext, onViolation RefViolationCallback, logger *slog.Logger) {
-	if onViolation == nil || len(refs) == 0 {
-		return
-	}
-	for _, ref := range refs {
-		out, err := exec.Command("git", "-C", ref.Path, "status", "--porcelain").Output()
-		if err != nil {
-			logger.Debug("ref guard: git status failed; skipping",
-				"phase", "處理中", "ref", ref.Repo, "error", err)
-			continue
-		}
-		if diff := strings.TrimSpace(string(out)); diff != "" {
-			onViolation(ref, diff, logger)
-		}
-	}
 }
 
 func writeAttachments(attachments []queue.AttachmentReady, dir string) ([]prompt.AttachmentInfo, error) {

--- a/worker/pool/executor_test.go
+++ b/worker/pool/executor_test.go
@@ -278,61 +278,42 @@ func initGitWorktree(t *testing.T, dir string) string {
 	return dir
 }
 
-// TestRunRefGuard_DetectsViolation creates a real git worktree, modifies a
-// tracked-ish file, and asserts the callback fires with the right ref.
-// Tests the lenient-callback path's most important property: it observes
-// without interrupting (no error returned, just side effects).
+// TestRunRefGuard_DetectsViolation creates a real git worktree with an
+// untracked file (representing an agent write) and asserts the guard returns
+// the violating ref's owner/name in the slice. Worker is task-agnostic — the
+// slice is the contract; app side acts on it.
 func TestRunRefGuard_DetectsViolation(t *testing.T) {
 	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
 	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("agent wrote here"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	var fired []string
-	cb := func(ref queue.RefRepoContext, diff string, _ *slog.Logger) {
-		fired = append(fired, ref.Repo)
-		if !strings.Contains(diff, "f.txt") {
-			t.Errorf("diff should mention f.txt, got %q", diff)
-		}
-	}
-	runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+	violations := runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, slog.Default())
 
-	if len(fired) != 1 || fired[0] != "foo/bar" {
-		t.Fatalf("expected one violation for foo/bar; got %v", fired)
+	if len(violations) != 1 || violations[0] != "foo/bar" {
+		t.Fatalf("expected violations=[foo/bar]; got %v", violations)
 	}
 }
 
-// TestRunRefGuard_CleanWorktree_NoCallback asserts the no-violation path
-// doesn't fire the callback — important so the metric only counts real
-// violations, not background activity.
-func TestRunRefGuard_CleanWorktree_NoCallback(t *testing.T) {
+// TestRunRefGuard_CleanWorktree_NoNoise asserts the no-violation path returns
+// nil — important so app side's `len(violations) > 0` check only triggers on
+// real writes, not on every successful job.
+func TestRunRefGuard_CleanWorktree_NoNoise(t *testing.T) {
 	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
 
-	var fired int
-	cb := func(_ queue.RefRepoContext, _ string, _ *slog.Logger) { fired++ }
-	runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, cb, slog.Default())
+	violations := runRefGuard([]queue.RefRepoContext{{Repo: "foo/bar", Path: dir}}, slog.Default())
 
-	if fired != 0 {
-		t.Fatalf("clean worktree must not fire callback, fired=%d", fired)
+	if violations != nil {
+		t.Fatalf("clean worktree must return nil violations; got %v", violations)
 	}
 }
 
-// TestRunRefGuard_NilCallback_NoOp ensures the guard is safe to invoke even
-// when no callback is configured (defensive — callers shouldn't normally
-// pass nil, but the impl should not panic).
-func TestRunRefGuard_NilCallback_NoOp(t *testing.T) {
-	dir := initGitWorktree(t, filepath.Join(t.TempDir(), "ref"))
-	runRefGuard([]queue.RefRepoContext{{Repo: "x/y", Path: dir}}, nil, slog.Default())
-}
-
-// TestRunRefGuard_EmptyRefs_NoOp covers the no-refs path so the callback
-// definitely doesn't fire and no git command runs.
+// TestRunRefGuard_EmptyRefs_NoOp covers the no-refs path: returns nil without
+// running any git command (no panic on nil/empty input).
 func TestRunRefGuard_EmptyRefs_NoOp(t *testing.T) {
-	var fired int
-	cb := func(_ queue.RefRepoContext, _ string, _ *slog.Logger) { fired++ }
-	runRefGuard(nil, cb, slog.Default())
-	if fired != 0 {
-		t.Fatalf("empty refs must not fire callback, fired=%d", fired)
+	violations := runRefGuard(nil, slog.Default())
+	if violations != nil {
+		t.Fatalf("empty refs must return nil; got %v", violations)
 	}
 }
 
@@ -507,6 +488,12 @@ func TestExecuteJob_MultiRepo_EndToEnd(t *testing.T) {
 	refsRoot := filepath.Join(primaryPath, ".refs")
 	if _, err := os.Stat(refsRoot); !os.IsNotExist(err) {
 		t.Errorf("refs root should be cleaned up; stat err = %v", err)
+	}
+
+	// Post-execute guard: dirtied frontend ref → JobResult.RefViolations
+	// carries owner/name. Worker is task-agnostic; app side reads this.
+	if len(res.RefViolations) != 1 || res.RefViolations[0] != "frontend/web" {
+		t.Errorf("RefViolations = %v, want [frontend/web]", res.RefViolations)
 	}
 }
 


### PR DESCRIPTION
## Summary

Backend prep for #217 Issue multi-repo refs. PR 1 of 2 — lands without user-facing impact. Worker now reports ref-guard violations via `JobResult.RefViolations`; app side emits the unified metric. Ask path is byte-for-byte equivalent (only the metric reporting point moved). Issue path stays default (no Issue ref UX yet — that's PR 2).

Spec: `docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md`
Plan: `docs/superpowers/plans/2026-04-29-issue-multi-repo.md`

## What's in here

### Schema (additive, omitempty)
- `JobResult.RefViolations []string` — owner/name list of refs the post-execute guard found dirty. Worker is task-agnostic; app side decides how to react.

### Metric unification
- Drop `ask_ref_write_violations_total{repo}` (Ask-only).
- Add `ref_write_violations_total{workflow, repo}` — both workflows share.
- Pre-launch state confirmed (no live Grafana dashboards) so the rename is safe.

### Worker `runRefGuard` simplification (grill Q9)
- `RefViolationCallback` type + `askLenientRefViolation` func removed.
- `runRefGuard(refs, logger) []string` returns violations slice, inline warn-logs.
- The "callback as future strict-injection point" abstraction never materialised — strict moved to app side per grill Q2.

### Shared `refExclusionsFor` helper (grill Q8)
- Free function in new `app/workflow/refstate.go`.
- `askState.RefExclusions()` body shrinks to one-line call.
- `issueState.RefExclusions()` will reuse it in PR 2.

### Ask metric migration to `result_listener`
- `ResultListener.recordMetrics` reads `result.RefViolations` and emits `ref_write_violations_total{workflow, repo}` per entry.
- Ask remains lenient — metric increments, dispatch continues, no fail.
- Issue path will fail-fast at `createAndPostIssue` s1 in PR 2.

## Tests

| Test | Coverage |
|---|---|
| `TestJobResult_RefViolations_RoundTrip` / `*_OmitEmpty` | Schema round-trip + omitempty regression |
| `TestRunRefGuard_DetectsViolation` (rewritten) | Returned slice = `[\"foo/bar\"]` after dirty file write |
| `TestRunRefGuard_CleanWorktree_NoNoise` (renamed) | Clean worktree → nil slice |
| `TestRunRefGuard_EmptyRefs_NoOp` (rewritten) | Empty refs → nil slice |
| `TestRunRefGuard_NilCallback_NoOp` (deleted) | Callback removed, no longer applicable |
| `TestExecuteJob_MultiRepo_EndToEnd` (extended) | Asserts `res.RefViolations == [frontend/web]` after dirty ref |
| `TestRefExclusionsFor` (new) | Helper table cases (4 combinations) |
| `TestResultListener_RefViolations_EmitsMetricPerWorkflow` (new) | Both `workflow=\"ask\"` and `workflow=\"issue\"` increment correctly |
| `TestResultListener_RefViolations_EmptySliceNoop` (new) | Counter untouched when no violations |

All tests green across `shared/`, `worker/`, `app/`, `cmd/agentdock/`, and `test/import_direction_test.go`.

## Out of scope (deferred to PR 2)

- Issue Slack ref UX phases (`issue_ref_decide` / `pick` / `continue` / `branch`)
- `BuildJob` ref-aware `output_rules` injection (3 rules)
- `createAndPostIssue` 5-step body normalization pipeline (s1 RefViolations / s2 sentinel / s3 prepend Related repos)
- `triage-issue/SKILL.md` "Reference repos" section
- Slack e2e + GitHub real-issue verification

## Test plan

- [ ] CI green
- [ ] Worker still works on existing single-repo Ask jobs (no regression — should be a no-op since `RefViolations` is empty in clean cases)
- [ ] After PR 2 lands: real Slack walk-through

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)