### PR TITLE
feat(worker+app): tool-name visibility in Slack progress (#228 PR 3)

### DIFF
--- a/app/bot/status_listener.go
+++ b/app/bot/status_listener.go
@@ -229,7 +229,16 @@ func renderStatusMessage(state *queue.JobState, r queue.StatusReport, phase stri
 			suffix = fmt.Sprintf(" · 奮鬥 %s", formatElapsed(time.Since(state.StartedAt)))
 		}
 		base := fmt.Sprintf(":fire: %s 開工啦！(%s)%s", label, agent, suffix)
-		if r.ToolCalls > 0 || r.FilesRead > 0 {
+		if r.LastTool != "" {
+			// Stream-aware activity line: tool name + first arg when present.
+			// Counter-only fallback below kicks in for non-stream agents that
+			// never produce LastTool.
+			activity := slackEscape(r.LastTool)
+			if r.LastToolArg != "" {
+				activity += " · " + slackEscape(r.LastToolArg)
+			}
+			base += "\n:wrench: 正在 " + activity
+		} else if r.ToolCalls > 0 || r.FilesRead > 0 {
 			base += fmt.Sprintf("\n%s 已經敲了 %d 次工具、翻了 %d 份檔",
 				label, r.ToolCalls, r.FilesRead)
 		}

--- a/app/bot/status_listener_test.go
+++ b/app/bot/status_listener_test.go
@@ -482,3 +482,81 @@ func TestFormatWorkerLabel(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderStatusMessage_RunningWithLastTool(t *testing.T) {
+	state := &queue.JobState{Status: queue.JobRunning, StartedAt: time.Now()}
+	r := queue.StatusReport{
+		WorkerID:    "host/worker-0",
+		PID:         1234,
+		AgentCmd:    "claude",
+		ToolCalls:   3, // counter present but should be ignored when LastTool set
+		FilesRead:   2,
+		LastTool:    "Read",
+		LastToolArg: "src/foo/bar.go",
+	}
+	got := renderStatusMessage(state, r, "running")
+	if !contains(got, ":wrench: 正在 Read · src/foo/bar.go") {
+		t.Errorf("missing tool-name activity line: %q", got)
+	}
+	if contains(got, "已經敲了") {
+		t.Errorf("counter line should NOT appear when LastTool is set: %q", got)
+	}
+}
+
+func TestRenderStatusMessage_RunningLastToolNoArg(t *testing.T) {
+	state := &queue.JobState{Status: queue.JobRunning, StartedAt: time.Now()}
+	r := queue.StatusReport{
+		WorkerID: "host/worker-0",
+		PID:      1234,
+		AgentCmd: "claude",
+		LastTool: "TodoWrite",
+		// LastToolArg empty — tool with no recognised input key.
+	}
+	got := renderStatusMessage(state, r, "running")
+	if !contains(got, ":wrench: 正在 TodoWrite") {
+		t.Errorf("missing bare tool-name line: %q", got)
+	}
+	// The separator should only show up when there is an arg to follow it.
+	if contains(got, ":wrench: 正在 TodoWrite · ") {
+		t.Errorf("separator should be omitted when LastToolArg is empty: %q", got)
+	}
+}
+
+func TestRenderStatusMessage_RunningLastToolEscaped(t *testing.T) {
+	state := &queue.JobState{Status: queue.JobRunning, StartedAt: time.Now()}
+	r := queue.StatusReport{
+		WorkerID:    "host/worker-0",
+		PID:         1234,
+		AgentCmd:    "claude",
+		LastTool:    "Read",
+		LastToolArg: "<scary>file.go", // includes chars Slack mrkdwn interprets
+	}
+	got := renderStatusMessage(state, r, "running")
+	if !contains(got, "&lt;scary&gt;file.go") {
+		t.Errorf("LastToolArg should be Slack-escaped: %q", got)
+	}
+	if contains(got, "<scary>") {
+		t.Errorf("raw <> leaked into Slack output: %q", got)
+	}
+}
+
+func TestRenderStatusMessage_RunningLastToolEmptyFallsBackToCounter(t *testing.T) {
+	// LastTool empty but ToolCalls/FilesRead non-zero (typical non-stream
+	// agent path) — renderer must keep the counter line.
+	state := &queue.JobState{Status: queue.JobRunning, StartedAt: time.Now()}
+	r := queue.StatusReport{
+		WorkerID:  "host/worker-0",
+		PID:       1234,
+		AgentCmd:  "codex",
+		ToolCalls: 7,
+		FilesRead: 3,
+		// LastTool empty
+	}
+	got := renderStatusMessage(state, r, "running")
+	if !contains(got, "已經敲了 7 次工具、翻了 3 份檔") {
+		t.Errorf("counter fallback missing: %q", got)
+	}
+	if contains(got, ":wrench:") {
+		t.Errorf("tool-name line should NOT appear when LastTool is empty: %q", got)
+	}
+}

--- a/shared/queue/interface.go
+++ b/shared/queue/interface.go
@@ -47,8 +47,14 @@ type StatusReport struct {
 	PID            int       `json:"pid"`
 	AgentCmd     string    `json:"agent_cmd"`
 	Alive        bool      `json:"alive"`
-	LastEvent    string    `json:"last_event,omitempty"`
-	LastEventAt  time.Time `json:"last_event_at"`
+	LastEvent   string    `json:"last_event,omitempty"`
+	// LastTool / LastToolArg surface the most recent tool_use event from
+	// streaming agents so Slack renderers can show "正在 Read · src/foo.go"
+	// instead of an aggregate counter. Empty for non-streaming agents — the
+	// renderer falls back to ToolCalls/FilesRead in that case.
+	LastTool    string    `json:"last_tool,omitempty"`
+	LastToolArg string    `json:"last_tool_arg,omitempty"`
+	LastEventAt time.Time `json:"last_event_at"`
 	ToolCalls    int       `json:"tool_calls"`
 	FilesRead    int       `json:"files_read"`
 	OutputBytes  int       `json:"output_bytes"`

--- a/shared/queue/stream.go
+++ b/shared/queue/stream.go
@@ -8,12 +8,13 @@ import (
 )
 
 type StreamEvent struct {
-	Type         string
-	ToolName     string
-	TextBytes    int
-	CostUSD      float64
-	InputTokens  int
-	OutputTokens int
+	Type              string
+	ToolName          string
+	ToolInputFirstArg string // truncated to toolInputArgMaxLen runes; empty when no recognized key
+	TextBytes         int
+	CostUSD           float64
+	InputTokens       int
+	OutputTokens      int
 }
 
 // ReadStreamJSON reads NDJSON from claude --output-format stream-json.
@@ -50,8 +51,13 @@ func ReadStreamJSON(r io.Reader, eventCh chan<- StreamEvent) string {
 				switch blockType {
 				case "tool_use":
 					name, _ := block["name"].(string)
+					input, _ := block["input"].(map[string]any)
 					select {
-					case eventCh <- StreamEvent{Type: "tool_use", ToolName: name}:
+					case eventCh <- StreamEvent{
+						Type:              "tool_use",
+						ToolName:          name,
+						ToolInputFirstArg: extractFirstArg(input),
+					}:
 					default:
 					}
 				case "text":
@@ -104,4 +110,36 @@ func ReadRawOutput(r io.Reader) string {
 		buf.WriteByte('\n')
 	}
 	return buf.String()
+}
+
+// toolInputArgMaxLen caps how much of a tool_use input field surfaces into
+// StreamEvent. Slack rendering may truncate further; this is the upstream cap.
+const toolInputArgMaxLen = 100
+
+// extractFirstArg returns a human-readable string from a claude tool_use
+// input object, truncated to toolInputArgMaxLen runes. Tries common keys in
+// priority order: file_path (Read/Write/Edit), command (Bash), pattern
+// (Grep), path (LS/Glob), url (WebFetch). Returns empty when no key matches
+// — Slack render then falls back to the counter line.
+func extractFirstArg(input map[string]any) string {
+	if input == nil {
+		return ""
+	}
+	keys := []string{"file_path", "command", "pattern", "path", "url"}
+	for _, k := range keys {
+		if v, ok := input[k].(string); ok && v != "" {
+			return truncateRunes(v, toolInputArgMaxLen)
+		}
+	}
+	return ""
+}
+
+// truncateRunes caps s to max runes, appending "…" when truncation occurs.
+// Rune-based to avoid splitting multi-byte UTF-8 characters mid-byte.
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
 }

--- a/shared/queue/stream_test.go
+++ b/shared/queue/stream_test.go
@@ -74,3 +74,120 @@ func TestReadRawOutput(t *testing.T) {
 		t.Errorf("raw output = %q", text)
 	}
 }
+
+func TestReadStreamJSON_ToolInputFirstArg(t *testing.T) {
+	// Verify the tool_use event surfaces input.file_path through the parser
+	// into StreamEvent.ToolInputFirstArg. Other key recognition is unit-tested
+	// in TestExtractFirstArg_*; this end-to-end path is the integration check.
+	input := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/foo/bar.go"}}]}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	ReadStreamJSON(r, eventCh)
+	close(eventCh)
+
+	var got StreamEvent
+	for e := range eventCh {
+		if e.Type == "tool_use" {
+			got = e
+			break
+		}
+	}
+	if got.ToolName != "Read" {
+		t.Errorf("ToolName = %q, want Read", got.ToolName)
+	}
+	if got.ToolInputFirstArg != "src/foo/bar.go" {
+		t.Errorf("ToolInputFirstArg = %q, want src/foo/bar.go", got.ToolInputFirstArg)
+	}
+}
+
+func TestExtractFirstArg_Empty(t *testing.T) {
+	if got := extractFirstArg(nil); got != "" {
+		t.Errorf("nil input: got %q, want empty", got)
+	}
+	if got := extractFirstArg(map[string]any{}); got != "" {
+		t.Errorf("empty input: got %q, want empty", got)
+	}
+}
+
+func TestExtractFirstArg_RecognizedKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{"file_path (Read)", map[string]any{"file_path": "src/foo.go"}, "src/foo.go"},
+		{"command (Bash)", map[string]any{"command": "git status"}, "git status"},
+		{"pattern (Grep)", map[string]any{"pattern": "TODO"}, "TODO"},
+		{"path (LS)", map[string]any{"path": "/tmp"}, "/tmp"},
+		{"url (WebFetch)", map[string]any{"url": "https://example.com"}, "https://example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractFirstArg(c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractFirstArg_PriorityOrder(t *testing.T) {
+	// file_path takes priority over command and others. Real claude tool_use
+	// objects only carry one of these at a time, but ordering guards future
+	// shape drift.
+	in := map[string]any{
+		"file_path": "src/foo.go",
+		"command":   "git status",
+		"pattern":   "TODO",
+	}
+	if got := extractFirstArg(in); got != "src/foo.go" {
+		t.Errorf("got %q, want file_path winner", got)
+	}
+}
+
+func TestExtractFirstArg_UnknownKey(t *testing.T) {
+	in := map[string]any{"unknown_field": "value"}
+	if got := extractFirstArg(in); got != "" {
+		t.Errorf("unknown key should yield empty: got %q", got)
+	}
+}
+
+func TestExtractFirstArg_NonStringValue(t *testing.T) {
+	// Type-assert to string fails silently when value is some other type
+	// (e.g. nested object). Must not panic; returns empty.
+	in := map[string]any{"file_path": 123}
+	if got := extractFirstArg(in); got != "" {
+		t.Errorf("non-string value should yield empty: got %q", got)
+	}
+}
+
+func TestExtractFirstArg_Truncated(t *testing.T) {
+	long := strings.Repeat("a", toolInputArgMaxLen+50)
+	in := map[string]any{"command": long}
+	got := extractFirstArg(in)
+	gotRunes := []rune(got)
+	if len(gotRunes) != toolInputArgMaxLen {
+		t.Errorf("len = %d runes, want %d", len(gotRunes), toolInputArgMaxLen)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated value should end with marker: got %q", got)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 100, "short"},
+		{"abcdefghij", 5, "abcd…"},
+		{"中文太長要截斷", 5, "中文太長…"},
+		{"exactly5", 8, "exactly5"},
+	}
+	for _, c := range cases {
+		if got := truncateRunes(c.in, c.max); got != c.want {
+			t.Errorf("truncateRunes(%q, %d) = %q, want %q", c.in, c.max, got, c.want)
+		}
+	}
+}

--- a/worker/pool/status.go
+++ b/worker/pool/status.go
@@ -8,18 +8,20 @@ import (
 )
 
 type statusAccumulator struct {
-	mu           sync.Mutex
-	jobID        string
-	workerID     string
-	nickname     string
-	pid          int
-	agentCmd     string
-	alive        bool
-	lastEvent    string
-	lastEventAt  time.Time
-	toolCalls    int
-	filesRead    int
-	outputBytes  int
+	mu             sync.Mutex
+	jobID          string
+	workerID       string
+	nickname       string
+	pid            int
+	agentCmd       string
+	alive          bool
+	lastEvent      string
+	lastTool       string
+	lastToolArg    string
+	lastEventAt    time.Time
+	toolCalls      int
+	filesRead      int
+	outputBytes    int
 	costUSD        float64
 	inputTokens    int
 	outputTokens   int
@@ -42,6 +44,8 @@ func (s *statusAccumulator) recordEvent(event queue.StreamEvent) {
 	case "tool_use":
 		s.toolCalls++
 		s.lastEvent = "tool_use:" + event.ToolName
+		s.lastTool = event.ToolName
+		s.lastToolArg = event.ToolInputFirstArg
 		if event.ToolName == "Read" {
 			s.filesRead++
 		}
@@ -73,6 +77,8 @@ func (s *statusAccumulator) toReport() queue.StatusReport {
 		AgentCmd:       s.agentCmd,
 		Alive:          s.alive,
 		LastEvent:      s.lastEvent,
+		LastTool:       s.lastTool,
+		LastToolArg:    s.lastToolArg,
 		LastEventAt:    s.lastEventAt,
 		ToolCalls:      s.toolCalls,
 		FilesRead:      s.filesRead,


### PR DESCRIPTION
## Summary

Final PR of the V8 plan from #228. Surfaces the most recent tool_use through the `worker → status bus → Slack` pipeline so thread readers see something like:

```
:fire: worker-3 開工啦！(claude) · 奮鬥 1m23s
:wrench: 正在 Read · src/foo/bar.go
```

instead of today's counter line `已經敲了 7 次工具、翻了 4 份檔`.

## Files touched

| Module | File | What |
|---|---|---|
| `shared` | `queue/stream.go` | `StreamEvent.ToolInputFirstArg` field + `extractFirstArg` + `truncateRunes` (rune-based, multi-byte safe) |
| `shared` | `queue/interface.go` | `StatusReport.LastTool` + `LastToolArg` (json `omitempty`, backward compatible) |
| `worker` | `pool/status.go` | `statusAccumulator` records tool name + first arg, forwards via `toReport` |
| `app` | `bot/status_listener.go` | `renderStatusMessage` running branch: `:wrench: 正在 {tool} · {arg}` with `slackEscape` on both fields, falls back to counter when `LastTool` empty |
| `shared` + `app` | `*_test.go` | end-to-end parser test, helper unit tests, render branch tests, fallback test |

## Backward compatibility

- `LastTool` / `LastToolArg` are `omitempty` JSON. Pre-PR3 workers serialize empty → renderer hits the existing counter branch. No deploy ordering required.
- For non-streaming agents (codex today, opencode-non-pure), `LastTool` is never populated — same fallback path. No regression there.
- `slackEscape` is applied to both fields before joining; agent-supplied paths with `<` / `>` / `&` are neutralised before reaching Slack mrkdwn.

## What's NOT in PR3

- `thinking` content rendering — explicitly out of scope per V8 one-pager (200-char Slack window + 15s debounce makes it noise, not signal).
- `tool_result` rendering — same reasoning.
- opencode `--format json` parsing — the V3 fallback is a feature, not a regression.
- `JobResult.CostUSD/InputTokens/OutputTokens` propagation — separate bug, unrelated.

## V8 PR split status

- ✅ #229 docs — V8 one-pager
- ✅ #230 PR 1 — hygiene bundle
- ✅ #232 PR 2 — inactivity timeout
- 🟡 **#this PR 3 — tool-name visibility**

## Test plan

- [x] `go build ./...` shared / worker / app modules
- [x] `go vet ./...` shared / worker / app modules
- [x] `go test -race ./...` shared / worker / app modules
- [x] `go test ./test/...` import-direction
- [x] No mock shell scripts with bare `sleep` (PR1+PR2 lesson tag — no scripts at all this round, since the new behavior is purely struct + render plumbing)
- [ ] Manual: send a real `@bot` issue to a thread with a streaming claude job, confirm Slack message shows `:wrench: 正在 Read · src/...` and updates as the agent moves through tools
- [ ] Manual: confirm the counter fallback `已經敲了 N 次工具、翻了 M 份檔` still appears for codex / opencode runs

Refs: #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)