### PR TITLE
feat(worker/agent): hygiene bundle (#228 PR 1)

### DIFF
--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -109,6 +109,10 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	// touch one place.
 	expanded := expandExtraArgs(agent.Args, agent.ExtraArgs)
 
+	if blocked := detectBlockedArgs(expanded); len(blocked) > 0 {
+		return "", fmt.Errorf("blocked args rejected: %s", strings.Join(blocked, ", "))
+	}
+
 	var args []string
 	if useStdin && hasPromptPlaceholder {
 		// Prompt too large for args — drop the prompt arg, use stdin instead.
@@ -136,8 +140,10 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
 	cmd.WaitDelay = 10 * time.Second
 
-	// Inject secrets as environment variables.
-	env := os.Environ()
+	// Inject secrets as environment variables. Filter inherited env to drop
+	// residual CLAUDE_CODE_* vars from the worker host that could pollute
+	// agent behavior across deployments.
+	env := filterClaudeCodeEnv(os.Environ())
 	if len(opts.Secrets) > 0 {
 		for k, v := range opts.Secrets {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
@@ -186,7 +192,7 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 			return "", fmt.Errorf("timeout after %s", timeout)
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("exit %d: %s", exitErr.ExitCode(), strings.TrimSpace(stderr.String()))
+			return "", fmt.Errorf("exit %d: %s", exitErr.ExitCode(), tailStderr(stderr.String()))
 		}
 		return "", err
 	}
@@ -203,11 +209,7 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	// kubectl exec'ing into the worker.
 	trimmed := strings.TrimSpace(output)
 	if trimmed == "" {
-		stderrTail := strings.TrimSpace(stderr.String())
-		if len(stderrTail) > 2000 {
-			stderrTail = "…" + stderrTail[len(stderrTail)-2000:]
-		}
-		logger.Warn("Agent exit 0 但 stdout 空", "phase", "失敗", "command", agent.Command, "stderr_tail", stderrTail)
+		logger.Warn("Agent exit 0 但 stdout 空", "phase", "失敗", "command", agent.Command, "stderr_tail", tailStderr(stderr.String()))
 	}
 	return trimmed, nil
 }
@@ -281,4 +283,75 @@ func substituteStringPlaceholders(args []string, values map[string]string) []str
 		result = append(result, a)
 	}
 	return result
+}
+
+// blockedArgs is the set of CLI flags that bypass the agent's host sandbox.
+// Memory feedback_worker_deployment_unknown rationale: workers may run on a
+// user's real machine, not an isolated pod, so allowing these would let the
+// agent touch $HOME, /etc, SSH keys, etc.
+var blockedArgs = []string{
+	"--dangerously-skip-permissions",
+}
+
+// claudeCodeEnvWhitelist is the set of CLAUDE_CODE_* env vars that pass
+// through to agent processes. Anything else with the CLAUDE_CODE_ prefix
+// inherited from the worker host is stripped to keep agent behavior
+// deterministic across deployment environments. Add entries when a new var
+// becomes load-bearing.
+var claudeCodeEnvWhitelist = map[string]bool{
+	"CLAUDE_CODE_NO_FLICKER": true, // see project_cmux_claude_flicker_workaround
+}
+
+// stderrTailLen caps how much of an agent's stderr survives into error
+// messages and warn logs. Large stderr blobs (e.g. claude SDK's every-event
+// JSON dumps) otherwise spam the logger and crowd out other signal.
+const stderrTailLen = 2000
+
+// tailStderr returns the trailing stderrTailLen bytes of s, prefixed with a
+// "…" marker when truncation occurred. Single truncation site so tail size
+// stays consistent across error and log surfaces.
+func tailStderr(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= stderrTailLen {
+		return s
+	}
+	return "…" + s[len(s)-stderrTailLen:]
+}
+
+// detectBlockedArgs returns any blockedArgs entries present in args. The flag
+// must stand alone or appear as `--flag=value`; substring matches inside
+// other args are NOT detected. Caller surfaces the result; this function has
+// no side effects.
+func detectBlockedArgs(args []string) []string {
+	var found []string
+	for _, a := range args {
+		for _, blocked := range blockedArgs {
+			if a == blocked || strings.HasPrefix(a, blocked+"=") {
+				found = append(found, a)
+			}
+		}
+	}
+	return found
+}
+
+// filterClaudeCodeEnv strips CLAUDE_CODE_* vars from env unless the key is
+// in claudeCodeEnvWhitelist. Non-CLAUDE_CODE_* entries pass through unchanged.
+// Output preserves input ordering for deterministic env substitution under
+// exec.Command.
+func filterClaudeCodeEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, "CLAUDE_CODE_") {
+			out = append(out, e)
+			continue
+		}
+		i := strings.IndexByte(e, '=')
+		if i < 0 {
+			continue
+		}
+		if claudeCodeEnvWhitelist[e[:i]] {
+			out = append(out, e)
+		}
+	}
+	return out
 }

