### PR TITLE
feat(worker/agent): inactivity timeout for streaming agents (#228 PR 2)

### DIFF
--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -176,18 +177,44 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	}
 	logger.Info("Agent process 已啟動", "phase", "處理中", "command", agent.Command, "pid", cmd.Process.Pid)
 
+	// Inactivity timer fires SIGTERM when no stream event arrives within
+	// agent.InactivityTimeout. Streaming agents only — non-stream CLIs emit
+	// no events and would be killed prematurely. Disabled when timeout <= 0.
+	var inactivityKilled atomic.Bool
+	eventCallback := opts.OnEvent
+	if agent.InactivityTimeout > 0 && agent.Stream {
+		inactivityTimer := time.AfterFunc(agent.InactivityTimeout, func() {
+			inactivityKilled.Store(true)
+			logger.Warn("Inactivity timeout 觸發，發送 SIGTERM",
+				"phase", "失敗",
+				"command", agent.Command,
+				"timeout", agent.InactivityTimeout)
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		})
+		defer inactivityTimer.Stop()
+		eventCallback = func(evt queue.StreamEvent) {
+			inactivityTimer.Reset(agent.InactivityTimeout)
+			if opts.OnEvent != nil {
+				opts.OnEvent(evt)
+			}
+		}
+	}
+
 	// Read stdout in a goroutine; wait for it before cmd.Wait().
 	var output string
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		output = readOutput(ctx, stdoutPipe, agent.Stream, opts.OnEvent)
+		output = readOutput(ctx, stdoutPipe, agent.Stream, eventCallback)
 	}()
 	wg.Wait()
 
 	err = cmd.Wait()
 	if err != nil {
+		if inactivityKilled.Load() {
+			return "", fmt.Errorf("inactivity timeout after %s (no stream events)", agent.InactivityTimeout)
+		}
 		if ctx.Err() == context.DeadlineExceeded {
 			return "", fmt.Errorf("timeout after %s", timeout)
 		}

--- a/worker/agent/runner_test.go
+++ b/worker/agent/runner_test.go
@@ -584,12 +584,15 @@ echo '`+streamResultLine+`'
 func TestRunner_InactivityTimeout_FiresOnIdleStream(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "idle-stream")
-	// One event then a long silence well past the timeout. Final event is
-	// never reached because the timer fires SIGTERM first.
+	// One event then a long silence well past the timeout. `exec sleep`
+	// replaces sh with sleep at the same PID so the inactivity timer's
+	// SIGTERM reaches the actual sleep process. Without exec, orphaned
+	// sleep keeps stdout/stderr pipes open and blocks cmd.Wait on Linux
+	// until natural completion — same trap PR1 fixed in version_test.go
+	// (commit 8acb83c).
 	os.WriteFile(script, []byte(`#!/bin/sh
 echo '`+streamEventLine+`'
-sleep 3
-echo '`+streamResultLine+`'
+exec sleep 3
 `), 0755)
 
 	runner := NewRunner([]config.AgentConfig{{

--- a/worker/agent/runner_test.go
+++ b/worker/agent/runner_test.go
@@ -548,3 +548,120 @@ echo "padding padding padding padding padding padding padding padding"
 		t.Errorf("CLAUDE_CODE_NO_FLICKER did not pass through: %q", output)
 	}
 }
+
+// streamEventLine is one NDJSON line shaped like claude's stream-json
+// `assistant`/`tool_use` event. Used by inactivity-timeout tests to
+// produce real StreamEvents through the runner's parser path.
+const streamEventLine = `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}`
+
+const streamResultLine = `{"type":"result","result":"streamed result with enough characters padding padding padding padding"}`
+
+func TestRunner_InactivityTimeout_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "blocking-stream")
+	// Long initial silence; with InactivityTimeout=0 (disabled) this must
+	// still complete successfully because the timer never starts.
+	os.WriteFile(script, []byte(`#!/bin/sh
+sleep 0.5
+echo '`+streamEventLine+`'
+echo '`+streamResultLine+`'
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
+		Stream: true,
+		// InactivityTimeout: 0 — explicitly disabled.
+	}})
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("disabled inactivity timeout should not kill: %v", err)
+	}
+	if !strings.Contains(output, "streamed result") {
+		t.Errorf("output: %q", output)
+	}
+}
+
+func TestRunner_InactivityTimeout_FiresOnIdleStream(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "idle-stream")
+	// One event then a long silence well past the timeout. Final event is
+	// never reached because the timer fires SIGTERM first.
+	os.WriteFile(script, []byte(`#!/bin/sh
+echo '`+streamEventLine+`'
+sleep 3
+echo '`+streamResultLine+`'
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 10 * time.Second,
+		Stream:            true,
+		InactivityTimeout: 300 * time.Millisecond,
+	}})
+	start := time.Now()
+	_, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected inactivity timeout error")
+	}
+	if !strings.Contains(err.Error(), "inactivity timeout") {
+		t.Errorf("err = %q, want substring \"inactivity timeout\"", err.Error())
+	}
+	// Should kill within ~timeout + stream-startup latency, not wait for full sleep.
+	if elapsed > 2*time.Second {
+		t.Errorf("inactivity should fire quickly, elapsed=%v", elapsed)
+	}
+}
+
+func TestRunner_InactivityTimeout_ResetsOnEvent(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "active-stream")
+	// Emit an event every 100ms for ~1s. With timeout=500ms, every event
+	// resets the timer well before expiry, so the run completes normally.
+	os.WriteFile(script, []byte(`#!/bin/sh
+i=0
+while [ $i -lt 8 ]; do
+    echo '`+streamEventLine+`'
+    sleep 0.1
+    i=$((i+1))
+done
+echo '`+streamResultLine+`'
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 10 * time.Second,
+		Stream:            true,
+		InactivityTimeout: 500 * time.Millisecond,
+	}})
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("inactivity timer should reset on each event: %v", err)
+	}
+	if !strings.Contains(output, "streamed result") {
+		t.Errorf("output: %q", output)
+	}
+}
+
+func TestRunner_InactivityTimeout_NotAppliedToNonStream(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "blocking-non-stream")
+	// Non-stream agent that takes longer than the inactivity timeout. Must
+	// complete because the timer is gated on Stream=true.
+	os.WriteFile(script, []byte(`#!/bin/sh
+sleep 0.5
+echo "non-stream output with enough characters padding padding padding padding"
+`), 0755)
+
+	runner := NewRunner([]config.AgentConfig{{
+		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
+		// Stream defaults to false
+		InactivityTimeout: 100 * time.Millisecond, // would fire if applied
+	}})
+	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("inactivity timeout must be no-op for non-stream agents: %v", err)
+	}
+	if !strings.Contains(output, "non-stream output") {
+		t.Errorf("output: %q", output)
+	}
+}

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -41,8 +41,14 @@ type AgentConfig struct {
 	Args      []string      `yaml:"args"`
 	ExtraArgs []string      `yaml:"extra_args"`
 	Timeout   time.Duration `yaml:"timeout"`
-	SkillDir  string        `yaml:"skill_dir"`
-	Stream    bool          `yaml:"stream"`
+	// InactivityTimeout: if > 0 and Stream is true, send SIGTERM when no
+	// stream event arrives within this duration. Default zero (disabled).
+	// Only meaningful for streaming agents — non-stream CLIs emit no events
+	// and would be killed prematurely if applied. Should be shorter than
+	// Timeout but long enough for a thinking-heavy turn (e.g. 2m).
+	InactivityTimeout time.Duration `yaml:"inactivity_timeout"`
+	SkillDir          string        `yaml:"skill_dir"`
+	Stream            bool          `yaml:"stream"`
 }
 
 // PromptConfig is the worker-owned prompt extension (the extra_rules segment


### PR DESCRIPTION
## Summary

PR 2 of the V8 plan from #228. Adds `agent.inactivity_timeout` config to `AgentConfig`. Default disabled; opt-in only.

When set and `Stream=true`, `runOne` arms a timer that fires SIGTERM if no stream event arrives within the configured duration. Each event resets the timer.

## Why this is a separate PR

Behavior change. Bundling with PR1's hygiene patches would mix operator-side cleanup with a real new feature, making review harder.

## Design notes

| Aspect | Choice | Why |
|---|---|---|
| Default | `0` (disabled) | Opt-in. Matches "structuring tool, not diagnosis tool" — the feature is operator-survival ergonomics, not normal-path. |
| Stream gate | Only when `agent.Stream=true` | Non-stream CLIs (codex today, opencode-non-pure) emit no events through the parser; applying the timer would kill them on first read. |
| Reset mechanism | Wrap `opts.OnEvent` with timer reset | Single splice site, no signature change to `readOutput`. The wrapped callback is the only thing `readOutput` sees. |
| Error path | `atomic.Bool` flag → distinct error message | Operators see `inactivity timeout after Xs (no stream events)` instead of a generic `exit -1`. |
| Process kill | `SIGTERM` (graceful), existing `cmd.WaitDelay=10s` provides force-kill fallback | Reuses the runner's existing graceful-termination path. |

## V8 PR split status

- ✅ PR 1 — hygiene bundle (#230, merged)
- 🟡 **PR 2 (this)** — inactivity timeout
- ⏸️ PR 3 — `StatusReport.LastTool` + Slack render (gated until this lands)

## Test plan

- [x] `go build ./...` worker module
- [x] `go vet ./...` worker module
- [x] `go test -race ./...` worker module — all green incl. new tests
- [x] `go test ./test/...` import-direction
- [x] New tests:
  - `TestRunner_InactivityTimeout_Disabled` — `0` value never fires
  - `TestRunner_InactivityTimeout_FiresOnIdleStream` — timer fires SIGTERM, error contains "inactivity timeout"
  - `TestRunner_InactivityTimeout_ResetsOnEvent` — continuous events keep agent alive
  - `TestRunner_InactivityTimeout_NotAppliedToNonStream` — `Stream=false` agents are exempt
- [ ] Manual: set `inactivity_timeout: 30s` on claude in `worker.yaml`, force a stuck agent (e.g. unreachable network), confirm worker logs `Inactivity timeout 觸發` and gives up cleanly.
- [ ] Manual: confirm normal claude jobs (with thinking-heavy turns) are not killed at default 30s — adjust default if false-positives observed.

Refs: #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)