### PR TITLE
feat(workflow/issue): multi-repo frontend (Slack phases, output_rules, pipeline, SKILL) (#217 PR 2)

### DIFF
--- a/app/agents/skills/triage-issue/SKILL.md
+++ b/app/agents/skills/triage-issue/SKILL.md
@@ -190,3 +190,76 @@ For an error:
 ```
 
 **Important:** The body field should contain the complete issue body as a single string with \n for newlines. Do NOT use `gh issue create` — just output the JSON.
+
+## Reference repos (multi-repo context)
+
+If the prompt has a `<ref_repos>` block, those directories are mounted at the
+absolute paths listed for read-only context (typical use: a frontend bug
+whose root cause is in the backend repo). Three rules apply.
+
+### 1. Read-only contract
+
+- You CAN: grep, read, follow imports, run `git log --oneline` in them.
+- You CANNOT: write, commit, edit, mv, rm any file under those paths.
+- Refs are physically OUTSIDE your cwd; use the absolute paths exactly as
+  listed in `<ref_repos>`. Don't try to compute relative paths to them —
+  they're sibling directories of your worktree, not subdirectories.
+- When citing ref content in the issue body, use the ref's `repo`
+  attribute (e.g. `backend/api: src/foo.ts:42`), not the absolute path —
+  the path is machine-only context, not user-facing.
+
+The worker runs `git status --porcelain` against each ref worktree after
+your run. Any dirty bits → the issue is **not** pushed to GitHub and the
+user gets a Slack failure banner.
+
+### 2. `## Related repos` is a hard body requirement
+
+When `<ref_repos>` is non-empty, your generated issue body MUST contain
+a `## Related repos` H2 section. Heading spelling must be exactly
+`## Related repos` (lowercase `repos`, no plural variant). Format:
+
+```
+## Related repos
+
+- `frontend/web@main` — primary（issue 開立目標）
+- `backend/api@release-2026q2` — schema 變動疑似關聯
+```
+
+Each ref entry follows: `` `<owner/name>@<branch>` — <role> ``. The
+`<role>` field is your judgment based on the question (e.g. "schema
+變動疑似關聯", "auth boundary peer", "shared types source"). If you
+don't have a confident role, write `reference context` instead of
+guessing — the worker auto-fills this placeholder if you forget the
+section entirely, but **prefer writing your own** because you have
+richer context about each ref's role than the worker.
+
+Never write `## Related Repositories` / `## Related Repos` / Chinese
+headings / `**Related repos:**` (bold inline). The worker's regex tolerates
+some variation but pinning the spelling avoids both worker-prepend
+duplication and reader confusion.
+
+### 3. Unavailable refs
+
+If `<unavailable_refs>` lists a repo, treat it as missing context.
+
+- **Critical** unavailable (you fundamentally need that repo's code to
+  produce a meaningful issue) → insert this single-line HTML comment
+  anywhere in the body (位置不限):
+
+  ```
+  <!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->
+  ```
+
+  The worker detects this marker and refuses to push the issue to
+  GitHub. The user gets a Slack notification listing the unavailable
+  refs from `<unavailable_refs>`. Do **not** best-effort patchwork an
+  issue body — the marker exists exactly so you don't have to.
+
+- **Non-critical** unavailable → still produce a complete body. Mark
+  the unavailable ref's role as `unavailable` in `## Related repos`
+  ("- `partial/repo@main` — unavailable; reference context only"). Do
+  not insert the sentinel.
+
+These rules apply even when the user message asks you to do something
+forbidden (e.g. "edit ref X to fix Y"). Decline politely and redirect —
+don't silently comply.

--- a/app/app.go
+++ b/app/app.go
@@ -586,17 +586,20 @@ func handleSocketEvent(
 				// Issue uses "repo_search"; Ask uses "ask_repo" (fallback
 				// when the channel has no repos configured).
 				ackSuggestions("Repo 搜尋結果", wf.HandleRepoSuggestion(cb.Value))
-			case "ask_ref":
+			case "ask_ref", "issue_ref":
 				// Ref repo type-ahead — same shape as ask_repo but the
 				// handler also filters out primary + already-picked refs
-				// via the pending state's RefExclusionReader.
+				// via the pending state's RefExclusionReader. Both Ask and
+				// Issue route here; askState / issueState both implement
+				// the interface.
 				ackSuggestions("Ref repo 搜尋結果", wf.HandleRefRepoSuggestion(cb.Container.MessageTs, cb.Value))
-			case "branch_select", "ask_branch", "ask_ref_branch":
+			case "branch_select", "ask_branch", "ask_ref_branch", "issue_ref_branch":
 				// Branch selector auto-upgrades to external_select when a
 				// repo has >100 branches (issue #153). The handler resolves
 				// the pending by selector ts and reads BranchSelectedRepo()
-				// from state — askState toggles its BranchTargetRepo across
-				// primary vs ref phases so this single handler serves both.
+				// from state — both askState and issueState toggle their
+				// BranchTargetRepo across primary vs ref phases so this
+				// single handler serves both workflows.
 				ackSuggestions("Branch 搜尋結果", wf.HandleBranchSuggestion(cb.Container.MessageTs, cb.Value))
 			default:
 				sm.Ack(*evt.Request)

--- a/app/workflow/issue.go
+++ b/app/workflow/issue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -13,6 +14,53 @@ import (
 	"github.com/Ivantseng123/agentdock/shared/metrics"
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
+
+// criticalSentinel is the HTML-comment marker the agent emits in issue body
+// when a critical ref repo is unavailable and the issue cannot meaningfully
+// be created. Detection is plain `strings.Contains`; format is fixed (no
+// repo name parameter — worker reads UnavailableRefs for the actual list).
+// Spec §4.7 / grill Q6.
+const criticalSentinel = "<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->"
+
+// relatedReposHeadingRE matches H1-H4 markdown headings whose text starts
+// "Related rep…" (singular, plural, or Repositories), case-insensitive.
+// Loose enough to cover normal LLM variation, strict enough to refuse
+// non-heading mentions (bold inline / Chinese / plain text). Spec §4.7
+// / grill Q3.
+var relatedReposHeadingRE = regexp.MustCompile(`(?im)^#{1,4}\s+related\s+rep`)
+
+// hasRelatedReposSection reports whether the issue body already contains a
+// `## Related repos` (or close variant) H2 heading. Caller uses the negative
+// to decide whether worker should prepend a minimal placeholder section.
+func hasRelatedReposSection(body string) bool {
+	return relatedReposHeadingRE.MatchString(body)
+}
+
+// prependRelatedRepos prepends a minimal `## Related repos` section to the
+// body, listing primary + each ref by `repo[@branch]` with a fixed role
+// placeholder. Agent's own version (when present) is preferred — caller
+// should gate via hasRelatedReposSection. Spec §4.7 s3.
+func prependRelatedRepos(body string, job *queue.Job) string {
+	var sb strings.Builder
+	sb.WriteString("## Related repos\n\n")
+	sb.WriteString(formatRefLine(job.Repo, job.Branch, "primary（issue 開立目標）"))
+	for _, ref := range job.RefRepos {
+		sb.WriteString(formatRefLine(ref.Repo, ref.Branch, "reference context"))
+	}
+	sb.WriteString("\n---\n\n")
+	sb.WriteString(body)
+	return sb.String()
+}
+
+// formatRefLine renders one bullet for the Related repos section. Branch is
+// omitted from the rendered line when empty so default-branch refs don't
+// produce a trailing `@`.
+func formatRefLine(repo, branch, role string) string {
+	if branch == "" {
+		return fmt.Sprintf("- `%s` — %s\n", repo, role)
+	}
+	return fmt.Sprintf("- `%s@%s` — %s\n", repo, branch, role)
+}
 
 // IssueWorkflow handles the legacy `@bot <repo>` and `@bot issue <repo>` flow.
 // Behaviour is preserved end-to-end from the pre-refactor `app/bot/workflow.go`
@@ -32,15 +80,42 @@ type issueState struct {
 	SelectedBranch string
 	ExtraDesc      string
 	RepoWasPicked  bool
+
+	// Multi-repo (ref) state. Mirrors askState's same fields exactly — see
+	// ask.go for full doc. AddRefs is the user's yes/no on the decide prompt;
+	// RefRepos accumulates as each ref is picked (Branch is filled in the
+	// per-ref branch loop). RefBranchIdx steps the per-ref branch picker
+	// forward. BranchTargetRepo is the transient "which repo are we asking
+	// branches for right now" — set before each branch select phase (primary
+	// OR ref) so BranchSelectedRepo can stay a single-method interface that
+	// doesn't need to know about phases.
+	AddRefs          bool
+	RefRepos         []queue.RefRepo
+	RefBranchIdx     int
+	BranchTargetRepo string
 }
 
 // BranchSelectedRepo satisfies workflow.BranchStateReader so app/bot can
-// read the repo off a Pending.State without depending on issueState.
+// read the repo off a Pending.State without depending on issueState. Reads
+// BranchTargetRepo (transient, set before each branch select phase) — for
+// primary branch select it equals SelectedRepo; for per-ref branch select
+// it's the current ref's repo. This keeps BranchStateReader phase-agnostic.
 func (s *issueState) BranchSelectedRepo() string {
 	if s == nil {
 		return ""
 	}
-	return s.SelectedRepo
+	return s.BranchTargetRepo
+}
+
+// RefExclusions returns the repos that should NOT appear as ref candidates:
+// the primary plus any refs already picked. Used by HandleRefRepoSuggestion
+// to filter type-ahead results when the channel has no static repo list.
+// Body delegates to the shared refExclusionsFor helper.
+func (s *issueState) RefExclusions() []string {
+	if s == nil {
+		return nil
+	}
+	return refExclusionsFor(s.SelectedRepo, s.RefRepos)
 }
 
 // NewIssueWorkflow constructs a workflow instance. All dependencies are
@@ -105,8 +180,7 @@ func (w *IssueWorkflow) Trigger(ctx context.Context, ev TriggerEvent, args strin
 			st.SelectedRepo = repo
 			if branch != "" {
 				st.SelectedBranch = branch
-				p.Phase = "description"
-				return w.descriptionPromptStep(p), nil
+				return w.maybeAskRefStep(p), nil
 			}
 			return w.afterRepoSelected(p, channelCfg), nil
 		}
@@ -176,8 +250,51 @@ func (w *IssueWorkflow) Selection(ctx context.Context, p *Pending, value string)
 
 	case "branch":
 		st.SelectedBranch = value
-		p.Phase = "description"
-		return w.descriptionPromptStep(p), nil
+		return w.maybeAskRefStep(p), nil
+
+	case "issue_ref_decide":
+		if value == "skip" {
+			st.AddRefs = false
+			return w.descriptionPromptStep(p), nil
+		}
+		st.AddRefs = true
+		return w.refPickStep(p), nil
+
+	case "issue_ref_pick":
+		// Cancellation → bail out of refs entirely. Match both the static-button
+		// value ("back_to_decide") and the external_select cancel button label
+		// ("← 不加 ref"), since the slack adapter sends the label as action value
+		// for cancel buttons.
+		if value == "back_to_decide" || value == "issue_ref_back" || value == "← 不加 ref" {
+			st.AddRefs = false
+			return w.descriptionPromptStep(p), nil
+		}
+		st.RefRepos = append(st.RefRepos, queue.RefRepo{
+			Repo:     value,
+			CloneURL: cleanCloneURL(value),
+		})
+		// Inline branch pick — ask THIS ref's branch immediately so the
+		// repo+branch decision is one coherent step from the user's view.
+		st.RefBranchIdx = len(st.RefRepos) - 1
+		return w.nextRefBranchStep(p), nil
+
+	case "issue_ref_continue":
+		switch value {
+		case "more":
+			return w.refPickStep(p), nil
+		case "done":
+			return w.descriptionPromptStep(p), nil
+		default:
+			return NextStep{Kind: NextStepError, ErrorText: fmt.Sprintf(":x: unexpected ref_continue value: %q", value)}, nil
+		}
+
+	case "issue_ref_branch":
+		if value == "取消" {
+			return NextStep{Kind: NextStepCancel}, nil
+		}
+		st.RefRepos[st.RefBranchIdx].Branch = value
+		// Branch picked → loop pivot ("再加一個 / 開始建 issue").
+		return w.refContinueStep(p), nil
 
 	case "description":
 		switch value {
@@ -225,6 +342,20 @@ func (w *IssueWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, s
 		reqID = logging.NewRequestID()
 	}
 
+	// Append ref-aware output_rules when the user attached refs (spec §4.6
+	// Layer 2). Three rules: read-only contract, critical sentinel emit
+	// instruction, `## Related repos` H2 spelling lock. SKILL.md (Layer 1)
+	// repeats these as soft guidance; output_rules is the hard prompt-end
+	// constraint.
+	outputRules := w.cfg.Workflows.Issue.Prompt.OutputRules
+	if len(st.RefRepos) > 0 {
+		outputRules = append(outputRules,
+			"不可寫入、修改、刪除 <ref_repos> 列出之任何 path 之下的檔案；refs 為唯讀脈絡。",
+			"若 <unavailable_refs> 含關鍵 ref，必須在 issue body 中加入 HTML comment：<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE --> （位置不限，存在即 fail-fast）；worker 偵測到此 marker 即不送 issue 到 GitHub。不要 best-effort 拼湊內容。",
+			"Issue body 必須包含 `## Related repos` 段，heading spelling 為 `## Related repos`（lowercase repos），列出 <ref_repos> 中每個 repo 與其角色（含 primary）。Role 不確定時寫 `reference context`。",
+		)
+	}
+
 	job := &queue.Job{
 		ID:          reqID,
 		RequestID:   reqID,
@@ -237,10 +368,11 @@ func (w *IssueWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job, s
 		CloneURL:    cleanCloneURL(st.SelectedRepo),
 		Priority:    w.channelPriority(p.ChannelID),
 		SubmittedAt: time.Now(),
+		RefRepos:    st.RefRepos,
 		PromptContext: &queue.PromptContext{
 			Goal:             w.cfg.Workflows.Issue.Prompt.Goal,
 			ResponseSchema:   w.cfg.Workflows.Issue.Prompt.ResponseSchema,
-			OutputRules:      w.cfg.Workflows.Issue.Prompt.OutputRules,
+			OutputRules:      outputRules,
 			Language:         w.cfg.PromptDefaults.Language,
 			ExtraDescription: st.ExtraDesc,
 			Branch:           st.SelectedBranch,
@@ -386,14 +518,66 @@ func (w *IssueWorkflow) createAndPostIssue(ctx context.Context, state *queue.Job
 		return nil
 	}
 
-	degraded := parsed.FilesFound == 0 || parsed.Questions >= 5
 	body := parsed.Body
+
+	// [s1] Strict guard fail-fast — worker reported ref worktree dirty bits.
+	// agent violated read-only contract → result is not trustworthy → skip
+	// GitHub push entirely, surface the violation in Slack so user knows why.
+	if len(r.RefViolations) > 0 {
+		msg := fmt.Sprintf(
+			":no_entry: 無法建立 issue：agent 違規寫入 ref repo `%s`，job 結果不可信。請重 trigger。",
+			strings.Join(r.RefViolations, ", "))
+		w.updateStatus(job, msg)
+		metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_ref_violation").Inc()
+		w.logger.Warn("issue rejected by ref-violation guard",
+			"phase", "失敗", "job_id", job.ID, "repo", job.Repo,
+			"refs", r.RefViolations)
+		return nil
+	}
+
+	// [s2] Critical-unavailable sentinel — agent self-declared that a critical
+	// ref couldn't be reached and the body shouldn't be pushed. Lookup the
+	// unavailable repos from PromptContext (worker fact, not agent claim).
+	if strings.Contains(body, criticalSentinel) {
+		var unavailableRefs []string
+		if job.PromptContext != nil {
+			unavailableRefs = job.PromptContext.UnavailableRefs
+		}
+		repoList := strings.Join(unavailableRefs, ", ")
+		if repoList == "" {
+			// Defensive: sentinel without UnavailableRefs (shouldn't happen —
+			// agent only writes the sentinel when prompted by an unavailable
+			// critical ref). Fall back to a generic message rather than emit
+			// an empty bullet list.
+			repoList = "(unspecified)"
+		}
+		msg := fmt.Sprintf(
+			":no_entry: 無法建立 issue：以下 ref repo 不可達，agent 判定關鍵脈絡缺失\n- %s\n\n請確認 worker GH_TOKEN 對這些 repo 有讀權後重 trigger。",
+			repoList)
+		w.updateStatus(job, msg)
+		metrics.WorkflowCompletionsTotal.WithLabelValues("issue", "rejected_critical_ref").Inc()
+		w.logger.Warn("issue rejected by critical-unavailable sentinel",
+			"phase", "失敗", "job_id", job.ID, "repo", job.Repo,
+			"unavailable_refs", unavailableRefs)
+		return nil
+	}
+
+	// [s4] (existing) Degraded-mode triage strip — runs before s3 prepend so
+	// the strip logic can't accidentally truncate the worker-added section.
+	degraded := parsed.FilesFound == 0 || parsed.Questions >= 5
 	if degraded {
 		body = stripTriageSection(body)
 	}
 
-	// Redact any configured secrets that the agent may have echoed into its
-	// parsed output before it lands on a permanent public surface (#180).
+	// [s3] Auto-fill `## Related repos` when refs were attached and agent
+	// didn't write the section. Worker's prepend uses fixed role placeholders;
+	// agent versions (with richer role descriptions) take priority.
+	if len(job.RefRepos) > 0 && !hasRelatedReposSection(body) {
+		body = prependRelatedRepos(body, job)
+	}
+
+	// [s5] (existing) Redact — runs after s3 prepend so worker-added content
+	// is also screened for secrets (defense in depth).
 	title := logging.Redact(parsed.Title, w.cfg.Secrets)
 	body = logging.Redact(body, w.cfg.Secrets)
 	labels := make([]string, len(parsed.Labels))
@@ -505,8 +689,7 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 	st := p.State.(*issueState)
 
 	if !channelCfg.IsBranchSelectEnabled() {
-		p.Phase = "description"
-		return w.descriptionPromptStep(p)
+		return w.maybeAskRefStep(p)
 	}
 
 	// Resolve branch list: config wins; fall back to live repo enumeration.
@@ -531,8 +714,7 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 		branches, listErr = w.repoCache.ListBranches(repoPath)
 		if listErr != nil {
 			// Graceful fallback: branch list unavailable → skip branch step.
-			p.Phase = "description"
-			return w.descriptionPromptStep(p)
+			return w.maybeAskRefStep(p)
 		}
 	}
 
@@ -540,13 +722,13 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 		if len(branches) == 1 {
 			st.SelectedBranch = branches[0]
 		}
-		p.Phase = "description"
-		return w.descriptionPromptStep(p)
+		return w.maybeAskRefStep(p)
 	}
 
 	// Multi-branch: show selector. The adapter picks button-row vs
 	// static_select based on len(branches) — repos with >24 branches used
 	// to hit Slack's actions-block cap and surface as ":x: 無法顯示選單".
+	st.BranchTargetRepo = st.SelectedRepo
 	p.Phase = "branch"
 	backAction, backLabel := "", ""
 	if st.RepoWasPicked {
@@ -702,4 +884,192 @@ func parseRepoArg(args string) (repo, branch string) {
 		branch = strings.TrimSpace(parts[1])
 	}
 	return repo, branch
+}
+
+// ── ref repo flow ────────────────────────────────────────────────────────────
+//
+// Mirrors AskWorkflow's ref helpers exactly — same shapes, same skip rules,
+// only the action_id prefix and prompt strings differ ("建 issue" vs "問問題").
+// See spec docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md §4.4.
+
+// refCandidates returns the channel-allowed repo list minus primary and
+// already-picked refs. Returns useExternalSearch=true when the channel uses
+// type-ahead repo search instead of a static list — caller dispatches to the
+// search-style selector with HandleRefRepoSuggestion as the suggestion handler.
+func (w *IssueWorkflow) refCandidates(p *Pending) (list []string, useExternalSearch bool) {
+	st, _ := p.State.(*issueState)
+	cc := w.cfg.ChannelDefaults
+	if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+		cc = c
+	}
+	repos := cc.GetRepos()
+	if len(repos) == 0 {
+		// External search: filtering happens in HandleRefRepoSuggestion.
+		return nil, true
+	}
+	picked := make(map[string]bool, len(st.RefRepos))
+	for _, r := range st.RefRepos {
+		picked[r.Repo] = true
+	}
+	for _, r := range repos {
+		if r == st.SelectedRepo || picked[r] {
+			continue
+		}
+		list = append(list, r)
+	}
+	return list, false
+}
+
+// maybeAskRefStep is the single entry into the ref flow. Skips entirely
+// when no candidate repos exist (channel has only primary) — keeps the
+// thread free of the "加入參考 repo？" message in that case (spec AC-12 mirror).
+func (w *IssueWorkflow) maybeAskRefStep(p *Pending) NextStep {
+	list, useExternalSearch := w.refCandidates(p)
+	if !useExternalSearch && len(list) == 0 {
+		return w.descriptionPromptStep(p)
+	}
+	p.Phase = "issue_ref_decide"
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   ":books: 加入參考 repo 嗎？(唯讀脈絡)",
+			ActionID: "issue_ref_decide",
+			Options: []SelectorOption{
+				{Label: "加入", Value: "add"},
+				{Label: "不用", Value: "skip"},
+			},
+		},
+		Pending: p,
+	}
+}
+
+// refPickStep posts the single-select picker for "next ref repo". Re-uses
+// the existing selector infrastructure (button row / static_select /
+// external_select auto-dispatch) — when the channel has no static list,
+// falls back to type-ahead search via the issue_ref action_id which
+// app/app.go routes to HandleRefRepoSuggestion (filters primary + picked).
+func (w *IssueWorkflow) refPickStep(p *Pending) NextStep {
+	st := p.State.(*issueState)
+	list, useExternalSearch := w.refCandidates(p)
+	p.Phase = "issue_ref_pick"
+	prompt := ":point_right: 選參考 repo:"
+	if len(st.RefRepos) > 0 {
+		prompt = fmt.Sprintf(":point_right: 選下一個參考 repo（已加 %d 個）:", len(st.RefRepos))
+	}
+	if useExternalSearch {
+		return NextStep{
+			Kind: NextStepSelector,
+			Selector: &SelectorSpec{
+				Prompt:         prompt,
+				ActionID:       "issue_ref",
+				Searchable:     true,
+				Placeholder:    "Type to search repos...",
+				CancelActionID: "issue_ref_back",
+				CancelLabel:    "← 不加 ref",
+			},
+			Pending: p,
+		}
+	}
+	options := make([]SelectorOption, 0, len(list)+1)
+	for _, r := range list {
+		options = append(options, SelectorOption{Label: r, Value: r})
+	}
+	options = append(options, SelectorOption{Label: "← 不加 ref", Value: "back_to_decide"})
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   prompt,
+			ActionID: "issue_ref",
+			Options:  options,
+		},
+		Pending: p,
+	}
+}
+
+// refContinueStep is the loop pivot after each ref pick: "再加一個 / 開始建 issue".
+// When the candidate pool is exhausted (static list and all picked), the
+// "再加一個" option drops so the user can only proceed to the description.
+func (w *IssueWorkflow) refContinueStep(p *Pending) NextStep {
+	st := p.State.(*issueState)
+	p.Phase = "issue_ref_continue"
+	list, useExternalSearch := w.refCandidates(p)
+	options := []SelectorOption{
+		{Label: "開始建 issue", Value: "done"},
+	}
+	// Allow another ref unless the static-list pool is fully consumed.
+	// External search is unbounded so always offer "再加一個" there.
+	if useExternalSearch || len(list) > 0 {
+		options = append([]SelectorOption{{Label: "再加一個 ref", Value: "more"}}, options...)
+	}
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:   fmt.Sprintf(":heavy_plus_sign: 已加 %d 個 ref。", len(st.RefRepos)),
+			ActionID: "issue_ref_continue",
+			Options:  options,
+		},
+		Pending: p,
+	}
+}
+
+// nextRefBranchStep handles the branch decision for the just-picked ref
+// (st.RefRepos[RefBranchIdx]). Same skip rules as primary:
+//   - branch_select disabled → no picker, leave Branch empty
+//   - ≤ 1 branch resolved   → auto-fill (or leave empty), no picker
+//   - otherwise             → show picker
+//
+// In all "no picker" cases the next step is refContinueStep (loop pivot),
+// not descriptionPromptStep — the user is always given a chance to add
+// another ref or end the loop, even when individual branch choices are
+// skipped.
+func (w *IssueWorkflow) nextRefBranchStep(p *Pending) NextStep {
+	st := p.State.(*issueState)
+	target := st.RefRepos[st.RefBranchIdx].Repo
+
+	cc := w.cfg.ChannelDefaults
+	if c, ok := w.cfg.Channels[p.ChannelID]; ok {
+		cc = c
+	}
+	if !cc.IsBranchSelectEnabled() {
+		return w.refContinueStep(p)
+	}
+
+	var branches []string
+	if len(cc.Branches) > 0 {
+		branches = cc.Branches
+	} else if w.repoCache != nil {
+		ghToken := ""
+		if w.cfg.Secrets != nil {
+			ghToken = w.cfg.Secrets["GH_TOKEN"]
+		}
+		if rp, err := w.repoCache.EnsureRepo(target, ghToken); err == nil {
+			if lb, lerr := w.repoCache.ListBranches(rp); lerr == nil {
+				branches = lb
+			}
+		}
+	}
+	if len(branches) <= 1 {
+		if len(branches) == 1 {
+			st.RefRepos[st.RefBranchIdx].Branch = branches[0]
+		}
+		return w.refContinueStep(p)
+	}
+
+	st.BranchTargetRepo = target
+	p.Phase = "issue_ref_branch"
+	options := make([]SelectorOption, 0, len(branches)+1)
+	for _, b := range branches {
+		options = append(options, SelectorOption{Label: b, Value: b})
+	}
+	options = append(options, SelectorOption{Label: "取消", Value: "取消"})
+	return NextStep{
+		Kind: NextStepSelector,
+		Selector: &SelectorSpec{
+			Prompt:           fmt.Sprintf(":point_right: Which branch of ref `%s`?", target),
+			ActionID:         "issue_ref_branch",
+			Options:          options,
+			MergeWithLastAck: true, // collapse ref's "✅ repo" + "✅ branch" → "✅ repo, branch"
+		},
+		Pending: p,
+	}
 }