--- a/worker/agent/runner_test.go
+++ b/worker/agent/runner_test.go
@@ -415,3 +415,136 @@ func TestRunner_CancelShortCircuitsProviderChain(t *testing.T) {
 		t.Errorf("err = %q, want \"cancelled\" (chain must not try the second agent)", err.Error())
 	}
 }
+
+func TestTailStderr(t *testing.T) {
+	if got := tailStderr("short"); got != "short" {
+		t.Errorf("tailStderr(short) = %q, want %q", got, "short")
+	}
+	if got := tailStderr("  trim  "); got != "trim" {
+		t.Errorf("tailStderr did not trim whitespace: got %q", got)
+	}
+	long := strings.Repeat("x", stderrTailLen+100)
+	got := tailStderr(long)
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("tailStderr did not prefix with marker: got prefix %q", got[:6])
+	}
+	if len(got) != stderrTailLen+len("…") {
+		t.Errorf("tailStderr len = %d, want %d", len(got), stderrTailLen+len("…"))
+	}
+}
+
+func TestDetectBlockedArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", []string{}, nil},
+		{"clean", []string{"--print", "-p", "hi"}, nil},
+		{"exact match", []string{"--dangerously-skip-permissions"}, []string{"--dangerously-skip-permissions"}},
+		{"with value", []string{"--dangerously-skip-permissions=yes"}, []string{"--dangerously-skip-permissions=yes"}},
+		{"substring no match", []string{"--mention-dangerously-skip-permissions"}, nil},
+		{"mixed", []string{"--print", "--dangerously-skip-permissions", "-p"}, []string{"--dangerously-skip-permissions"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectBlockedArgs(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterClaudeCodeEnv(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"CLAUDE_CODE_NO_FLICKER=1",
+		"CLAUDE_CODE_RESIDUE=oops",
+		"HOME=/home/me",
+		"CLAUDE_CODE_BAD_FORMAT", // no = sign, malformed
+	}
+	got := filterClaudeCodeEnv(in)
+	want := []string{
+		"PATH=/usr/bin",
+		"CLAUDE_CODE_NO_FLICKER=1",
+		"HOME=/home/me",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRunner_BlockedArgsRejected(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "should-not-run")
+	os.WriteFile(script, []byte("#!/bin/sh\necho should not run\n"), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command:   script,
+		Args:      []string{"{extra_args}", "{prompt}"},
+		ExtraArgs: []string{"--dangerously-skip-permissions"},
+		Timeout:   5 * time.Second,
+	}})
+	_, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err == nil {
+		t.Fatal("expected error when blocked arg present")
+	}
+	if !strings.Contains(err.Error(), "blocked args rejected") {
+		t.Errorf("err = %q, want substring \"blocked args rejected\"", err.Error())
+	}
+}
+
+func TestRunner_StderrTailTruncated(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "noisy-failer")
+	// Print > stderrTailLen bytes to stderr then exit non-zero. yes |head gives
+	// repeatable bulk content without depending on /dev/urandom.
+	os.WriteFile(script, []byte(`#!/bin/sh
+yes "spam-line-content-padding-padding-padding-padding-padding" | head -n 200 >&2
+exit 1
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
+	}})
+	_, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "…") {
+		t.Errorf("err message missing truncation marker: %q", msg)
+	}
+	// Sanity bound: even with 200 lines of spam, total error message stays
+	// within stderrTailLen + a small wrapper budget.
+	if len(msg) > stderrTailLen+500 {
+		t.Errorf("err message too long: %d bytes (stderrTailLen=%d)", len(msg), stderrTailLen)
+	}
+}
+
+func TestRunner_ClaudeCodeEnvStripped(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_RESIDUE", "should-be-stripped")
+	t.Setenv("CLAUDE_CODE_NO_FLICKER", "1")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "env-probe")
+	os.WriteFile(script, []byte(`#!/bin/sh
+env | grep '^CLAUDE_CODE_' | sort
+echo "padding padding padding padding padding padding padding padding"
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
+	}})
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if strings.Contains(output, "CLAUDE_CODE_RESIDUE") {
+		t.Errorf("CLAUDE_CODE_RESIDUE leaked into agent env: %q", output)
+	}
+	if !strings.Contains(output, "CLAUDE_CODE_NO_FLICKER=1") {
+		t.Errorf("CLAUDE_CODE_NO_FLICKER did not pass through: %q", output)
+	}
+}

--- a/worker/agent/version.go
+++ b/worker/agent/version.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// versionDetectTimeout caps how long worker startup waits for one agent's
+// --version to respond. Slow CLIs delay startup; missing CLIs fail fast.
+const versionDetectTimeout = 5 * time.Second
+
+// LogVersions runs `<command> --version` for each configured agent and
+// records the result. Failures (missing binary, non-zero exit, no --version
+// support) emit warn-level logs but never block startup — agents older than
+// the --version convention must not crash workers.
+func (r *Runner) LogVersions(ctx context.Context, logger *slog.Logger) {
+	for _, ag := range r.agents {
+		version, err := detectVersion(ctx, ag.Command)
+		if err != nil {
+			logger.Warn("Agent --version 探測失敗", "phase", "處理中", "command", ag.Command, "error", err)
+			continue
+		}
+		logger.Info("Agent 版本", "phase", "處理中", "command", ag.Command, "version", version)
+	}
+}
+
+// detectVersion runs `command --version` with a per-agent timeout and
+// returns the trimmed first line. The first line is the convention for CLIs
+// that print a banner before the version (claude, codex, opencode all
+// conform). Caller decides how to surface failures.
+func detectVersion(ctx context.Context, command string) (string, error) {
+	versionCtx, cancel := context.WithTimeout(ctx, versionDetectTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(versionCtx, command, "--version").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("exec %s --version: %w", command, err)
+	}
+	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if line == "" {
+		return "", fmt.Errorf("%s --version returned empty output", command)
+	}
+	return line, nil
+}

--- a/worker/agent/version_test.go
+++ b/worker/agent/version_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectVersion_Success(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-cli")
+	os.WriteFile(script, []byte(`#!/bin/sh
+echo "fake-cli 1.2.3"
+echo "build: abcdef"
+`), 0755)
+
+	got, err := detectVersion(context.Background(), script)
+	if err != nil {
+		t.Fatalf("detectVersion failed: %v", err)
+	}
+	if got != "fake-cli 1.2.3" {
+		t.Errorf("got %q, want %q (first line only)", got, "fake-cli 1.2.3")
+	}
+}
+
+func TestDetectVersion_NotFound(t *testing.T) {
+	_, err := detectVersion(context.Background(), "/nonexistent/cli-binary")
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "exec") {
+		t.Errorf("err should mention exec, got: %v", err)
+	}
+}
+
+func TestDetectVersion_NonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "broken-cli")
+	os.WriteFile(script, []byte("#!/bin/sh\necho oops\nexit 2\n"), 0755)
+
+	_, err := detectVersion(context.Background(), script)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+}
+
+func TestDetectVersion_EmptyOutput(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "silent-cli")
+	os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0755)
+
+	_, err := detectVersion(context.Background(), script)
+	if err == nil {
+		t.Fatal("expected error for empty output")
+	}
+	if !strings.Contains(err.Error(), "empty output") {
+		t.Errorf("err should mention empty output, got: %v", err)
+	}
+}
+
+func TestDetectVersion_RespectsTimeout(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "slow-cli")
+	os.WriteFile(script, []byte("#!/bin/sh\nsleep 10\necho slow\n"), 0755)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := detectVersion(ctx, script)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from timeout")
+	}
+	// Caller-supplied ctx (200ms) is shorter than versionDetectTimeout (5s) —
+	// the caller's deadline must dominate.
+	if elapsed > 2*time.Second {
+		t.Errorf("detectVersion did not respect caller ctx: elapsed=%v", elapsed)
+	}
+}