--- a/app/workflow/issue_test.go
+++ b/app/workflow/issue_test.go
@@ -88,7 +88,9 @@ func TestIssueWorkflow_Trigger_MultiRepoShowsSelector(t *testing.T) {
 func TestIssueWorkflow_Selection_RepoPhase_TransitionsToBranchOrDescription(t *testing.T) {
 	// After picking a repo, workflow transitions to branch selector (if
 	// multi-branch) or description prompt (if single/no branch list).
-	w, _, _ := newTestIssueWorkflow(t)
+	// Single-repo channel ensures the new ref-decide phase auto-skips
+	// (0 candidates after primary filtered out — spec AC-I11 mirror).
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar"}))
 	p := &Pending{Phase: "repo", State: &issueState{}, ChannelID: "C1", ThreadTS: "1.0"}
 
 	step, err := w.Selection(context.Background(), p, "foo/bar")
@@ -585,4 +587,727 @@ func newTestIssueWorkflow(t *testing.T, opts ...issueOpt) (*IssueWorkflow, *fake
 	ic := &fakeIssueCreator{}
 	w := NewIssueWorkflow(cfg, slack, ic, nil, nil, slog.Default())
 	return w, slack, ic
+}
+
+// ── ref-flow phase tests (mirror ask_test.go ref tests) ──────────────────────
+
+// TestIssueWorkflow_RefFlow_DecidePromptOffered covers the entry to the ref
+// flow after primary branch is picked: ref candidates exist (channel has
+// extra repos beyond primary) so issue_ref_decide fires.
+func TestIssueWorkflow_RefFlow_DecidePromptOffered(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux", "third/repo"}))
+	p := &Pending{
+		Phase:     "branch",
+		State:     &issueState{SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_decide" {
+		t.Fatalf("Phase = %q, want issue_ref_decide", p.Phase)
+	}
+	if len(step.Selector.Options) != 2 {
+		t.Errorf("decide selector should have 2 options (加入/不用), got %d", len(step.Selector.Options))
+	}
+}
+
+// TestIssueWorkflow_RefFlow_ZeroCandidatesSkipsDecide covers AC-I11 mirror:
+// when the channel's static repo list contains only primary, the ref decide
+// phase is skipped entirely so the thread doesn't see "加入參考 repo？".
+func TestIssueWorkflow_RefFlow_ZeroCandidatesSkipsDecide(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar"}))
+	p := &Pending{
+		Phase:     "branch",
+		State:     &issueState{SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase == "issue_ref_decide" {
+		t.Errorf("Phase = issue_ref_decide; want it skipped (0 candidates)")
+	}
+	if p.Phase != "description" {
+		t.Errorf("Phase = %q, want description", p.Phase)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_DecideAddRoutesToPick covers the "加入" → ref
+// pick transition. AddRefs flips true and the picker phase appears.
+func TestIssueWorkflow_RefFlow_DecideAddRoutesToPick(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux"}))
+	p := &Pending{
+		Phase:     "issue_ref_decide",
+		State:     &issueState{SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "add")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_pick" {
+		t.Errorf("Phase = %q, want issue_ref_pick", p.Phase)
+	}
+	st := p.State.(*issueState)
+	if !st.AddRefs {
+		t.Error("AddRefs should be true after 加入")
+	}
+}
+
+// TestIssueWorkflow_RefFlow_DecideSkipRoutesToDescription covers the "不用"
+// path — AddRefs stays false and we proceed to the existing description
+// flow without touching ref state.
+func TestIssueWorkflow_RefFlow_DecideSkipRoutesToDescription(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux"}))
+	p := &Pending{
+		Phase:     "issue_ref_decide",
+		State:     &issueState{SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "description" {
+		t.Errorf("Phase = %q, want description", p.Phase)
+	}
+	st := p.State.(*issueState)
+	if st.AddRefs {
+		t.Error("AddRefs should remain false after skip")
+	}
+	if len(st.RefRepos) != 0 {
+		t.Errorf("RefRepos should be empty, got %v", st.RefRepos)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_PickFiltersPrimary covers AC-I10 mirror: primary
+// must not appear in the ref candidate list.
+func TestIssueWorkflow_RefFlow_PickFiltersPrimary(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux", "third/repo"}))
+	p := &Pending{
+		Phase:     "issue_ref_decide",
+		State:     &issueState{SelectedRepo: "foo/bar"},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "add")
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "foo/bar" {
+			t.Errorf("primary foo/bar must not appear in ref candidates; got %v", values)
+		}
+	}
+	wantSet := map[string]bool{"baz/qux": true, "third/repo": true, "back_to_decide": true}
+	for _, v := range values {
+		if !wantSet[v] {
+			t.Errorf("unexpected ref candidate value: %q (got %v)", v, values)
+		}
+	}
+}
+
+// TestIssueWorkflow_RefFlow_PickGoesToContinueWhenNoBranchSelect covers the
+// inline flow when branch_select is disabled: pick a ref → branch loop drains
+// instantly → land on continue ("再加一個 / 開始建 issue").
+func TestIssueWorkflow_RefFlow_PickGoesToContinueWhenNoBranchSelect(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux", "third/repo"}))
+	// branch_select default false → ref branch picker skipped per ref.
+	p := &Pending{
+		Phase:     "issue_ref_pick",
+		State:     &issueState{SelectedRepo: "foo/bar", AddRefs: true},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_continue" {
+		t.Errorf("Phase = %q, want issue_ref_continue", p.Phase)
+	}
+	st := p.State.(*issueState)
+	if len(st.RefRepos) != 1 || st.RefRepos[0].Repo != "baz/qux" {
+		t.Errorf("RefRepos = %v, want one entry of baz/qux", st.RefRepos)
+	}
+	if st.RefRepos[0].CloneURL == "" {
+		t.Error("RefRepos[0].CloneURL should be populated by cleanCloneURL")
+	}
+	values := selectorValues(step.Selector.Options)
+	wantSet := map[string]bool{"more": true, "done": true}
+	for _, v := range values {
+		if !wantSet[v] {
+			t.Errorf("unexpected continue option %q (got %v)", v, values)
+		}
+	}
+}
+
+// TestIssueWorkflow_RefFlow_PickGoesToBranchWhenBranchSelect covers the
+// inline interleaved flow: pick a ref → issue_ref_branch fires for THAT ref
+// (not all refs collected first). Mirrors ask Q4 grill — inline matches
+// primary's flow shape.
+func TestIssueWorkflow_RefFlow_PickGoesToBranchWhenBranchSelect(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux", "third/repo"}))
+	trueVal := true
+	w.cfg.ChannelDefaults.BranchSelect = &trueVal
+	w.cfg.ChannelDefaults.Branches = []string{"main", "release"}
+	p := &Pending{
+		Phase:     "issue_ref_pick",
+		State:     &issueState{SelectedRepo: "foo/bar", AddRefs: true},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_branch" {
+		t.Fatalf("Phase = %q, want issue_ref_branch (inline branch pick)", p.Phase)
+	}
+	st := p.State.(*issueState)
+	if st.BranchTargetRepo != "baz/qux" {
+		t.Errorf("BranchTargetRepo = %q, want baz/qux (the just-picked ref)", st.BranchTargetRepo)
+	}
+	if !strings.Contains(step.Selector.Prompt, "baz/qux") {
+		t.Errorf("prompt should reference baz/qux; got %q", step.Selector.Prompt)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_PickDedupAlreadyPicked covers AC-I10 mirror:
+// same repo can't appear twice in the candidate list.
+func TestIssueWorkflow_RefFlow_PickDedupAlreadyPicked(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux", "third/repo"}))
+	p := &Pending{
+		Phase: "issue_ref_continue",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+			RefRepos:     []queue.RefRepo{{Repo: "baz/qux", CloneURL: "https://github.com/baz/qux.git"}},
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "more")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_pick" {
+		t.Errorf("Phase = %q, want issue_ref_pick", p.Phase)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "baz/qux" {
+			t.Errorf("already-picked baz/qux must not appear in candidates; got %v", values)
+		}
+	}
+	found := false
+	for _, v := range values {
+		if v == "third/repo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("third/repo missing from candidates: %v", values)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_ContinueExhaustedPoolHidesMore covers a UX
+// detail: when the static candidate pool is fully consumed, "再加一個" drops
+// from the continue selector.
+func TestIssueWorkflow_RefFlow_ContinueExhaustedPoolHidesMore(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux"}))
+	p := &Pending{
+		Phase: "issue_ref_pick",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	step, err := w.Selection(context.Background(), p, "baz/qux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_continue" {
+		t.Fatalf("Phase = %q, want issue_ref_continue (no branch_select → straight to continue)", p.Phase)
+	}
+	values := selectorValues(step.Selector.Options)
+	for _, v := range values {
+		if v == "more" {
+			t.Errorf("'more' option should be hidden when pool is exhausted; got %v", values)
+		}
+	}
+	if len(values) != 1 || values[0] != "done" {
+		t.Errorf("expected only 'done' option, got %v", values)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_ContinueDoneRoutesToDescription covers
+// "開始建 issue" — exits the ref loop entirely. Branches are already filled
+// per-ref during pick (inline flow); done has no branch loop to enter.
+func TestIssueWorkflow_RefFlow_ContinueDoneRoutesToDescription(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "baz/qux"}))
+	p := &Pending{
+		Phase: "issue_ref_continue",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+			RefRepos: []queue.RefRepo{
+				{Repo: "baz/qux", CloneURL: "https://github.com/baz/qux.git"},
+			},
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+	_, err := w.Selection(context.Background(), p, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "description" {
+		t.Errorf("Phase = %q, want description", p.Phase)
+	}
+}
+
+// TestIssueWorkflow_RefFlow_InlineBranchPickerPerRef covers the full inline
+// flow: pick ref1 → branch1 → continue → pick ref2 → branch2 → done. Each
+// ref's branch is asked immediately after picking that ref.
+func TestIssueWorkflow_RefFlow_InlineBranchPickerPerRef(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t, withChannelRepos([]string{"foo/bar", "frontend/web", "backend/api"}))
+	trueVal := true
+	w.cfg.ChannelDefaults.BranchSelect = &trueVal
+	w.cfg.ChannelDefaults.Branches = []string{"main", "release"}
+	p := &Pending{
+		Phase: "issue_ref_pick",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+			AddRefs:      true,
+		},
+		ChannelID: "C1", ThreadTS: "1.0",
+	}
+
+	step, err := w.Selection(context.Background(), p, "frontend/web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_branch" {
+		t.Fatalf("after ref1 pick, Phase = %q, want issue_ref_branch", p.Phase)
+	}
+	st := p.State.(*issueState)
+	if st.BranchTargetRepo != "frontend/web" {
+		t.Errorf("BranchTargetRepo = %q, want frontend/web", st.BranchTargetRepo)
+	}
+	if !strings.Contains(step.Selector.Prompt, "frontend/web") {
+		t.Errorf("prompt should reference frontend/web; got %q", step.Selector.Prompt)
+	}
+
+	_, err = w.Selection(context.Background(), p, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_continue" {
+		t.Fatalf("after ref1 branch pick, Phase = %q, want issue_ref_continue", p.Phase)
+	}
+	if st.RefRepos[0].Branch != "main" {
+		t.Errorf("ref[0].Branch = %q, want main", st.RefRepos[0].Branch)
+	}
+
+	_, err = w.Selection(context.Background(), p, "more")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_pick" {
+		t.Fatalf("after 'more', Phase = %q, want issue_ref_pick", p.Phase)
+	}
+
+	_, err = w.Selection(context.Background(), p, "backend/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_branch" {
+		t.Fatalf("after ref2 pick, Phase = %q, want issue_ref_branch", p.Phase)
+	}
+	if st.BranchTargetRepo != "backend/api" {
+		t.Errorf("BranchTargetRepo = %q, want backend/api", st.BranchTargetRepo)
+	}
+
+	_, err = w.Selection(context.Background(), p, "release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "issue_ref_continue" {
+		t.Fatalf("after ref2 branch pick, Phase = %q, want issue_ref_continue", p.Phase)
+	}
+	if st.RefRepos[1].Branch != "release" {
+		t.Errorf("ref[1].Branch = %q, want release", st.RefRepos[1].Branch)
+	}
+
+	_, err = w.Selection(context.Background(), p, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Phase != "description" {
+		t.Errorf("after 'done', Phase = %q, want description", p.Phase)
+	}
+}
+
+// TestIssueWorkflow_BuildJob_WithRefs_PopulatesJobAndRules covers AC-I9:
+// Job.RefRepos passthrough + dynamic output_rules injection of THREE rules
+// (Issue has the additional `## Related repos` H2 spelling rule beyond Ask's
+// two).
+func TestIssueWorkflow_BuildJob_WithRefs_PopulatesJobAndRules(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t)
+	w.cfg.Workflows.Issue.Prompt.OutputRules = []string{"existing rule"}
+	p := &Pending{
+		ChannelID:   "C1",
+		ThreadTS:    "1.0",
+		Reporter:    "Alice",
+		ChannelName: "general",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+			RefRepos: []queue.RefRepo{
+				{Repo: "frontend/web", CloneURL: "https://github.com/frontend/web.git", Branch: "main"},
+				{Repo: "backend/api", CloneURL: "https://github.com/backend/api.git"},
+			},
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(job.RefRepos) != 2 {
+		t.Errorf("Job.RefRepos len = %d, want 2", len(job.RefRepos))
+	}
+	rules := job.PromptContext.OutputRules
+	if len(rules) != 4 {
+		t.Fatalf("OutputRules len = %d, want 4 (existing + 3 injected); got %v", len(rules), rules)
+	}
+	if rules[0] != "existing rule" {
+		t.Errorf("existing rule should remain at index 0; got %q", rules[0])
+	}
+	if !strings.Contains(rules[1], "不可寫入") {
+		t.Errorf("rule[1] should be read-only enforcement; got %q", rules[1])
+	}
+	if !strings.Contains(rules[2], "AGENTDOCK:CRITICAL_REF_UNAVAILABLE") {
+		t.Errorf("rule[2] should mention sentinel; got %q", rules[2])
+	}
+	if !strings.Contains(rules[3], "Related repos") {
+		t.Errorf("rule[3] should require ## Related repos heading; got %q", rules[3])
+	}
+}
+
+// TestIssueWorkflow_BuildJob_NoRefs_NoRulesInjected covers the regression
+// case: no refs picked → output_rules unchanged from configured value.
+func TestIssueWorkflow_BuildJob_NoRefs_NoRulesInjected(t *testing.T) {
+	w, _, _ := newTestIssueWorkflow(t)
+	w.cfg.Workflows.Issue.Prompt.OutputRules = []string{"existing rule"}
+	p := &Pending{
+		ChannelID:   "C1",
+		ThreadTS:    "1.0",
+		Reporter:    "Alice",
+		ChannelName: "general",
+		State: &issueState{
+			SelectedRepo: "foo/bar",
+		},
+	}
+	job, _, err := w.BuildJob(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(job.RefRepos) != 0 {
+		t.Errorf("Job.RefRepos = %v, want empty", job.RefRepos)
+	}
+	rules := job.PromptContext.OutputRules
+	if len(rules) != 1 || rules[0] != "existing rule" {
+		t.Errorf("OutputRules = %v, want only 'existing rule'", rules)
+	}
+}
+
+// TestIssueState_RefExclusions_PrimaryAndPicked covers the RefExclusionReader
+// implementation used by HandleRefRepoSuggestion to filter type-ahead
+// results in external-search channels.
+func TestIssueState_RefExclusions_PrimaryAndPicked(t *testing.T) {
+	st := &issueState{
+		SelectedRepo: "foo/bar",
+		RefRepos: []queue.RefRepo{
+			{Repo: "frontend/web"},
+			{Repo: "backend/api"},
+		},
+	}
+	excl := st.RefExclusions()
+	if len(excl) != 3 {
+		t.Fatalf("RefExclusions len = %d, want 3 (primary + 2 picked)", len(excl))
+	}
+	want := map[string]bool{"foo/bar": true, "frontend/web": true, "backend/api": true}
+	for _, r := range excl {
+		if !want[r] {
+			t.Errorf("unexpected exclusion: %q", r)
+		}
+	}
+}
+
+// TestIssueState_BranchSelectedRepo_FollowsBranchTarget asserts the transient
+// field swap that lets a single BranchStateReader interface serve both
+// primary and per-ref branch picking.
+func TestIssueState_BranchSelectedRepo_FollowsBranchTarget(t *testing.T) {
+	st := &issueState{
+		SelectedRepo:     "foo/bar",
+		BranchTargetRepo: "foo/bar",
+	}
+	if got := st.BranchSelectedRepo(); got != "foo/bar" {
+		t.Errorf("primary phase: BranchSelectedRepo = %q, want foo/bar", got)
+	}
+	st.BranchTargetRepo = "frontend/web"
+	if got := st.BranchSelectedRepo(); got != "frontend/web" {
+		t.Errorf("ref phase: BranchSelectedRepo = %q, want frontend/web", got)
+	}
+}
+
+// ── createAndPostIssue 5-step pipeline tests (Issue-specific) ────────────────
+
+// TestCreateAndPostIssue_S1_RefViolations_FailsAndDoesNotPush asserts that a
+// JobResult carrying RefViolations from the worker triggers the strict
+// fail-fast path: no GitHub push, banner names the violating refs, metric
+// emits with rejected_ref_violation outcome. (AC-I7)
+func TestCreateAndPostIssue_S1_RefViolations_FailsAndDoesNotPush(t *testing.T) {
+	w, slack, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", ChannelID: "C1", ThreadTS: "1.0",
+	}
+	state := &queue.JobState{Job: job}
+	r := &queue.JobResult{
+		JobID:         "j1",
+		Status:        "completed",
+		RawOutput:     "===TRIAGE_RESULT===\n{\"status\":\"CREATED\",\"title\":\"x\",\"body\":\"## Description\\n\\nfoo\"}",
+		RefViolations: []string{"frontend/web"},
+	}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: "## Description\n\nfoo"}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+
+	if ic.LastTitle != "" {
+		t.Errorf("CreateIssue should NOT have been called on s1 fail; got title=%q", ic.LastTitle)
+	}
+	if got := slack.LastPosted(); got == "" || !strings.Contains(got, "frontend/web") {
+		t.Errorf("Slack banner should mention violating ref; got %q", got)
+	}
+	if got := slack.LastPosted(); !strings.Contains(got, "違規寫入") {
+		t.Errorf("Slack banner should explain the failure; got %q", got)
+	}
+}
+
+// TestCreateAndPostIssue_S2_CriticalSentinel_FailsAndDoesNotPush asserts
+// that an agent body containing the HTML-comment sentinel triggers the
+// critical-unavailable fail-fast path: no GitHub push, banner names the
+// unavailable refs from PromptContext (not from the sentinel — it's bare).
+// (AC-I12)
+func TestCreateAndPostIssue_S2_CriticalSentinel_FailsAndDoesNotPush(t *testing.T) {
+	w, slack, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", ChannelID: "C1", ThreadTS: "1.0",
+		PromptContext: &queue.PromptContext{
+			UnavailableRefs: []string{"broken/repo"},
+		},
+	}
+	state := &queue.JobState{Job: job}
+	body := "<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->\n\n## 無法回答\n\nbackend ref unreachable."
+	r := &queue.JobResult{JobID: "j1", Status: "completed", RawOutput: "x"}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: body}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+
+	if ic.LastTitle != "" {
+		t.Errorf("CreateIssue should NOT have been called on sentinel; got title=%q", ic.LastTitle)
+	}
+	if got := slack.LastPosted(); !strings.Contains(got, "broken/repo") {
+		t.Errorf("Slack banner should list UnavailableRefs; got %q", got)
+	}
+	if got := slack.LastPosted(); !strings.Contains(got, "關鍵脈絡") {
+		t.Errorf("Slack banner should explain critical-unavailable failure; got %q", got)
+	}
+}
+
+// TestCreateAndPostIssue_S3_AgentWroteRelatedRepos_NotPrepended asserts that
+// when the agent already wrote a `## Related repos` section, the worker
+// does NOT prepend a duplicate. (AC-I4)
+func TestCreateAndPostIssue_S3_AgentWroteRelatedRepos_NotPrepended(t *testing.T) {
+	w, _, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", Branch: "main", ChannelID: "C1", ThreadTS: "1.0",
+		RefRepos: []queue.RefRepo{
+			{Repo: "frontend/web", Branch: "main"},
+		},
+	}
+	state := &queue.JobState{Job: job}
+	body := "## Related repos\n\n- `frontend/web@main` — root cause suspect\n\n## Description\n\nfoo"
+	r := &queue.JobResult{JobID: "j1", Status: "completed"}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: body}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+
+	if ic.LastBody == "" {
+		t.Fatal("CreateIssue should have been called with body")
+	}
+	// Worker must not have prepended a second `## Related repos` heading.
+	headingCount := strings.Count(strings.ToLower(ic.LastBody), "## related repos")
+	if headingCount != 1 {
+		t.Errorf("expected exactly 1 `## Related repos` heading, got %d in body:\n%s", headingCount, ic.LastBody)
+	}
+	// Agent's role description must survive (no truncation/replacement).
+	if !strings.Contains(ic.LastBody, "root cause suspect") {
+		t.Errorf("agent's role description lost; body=%q", ic.LastBody)
+	}
+}
+
+// TestCreateAndPostIssue_S3_AgentMissed_PrependsMinimal asserts that when
+// the agent forgot to include `## Related repos`, the worker prepends a
+// minimal version derived from Job.RefRepos using the `reference context`
+// placeholder. (AC-I5)
+func TestCreateAndPostIssue_S3_AgentMissed_PrependsMinimal(t *testing.T) {
+	w, _, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", Branch: "main", ChannelID: "C1", ThreadTS: "1.0",
+		RefRepos: []queue.RefRepo{
+			{Repo: "frontend/web", Branch: "main"},
+			{Repo: "backend/api"},
+		},
+	}
+	state := &queue.JobState{Job: job}
+	body := "## Description\n\nfoo bar"
+	r := &queue.JobResult{JobID: "j1", Status: "completed"}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: body}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+	if ic.LastBody == "" {
+		t.Fatal("CreateIssue should have been called with body")
+	}
+	// Body should now start with `## Related repos`.
+	if !strings.HasPrefix(ic.LastBody, "## Related repos\n\n") {
+		t.Errorf("body should start with ## Related repos; got prefix:\n%s", ic.LastBody[:min(120, len(ic.LastBody))])
+	}
+	// Primary entry uses the Chinese parenthetical role.
+	if !strings.Contains(ic.LastBody, "`foo/bar@main` — primary（issue 開立目標）") {
+		t.Errorf("primary entry missing or wrong format; body=%q", ic.LastBody)
+	}
+	// Refs use the placeholder `reference context`.
+	if !strings.Contains(ic.LastBody, "`frontend/web@main` — reference context") {
+		t.Errorf("ref1 entry missing/wrong format; body=%q", ic.LastBody)
+	}
+	// Ref without branch should omit the @branch suffix.
+	if !strings.Contains(ic.LastBody, "`backend/api` — reference context") {
+		t.Errorf("ref2 (no branch) entry missing/wrong format; body=%q", ic.LastBody)
+	}
+	// Original body content survives after the prepended section.
+	if !strings.Contains(ic.LastBody, "foo bar") {
+		t.Errorf("original body content lost; got %q", ic.LastBody)
+	}
+}
+
+// TestCreateAndPostIssue_S3_NoRefs_NoOp asserts that the body normalization
+// pipeline is a no-op when no refs are attached — pushed body equals the
+// agent body byte-for-byte (modulo Redact passthrough). (AC-I6)
+func TestCreateAndPostIssue_S3_NoRefs_NoOp(t *testing.T) {
+	w, _, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", Branch: "main", ChannelID: "C1", ThreadTS: "1.0",
+	}
+	state := &queue.JobState{Job: job}
+	body := "## Description\n\nfoo bar"
+	r := &queue.JobResult{JobID: "j1", Status: "completed"}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: body}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+	if ic.LastBody != body {
+		t.Errorf("body should be unchanged when no refs; got %q want %q", ic.LastBody, body)
+	}
+	if strings.Contains(ic.LastBody, "## Related repos") {
+		t.Errorf("body should NOT contain ## Related repos when no refs; got %q", ic.LastBody)
+	}
+}
+
+// TestHasRelatedReposSection_RegexVariants table-tests the loose regex used
+// for auto-fill detection. Hits should cover normal LLM output variation
+// (singular/plural, case, H1-H4); misses should cover non-heading mentions
+// (bold inline, Chinese, plain text). (AC-I10 + grill Q3)
+func TestHasRelatedReposSection_RegexVariants(t *testing.T) {
+	hits := []string{
+		"## Related repos\n\n- foo",
+		"## Related Repos\n",
+		"## Related Repositories\n",
+		"### Related Repo\n",
+		"# RELATED REPOS\n",
+		"## related repo\n",
+		"#### Related repos\n",
+	}
+	misses := []string{
+		"## 相關 repos\n",
+		"**Related repos:**\n",
+		"This issue is related to backend repos.\n",
+		"## Description\n\n關於 related repos 的事...\n",
+		"",
+	}
+	for _, in := range hits {
+		if !hasRelatedReposSection(in) {
+			t.Errorf("expected hit, got miss for: %q", in)
+		}
+	}
+	for _, in := range misses {
+		if hasRelatedReposSection(in) {
+			t.Errorf("expected miss, got hit for: %q", in)
+		}
+	}
+}
+
+// TestCreateAndPostIssue_PipelineOrder_S1BeforeS2 asserts that when both
+// strict guard and critical sentinel signals are present, s1 (RefViolations)
+// fires first — outcome metric is rejected_ref_violation, not
+// rejected_critical_ref. Order matters because each step is a return path.
+func TestCreateAndPostIssue_PipelineOrder_S1BeforeS2(t *testing.T) {
+	w, slack, ic := newTestIssueWorkflow(t)
+	job := &queue.Job{
+		ID: "j1", Repo: "foo/bar", ChannelID: "C1", ThreadTS: "1.0",
+		PromptContext: &queue.PromptContext{
+			UnavailableRefs: []string{"broken/repo"},
+		},
+	}
+	state := &queue.JobState{Job: job}
+	body := "<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->\n\n## Body\n\n..."
+	r := &queue.JobResult{
+		JobID:         "j1",
+		Status:        "completed",
+		RefViolations: []string{"frontend/web"}, // s1 signal
+	}
+	parsed := TriageResult{Status: "CREATED", Title: "x", Body: body}
+
+	if err := w.createAndPostIssue(context.Background(), state, r, parsed); err != nil {
+		t.Fatalf("createAndPostIssue: %v", err)
+	}
+	if ic.LastTitle != "" {
+		t.Errorf("CreateIssue should NOT have been called; got title=%q", ic.LastTitle)
+	}
+	// s1 banner mentions frontend/web (the violating ref); s2 banner would
+	// mention broken/repo. Confirm s1 won.
+	got := slack.LastPosted()
+	if !strings.Contains(got, "frontend/web") {
+		t.Errorf("expected s1 banner (frontend/web), got %q", got)
+	}
+	if strings.Contains(got, "broken/repo") {
+		t.Errorf("s2 fired before s1 — banner contains broken/repo: %q", got)
+	}
+}
+
+// min is a tiny helper for slicing logic in error messages.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/app/workflow/ports_test.go
+++ b/app/workflow/ports_test.go
@@ -24,6 +24,15 @@ type fakeSlackPort struct {
 
 func newFakeSlackPort() *fakeSlackPort { return &fakeSlackPort{} }
 
+// LastPosted returns the most recent text written to Posted, or "" if none.
+// Convenience for tests that only care about the final banner.
+func (f *fakeSlackPort) LastPosted() string {
+	if len(f.Posted) == 0 {
+		return ""
+	}
+	return f.Posted[len(f.Posted)-1]
+}
+
 func (f *fakeSlackPort) PostMessage(ch, text, ts string) error {
 	f.Posted = append(f.Posted, text)
 	return nil


### PR DESCRIPTION
## Summary

Frontend half of #217 (Issue multi-repo). Pairs with #223 (PR 1 backend, already merged) — together they enable end-to-end ref support for the Issue workflow, mirroring what PR #220 + #222 did for Ask.

User flow: picks N ref repos in Slack → worker prepares them at `<primary>-refs/<owner>__<repo>/` → agent grep/reads under read-only contract enforced by three layers (SKILL.md soft → output_rules hard → worker post-execute guard observability) → app-side body normalization pipeline catches violations + critical-unavailable sentinel + auto-fills `## Related repos` when agent forgets.

Spec: `docs/superpowers/specs/2026-04-29-issue-multi-repo-design.md`
Plan: `docs/superpowers/plans/2026-04-29-issue-multi-repo.md`

## What's in here

### App workflow (`app/workflow/issue.go`)

- `issueState` gains 4 ref fields (mirrors `askState`): `AddRefs`, `RefRepos`, `RefBranchIdx`, `BranchTargetRepo`.
- `BranchSelectedRepo()` reads `BranchTargetRepo` (transient field swap so `BranchStateReader` stays phase-agnostic).
- New `RefExclusions()` delegates to shared `refExclusionsFor` (PR 1 helper).
- 4 new phase methods (mirror `ask.go`): `maybeAskRefStep` / `refPickStep` / `refContinueStep` / `nextRefBranchStep` + `refCandidates` helper.
- Selection switch grows 4 cases: `issue_ref_decide` / `issue_ref_pick` / `issue_ref_continue` / `issue_ref_branch`.
- 5 existing `descriptionPromptStep` call sites redirected to `maybeAskRefStep`.
- `BranchTargetRepo` set before primary branch picker.
- `BuildJob` appends 3 ref-aware `output_rules` when `len(RefRepos) > 0`:
  1. Read-only contract for ref paths
  2. Critical-unavailable sentinel emit instruction
  3. `## Related repos` H2 spelling lock + role hybrid description

### App-side body normalization pipeline (`createAndPostIssue`)

| Step | Action | Condition |
|---|---|---|
| s1 | strict guard fail-fast | `result.RefViolations` non-empty → Slack banner names violating refs, no push, `workflow_completions_total{outcome=\"rejected_ref_violation\"}` += 1 |
| s2 | critical sentinel detect | body contains `<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->` → Slack banner lists `PromptContext.UnavailableRefs`, no push, `workflow_completions_total{outcome=\"rejected_critical_ref\"}` += 1 |
| s4 (existing) | `stripTriageSection` | runs before s3 so degraded mode can't truncate worker prepend |
| s3 | `ensureRelatedRepos` | agent didn't write `## Related repos` (loose regex tolerates H1-H4 / plural / case) → worker prepends minimal section with `reference context` role placeholder |
| s5 (existing) | `Redact` | covers worker-added content (defense in depth) |
| s6 (existing) | `CreateIssue` | only path that pushes to GitHub |

### Slack adapter wiring (`app/app.go`)

- `BlockSuggestion` routes `ask_ref` + `issue_ref` to `HandleRefRepoSuggestion`.
- `BlockSuggestion` routes `branch_select` / `ask_branch` / `ask_ref_branch` / `issue_ref_branch` to `HandleBranchSuggestion` (reused — both states implement `BranchStateReader` interface and toggle `BranchTargetRepo`).

### SKILL.md (`app/agents/skills/triage-issue/SKILL.md`)

New \"Reference repos (multi-repo context)\" section with 3 rule blocks:

1. **Read-only contract** — CAN grep/read; CANNOT write/commit/edit/mv/rm. Absolute paths from `<ref_repos>`. Citations use `repo: path:line`, not absolute path.
2. **`## Related repos` hard requirement** — heading spelling exact (`## Related repos`, lowercase `repos`). Per-entry format `` - `<owner/name>@<branch>` — <role> ``. Role hybrid: agent picks if confident, `reference context` otherwise. Worker auto-fills if forgotten.
3. **Critical-unavailable sentinel** — insert `<!-- AGENTDOCK:CRITICAL_REF_UNAVAILABLE -->` (anywhere in body). Worker detects and refuses GitHub push. Non-critical → mark role as `unavailable` instead.

## Tests

| Test | Coverage |
|---|---|
| `TestIssueWorkflow_RefFlow_DecidePromptOffered` | Entry to ref flow when candidates exist |
| `TestIssueWorkflow_RefFlow_ZeroCandidatesSkipsDecide` | **AC-I11** — single-repo channel auto-skips |
| `TestIssueWorkflow_RefFlow_DecideAddRoutesToPick` | \"加入\" → ref pick |
| `TestIssueWorkflow_RefFlow_DecideSkipRoutesToDescription` | \"不用\" → existing flow, no ref state set |
| `TestIssueWorkflow_RefFlow_PickFiltersPrimary` | Primary excluded from candidates |
| `TestIssueWorkflow_RefFlow_PickGoesToContinueWhenNoBranchSelect` | Loop pivot transition + cleanCloneURL passthrough |
| `TestIssueWorkflow_RefFlow_PickGoesToBranchWhenBranchSelect` | Inline branch picker fires for just-picked ref |
| `TestIssueWorkflow_RefFlow_PickDedupAlreadyPicked` | Same repo can't appear twice |
| `TestIssueWorkflow_RefFlow_ContinueExhaustedPoolHidesMore` | UX detail — \"再加一個\" drops when pool empty |
| `TestIssueWorkflow_RefFlow_ContinueDoneRoutesToDescription` | \"開始建 issue\" exits ref loop |
| `TestIssueWorkflow_RefFlow_InlineBranchPickerPerRef` | Multi-ref full flow: pick→branch→continue→pick→branch→done |
| `TestIssueWorkflow_BuildJob_WithRefs_PopulatesJobAndRules` | **AC-I9** — 3 rules appended; existing rules preserved |
| `TestIssueWorkflow_BuildJob_NoRefs_NoRulesInjected` | Regression: no refs → no injection |
| `TestIssueState_RefExclusions_PrimaryAndPicked` | RefExclusionReader impl |
| `TestIssueState_BranchSelectedRepo_FollowsBranchTarget` | BranchTargetRepo swap covers primary + ref phases |
| `TestCreateAndPostIssue_S1_RefViolations_FailsAndDoesNotPush` | **AC-I7** — strict guard fail-fast |
| `TestCreateAndPostIssue_S2_CriticalSentinel_FailsAndDoesNotPush` | **AC-I12** — sentinel detect |
| `TestCreateAndPostIssue_S3_AgentWroteRelatedRepos_NotPrepended` | **AC-I4** — agent's version preserved |
| `TestCreateAndPostIssue_S3_AgentMissed_PrependsMinimal` | **AC-I5** — worker auto-fill |
| `TestCreateAndPostIssue_S3_NoRefs_NoOp` | **AC-I6** — pipeline no-op when no refs |
| `TestHasRelatedReposSection_RegexVariants` | **AC-I10** — regex covers H1-H4 + plural variants; misses Chinese / bold / plain text |
| `TestCreateAndPostIssue_PipelineOrder_S1BeforeS2` | Both signals → s1 wins |
| (1 existing test updated) | Single-repo channel so 0-candidate skip preserves the original \"branch pick → description\" semantic |

`LastPosted()` helper added to `fakeSlackPort` for cleaner banner assertions.

All app + worker + shared module tests pass; `test/import_direction_test.go` passes.

## Manual e2e test plan (your job)

This is the half you can actually walk in Slack. Suggested flow:

```bash
gh pr checkout <this PR>
# Make sure both app and worker rebuild & deploy with this branch.
```

In your test channel (`ai_trigger_issue_bot`):

- **0-ref baseline (regression)** — `@bot issue` with no refs → existing flow unchanged; issue pushed without `## Related repos`.
- **1-ref happy path, multi-repo channel** — channel with 2-3 repos. Walk through decide → pick → continue done → primary branch → ref branch (if applicable) → description → submit. Verify thread shows `chat.update` reuse: only one selector message ts changes content, not new messages each step.
- **3-ref full flow** — pick 3 different refs. Count permanent message rows in the thread after submit — should be ≤ 2 (AC-I11). Verify GitHub issue body contains `## Related repos` with all 4 entries (1 primary + 3 refs).
- **Force ref clone failure (critical sentinel)** — pick a ref the worker's PAT can't read; phrase question so agent emits the sentinel. Verify:
  - Issue **NOT** pushed to GitHub (verify via `gh`)
  - Slack banner: `:no_entry: 無法建立 issue：以下 ref repo 不可達...`
  - `workflow_completions_total{workflow=\"issue\", outcome=\"rejected_critical_ref\"}` += 1
- **Force ref write violation (strict guard)** — manipulate skill prompt or harness so agent writes a file under a ref worktree. Verify:
  - Issue **NOT** pushed to GitHub
  - Slack banner: `:no_entry: 無法建立 issue：agent 違規寫入 ref repo \`<repo>\`...`
  - `workflow_completions_total{workflow=\"issue\", outcome=\"rejected_ref_violation\"}` += 1
  - `ref_write_violations_total{workflow=\"issue\", repo=...}` += 1

## Out of scope

- PR Review multi-repo — #215 already declared out of scope.
- LLM self-judges \"root cause in ref X\" + \"should open issue in X\" routing — grill Q2 explicitly cut.
- Cross-repo auto cross-link issues — write permission only on primary; hard constraint.
- Per-ref token / independent auth scope — reuses worker-level PAT.

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)