--- a/worker/agent/version_test.go
+++ b/worker/agent/version_test.go
@@ -64,7 +64,12 @@ func TestDetectVersion_EmptyOutput(t *testing.T) {
 func TestDetectVersion_RespectsTimeout(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "slow-cli")
-	os.WriteFile(script, []byte("#!/bin/sh\nsleep 10\necho slow\n"), 0755)
+	// `exec` replaces the shell with sleep so the cancel signal hits the
+	// sleep process directly (same PID). Without `exec`, sh is the parent
+	// and orphaned sleep keeps the stdout/stderr pipes open until it
+	// finishes naturally, blocking CombinedOutput on Linux. macOS appears
+	// to behave differently, hence local-pass / CI-fail.
+	os.WriteFile(script, []byte("#!/bin/sh\nexec sleep 10\n"), 0755)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -60,6 +60,7 @@ func Run(cfg *config.Config) error {
 	}
 
 	agentRunner := agent.NewRunnerFromConfig(cfg)
+	agentRunner.LogVersions(context.Background(), appLogger)
 
 	secretKey, err := crypto.DecodeSecretKey(cfg.SecretKey)
 	if err != nil {


### PR DESCRIPTION
## Summary

PR 1 of the V8 plan from #228. Four small operator-side patches in a single bundle. No Slack-facing changes — all observable on worker logs / behavior.

| Patch | Why |
|---|---|
| `stderr` truncation on non-zero exit (2KB tail, single helper) | Noisy claude/opencode failures used to dump unbounded stderr into logs. Now consistent with the existing exit-0+empty-stdout path. |
| `CLAUDE_CODE_*` env strip with whitelist | Worker hosts (especially developer laptops) accumulate residual `CLAUDE_CODE_*` vars that pollute agent behavior across deployments. `CLAUDE_CODE_NO_FLICKER` whitelisted (memory `project_cmux_claude_flicker_workaround`). |
| Blocked args filter (`--dangerously-skip-permissions` + `=value` form) | Memory `feedback_worker_deployment_unknown`: workers may run on a user's real machine, not an isolated pod, so blanket-permission flags must be rejected at runtime even when injected via `worker.yaml`. |
| `agent --version` detection at startup | Helps diagnose CLI version drift on operator boxes; warn-only, never blocks startup. |

## V8 PR split

- **PR 1 (this)** — hygiene bundle, no behavior change to running agents
- PR 2 — `agent.inactivity_timeout` (behavior change, isolated)
- PR 3 — `StatusReport.LastTool` + Slack render `:wrench: 正在 Read · src/foo.go`

See `docs/ideas/worker-agent-progress-visibility.md` for full rationale.

## Test plan

- [x] `go build ./...` — worker module builds
- [x] `go vet ./...` — worker module vet clean
- [x] `go test ./...` — worker module + root import-direction tests pass
- [x] New unit tests for `tailStderr` / `detectBlockedArgs` / `filterClaudeCodeEnv` / `detectVersion` (success, missing binary, non-zero exit, empty output, ctx-deadline)
- [x] New integration tests `TestRunner_BlockedArgsRejected` / `TestRunner_StderrTailTruncated` / `TestRunner_ClaudeCodeEnvStripped`
- [ ] Manual: start worker, confirm `Agent 版本` info logs appear at startup
- [ ] Manual: confirm `CLAUDE_CODE_NO_FLICKER` continues to work for cmux flicker workaround
- [ ] Manual: try injecting `--dangerously-skip-permissions` in `worker.yaml` and verify the run is rejected

Refs: #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)