### PR TITLE
feat(worker+shared): tool-name visibility for opencode (#228 PR 4)

### DIFF
--- a/app/config/defaults.go
+++ b/app/config/defaults.go
@@ -132,7 +132,7 @@ const (
 ===ASK_RESULT===
 {"answer": "<your full markdown answer as a single JSON string>"}
 
-The JSON key MUST be literally "answer" (six letters: a-n-s-w-e-r). Do NOT use "text", "content", "response", "result", "message", or any synonym. Any other key causes a parse failure.`
+The JSON key MUST be literally "answer" — any other key fails to parse.`
 
 	// Mirrors app/workflow/pr_review_parser.go:ReviewResult and the
 	// github-pr-review skill's "Emit the result marker" section. Keep the
@@ -199,32 +199,45 @@ The app strips those sections in degraded runs (low files_found / high open_ques
 // detection log added at the same time.
 const cwdOnlySandboxRule = "All temporary files and shell redirections MUST be written inside the current working directory (e.g. `./fp.json`, `./screenshot.png`). Never write to `/tmp/`, `/var/`, `$HOME`, `~`, or any other path outside cwd — opencode's sandbox treats those as external_directory and headless `opencode run` auto-rejects the write, silently failing the task with no result marker."
 
+// noXMLWrappingRule prevents the model from mirroring the prompt's XML
+// envelope into its reply. The prompt is XML-heavy (security_rules /
+// output_rules / response_schema as nested tags); some models — observed
+// 2026-05-01 with opencode/minimax-m2.5-free — treat that structure as a
+// tool-call template and emit `<parameter>...</parameter>` or
+// `<answer>...</answer>` around their output, escaping the closing JSON
+// quote in the process and breaking the marker-block parsers (ask,
+// issue, pr_review). Shared across workflows because the failure mode is
+// model-side, not workflow-specific.
+const noXMLWrappingRule = "Reply in plain markdown. Do NOT wrap your output in XML tags like `<answer>`, `<parameter>`, or `<response>` — the XML in this prompt is for structuring input to you, not a template for your reply."
+
 var (
+	// Slack mrkdwn syntax detail and self-reference handling are owned by
+	// ask-assistant SKILL.md (§7 and §1 respectively); previous output_rules
+	// duplicated both. Output_rules keeps only the prompt-time hard
+	// constraints that aren't load-bearing in the skill body: the headline
+	// Slack-mrkdwn directive (belt-and-suspenders against models that skip
+	// the skill), the heading ban, and the length cap.
 	defaultAskOutputRules = []string{
-		"Format the answer in Slack mrkdwn — NOT GitHub markdown. Use *text* (single asterisk) for bold, _text_ for italic, ~text~ for strikethrough, <url|label> for links. Do not use # / ## / ### headings; use *bold* as section labels. Triple-backtick fenced code blocks and single-backtick inline code both render correctly.",
-		// Old rule was "No title, no labels — output the answer content only."
-		// That directly contradicted Rule 1 above and SKILL.md §4a, which both
-		// expect *bold* section labels (e.g. *簡答* / *依據*). Agents (correctly)
-		// prioritised this hard-sounding rule and dropped skill structure.
-		// Now: only ban opening heading/title lines, keep the length cap, and
-		// explicitly bless inline *bold* labels so skill structure survives.
-		"Do not open with an H1/H2/H3 heading or standalone title line — start directly with the answer content. *bold* section labels inside the body (e.g. *簡答*, *依據*, *延伸*) are encouraged per the ask-assistant skill. Keep the total answer ≤30000 chars.",
-		"When referring to yourself, use the exact Slack handle from the <bot> tag in <issue_context> (e.g. 'ai_trigger_issue_bot') verbatim. Do NOT invent shorthand like '@bot ask', 'Ask 助理', 'AI 助理', '程式碼助手'. If a sentence doesn't need self-reference, just answer without name-dropping.",
+		"Output Slack mrkdwn (not GitHub markdown): no `#`/`##`/`###` headings — use *bold* as section labels (e.g. *簡答*). Start directly with answer content. Keep total ≤30000 chars.",
 		cwdOnlySandboxRule,
+		noXMLWrappingRule,
 	}
 	defaultPRReviewOutputRules = []string{
 		"Focus on correctness, security, style",
 		"Summary ≤ 2000 chars",
 		cwdOnlySandboxRule,
+		noXMLWrappingRule,
 	}
 	// Issue.OutputRules used to be intentionally empty — formatting rules live
 	// in the triage-issue skill's SKILL.md body template, machine schema lives
 	// in Issue.ResponseSchema. The cwd-only rule is the one exception: it's a
 	// sandbox guard that applies regardless of the skill in use, so it's
 	// promoted from skill text to a hard output_rule per the project convention
-	// "硬規則直接升格到 output_rules".
+	// "硬規則直接升格到 output_rules". noXMLWrappingRule joins it for the
+	// same reason — model-side failure, applies regardless of skill content.
 	defaultIssueOutputRules = []string{
 		cwdOnlySandboxRule,
+		noXMLWrappingRule,
 	}
 )
 

--- a/docs/ideas/worker-agent-progress-visibility.md
+++ b/docs/ideas/worker-agent-progress-visibility.md
@@ -103,9 +103,19 @@ PRs are split for independent user verification, per
 - **`thinking` content in Slack** — 200-char truncation in a 15s
   debounce window converts useful thought into noise.
 - **`tool_result` in Slack** — same.
-- **opencode `--format json` parsing** — `--pure` interaction is
+- ~~**opencode `--format json` parsing** — `--pure` interaction is
   unverified, and the V3 fallback (`LastTool == ""`) means opencode
-  visibility is a no-op rather than a regression.
+  visibility is a no-op rather than a regression.~~ Reopened and shipped
+  in PR4 once `--pure --format json` was empirically verified to emit
+  per-tool NDJSON events. The earlier "cascade collapse" concern in
+  `worker/agent/runner.go` turned out to be a stdin-not-closed artifact
+  on interactive shells; the worker's `exec.Command` defaults already
+  close child stdin, so no permission relaxation
+  (`OPENCODE_PERMISSION={"*":"allow"}` etc.) was needed. PR4 added a
+  flat-shape parser (`shared/queue/stream.go ReadStreamJSONOpencode`),
+  generalized the `Stream bool` toggle to a `StreamFormat string`
+  selector, and extended `extractFirstArg` with the camelCase `filePath`
+  key opencode uses for Read/Edit/Write.
 - **codex `app-server` rewrite** — separate 1000+ LOC effort; tracked
   separately if codex stream support ever becomes load-bearing.
 - **`JobResult.CostUSD/InputTokens/OutputTokens` propagation** — the

--- a/shared/queue/stream.go
+++ b/shared/queue/stream.go
@@ -17,9 +17,11 @@ type StreamEvent struct {
 	OutputTokens      int
 }
 
-// ReadStreamJSON reads NDJSON from claude --output-format stream-json.
-// Returns final text from "result" event, or reassembled message_delta as fallback.
-func ReadStreamJSON(r io.Reader, eventCh chan<- StreamEvent) string {
+// ReadStreamJSONClaude reads NDJSON from `claude --print --output-format
+// stream-json`. Tool calls are nested under `message.content[]` blocks of
+// type `tool_use`; the final answer arrives as a single `result` event with
+// totals.
+func ReadStreamJSONClaude(r io.Reader, eventCh chan<- StreamEvent) string {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 
@@ -100,6 +102,93 @@ func ReadStreamJSON(r io.Reader, eventCh chan<- StreamEvent) string {
 	return reassembled.String()
 }
 
+// ReadStreamJSONOpencode reads NDJSON from `opencode run --format json`.
+// Event shape is FLAT — tool calls live at top-level `part.tool` /
+// `part.state.input` instead of claude's `message.content[].tool_use`. Tool
+// names are lowercase (`read`/`bash`/`grep`); titleCaseTool normalizes them
+// to claude's PascalCase taxonomy so downstream handlers built around it
+// (e.g. statusAccumulator's "Read" filesRead match) work without per-agent
+// special cases.
+//
+// opencode reports tokens per `step_finish` event rather than once at end;
+// we accumulate and emit a single synthesized `result` event after the
+// scanner closes, mirroring claude's terminal-result contract.
+//
+// Final text is reassembled from `text` events (opencode has no equivalent
+// of claude's `result.result` field).
+func ReadStreamJSONOpencode(r io.Reader, eventCh chan<- StreamEvent) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var output strings.Builder
+	var totalCost float64
+	var totalInputTokens, totalOutputTokens int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var raw struct {
+			Type string `json:"type"`
+			Part struct {
+				Tool  string `json:"tool"`
+				Text  string `json:"text"`
+				State *struct {
+					Input map[string]any `json:"input"`
+				} `json:"state,omitempty"`
+				Tokens *struct {
+					Input  int `json:"input"`
+					Output int `json:"output"`
+				} `json:"tokens,omitempty"`
+				Cost float64 `json:"cost"`
+			} `json:"part"`
+		}
+		if json.Unmarshal([]byte(line), &raw) != nil {
+			continue
+		}
+		switch raw.Type {
+		case "tool_use":
+			var input map[string]any
+			if raw.Part.State != nil {
+				input = raw.Part.State.Input
+			}
+			select {
+			case eventCh <- StreamEvent{
+				Type:              "tool_use",
+				ToolName:          titleCaseTool(raw.Part.Tool),
+				ToolInputFirstArg: extractFirstArg(input),
+			}:
+			default:
+			}
+		case "text":
+			text := raw.Part.Text
+			if text != "" {
+				output.WriteString(text)
+				select {
+				case eventCh <- StreamEvent{Type: "message_delta", TextBytes: len(text)}:
+				default:
+				}
+			}
+		case "step_finish":
+			if raw.Part.Tokens != nil {
+				totalInputTokens += raw.Part.Tokens.Input
+				totalOutputTokens += raw.Part.Tokens.Output
+			}
+			totalCost += raw.Part.Cost
+		}
+	}
+
+	select {
+	case eventCh <- StreamEvent{
+		Type:         "result",
+		CostUSD:      totalCost,
+		InputTokens:  totalInputTokens,
+		OutputTokens: totalOutputTokens,
+	}:
+	default:
+	}
+
+	return output.String()
+}
+
 // ReadRawOutput reads plain text stdout (non-stream agents).
 func ReadRawOutput(r io.Reader) string {
 	scanner := bufio.NewScanner(r)
@@ -116,22 +205,43 @@ func ReadRawOutput(r io.Reader) string {
 // StreamEvent. Slack rendering may truncate further; this is the upstream cap.
 const toolInputArgMaxLen = 100
 
-// extractFirstArg returns a human-readable string from a claude tool_use
-// input object, truncated to toolInputArgMaxLen runes. Tries common keys in
-// priority order: file_path (Read/Write/Edit), command (Bash), pattern
-// (Grep), path (LS/Glob), url (WebFetch). Returns empty when no key matches
-// — Slack render then falls back to the counter line.
+// extractFirstArg returns a human-readable string from a tool_use input
+// object, truncated to toolInputArgMaxLen runes. Tries common keys in
+// priority order:
+//   - file_path / filePath: Read, Edit, Write (claude snake / opencode camel)
+//   - command:              Bash
+//   - pattern:              Grep
+//   - path:                 LS, Glob
+//   - url:                  WebFetch
+//
+// Returns empty when no key matches — Slack render then falls back to the
+// counter line. Both snake_case and camelCase are accepted to cover the two
+// agents' input conventions; tools rarely carry both, but if they do the
+// snake form wins (claude's convention is more widely tested).
 func extractFirstArg(input map[string]any) string {
 	if input == nil {
 		return ""
 	}
-	keys := []string{"file_path", "command", "pattern", "path", "url"}
+	keys := []string{"file_path", "filePath", "command", "pattern", "path", "url"}
 	for _, k := range keys {
 		if v, ok := input[k].(string); ok && v != "" {
 			return truncateRunes(v, toolInputArgMaxLen)
 		}
 	}
 	return ""
+}
+
+// titleCaseTool capitalizes the first ASCII letter of name. opencode emits
+// lowercase tool names (read/bash/grep); claude emits PascalCase
+// (Read/Bash). Normalizing here lets downstream consumers — Slack render,
+// statusAccumulator's hardcoded "Read" match for filesRead — share a single
+// taxonomy. Non-ASCII or empty input passes through unchanged so future tool
+// names with extended characters don't get mangled.
+func titleCaseTool(name string) string {
+	if name == "" || name[0] < 'a' || name[0] > 'z' {
+		return name
+	}
+	return string(name[0]-'a'+'A') + name[1:]
 }
 
 // truncateRunes caps s to max runes, appending "…" when truncation occurs.

--- a/shared/queue/stream_test.go
+++ b/shared/queue/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestReadStreamJSON_ResultEvent(t *testing.T) {
+func TestReadStreamJSONClaude_ResultEvent(t *testing.T) {
 	input := `{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at code..."}]}}
 {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"Found the issue..."}]}}
@@ -13,7 +13,7 @@ func TestReadStreamJSON_ResultEvent(t *testing.T) {
 
 	r := strings.NewReader(input)
 	eventCh := make(chan StreamEvent, 100)
-	text := ReadStreamJSON(r, eventCh)
+	text := ReadStreamJSONClaude(r, eventCh)
 	close(eventCh)
 
 	if text != "Final answer text here" {
@@ -52,13 +52,13 @@ func TestReadStreamJSON_ResultEvent(t *testing.T) {
 	}
 }
 
-func TestReadStreamJSON_FallbackToReassembly(t *testing.T) {
+func TestReadStreamJSONClaude_FallbackToReassembly(t *testing.T) {
 	input := `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"World"}]}}`
 
 	r := strings.NewReader(input)
 	eventCh := make(chan StreamEvent, 100)
-	text := ReadStreamJSON(r, eventCh)
+	text := ReadStreamJSONClaude(r, eventCh)
 	close(eventCh)
 
 	if text != "Hello World" {
@@ -75,7 +75,7 @@ func TestReadRawOutput(t *testing.T) {
 	}
 }
 
-func TestReadStreamJSON_ToolInputFirstArg(t *testing.T) {
+func TestReadStreamJSONClaude_ToolInputFirstArg(t *testing.T) {
 	// Verify the tool_use event surfaces input.file_path through the parser
 	// into StreamEvent.ToolInputFirstArg. Other key recognition is unit-tested
 	// in TestExtractFirstArg_*; this end-to-end path is the integration check.
@@ -83,7 +83,7 @@ func TestReadStreamJSON_ToolInputFirstArg(t *testing.T) {
 
 	r := strings.NewReader(input)
 	eventCh := make(chan StreamEvent, 10)
-	ReadStreamJSON(r, eventCh)
+	ReadStreamJSONClaude(r, eventCh)
 	close(eventCh)
 
 	var got StreamEvent
@@ -98,6 +98,151 @@ func TestReadStreamJSON_ToolInputFirstArg(t *testing.T) {
 	}
 	if got.ToolInputFirstArg != "src/foo/bar.go" {
 		t.Errorf("ToolInputFirstArg = %q, want src/foo/bar.go", got.ToolInputFirstArg)
+	}
+}
+
+// TestReadStreamJSONOpencode_ReadTool fixture is a minimized capture from
+// `opencode 1.14.29 run --pure --format json` reading a small file. Confirms
+// the opencode parser surfaces tool_use events with title-cased tool name and
+// the camelCase filePath argument.
+func TestReadStreamJSONOpencode_ReadTool(t *testing.T) {
+	input := `{"type":"step_start","sessionID":"ses_x","part":{"type":"step-start"}}
+{"type":"tool_use","sessionID":"ses_x","part":{"type":"tool","tool":"read","callID":"call_a","state":{"status":"completed","input":{"filePath":"/tmp/test.txt"}}}}
+{"type":"text","sessionID":"ses_x","part":{"type":"text","text":"The magic number is 42."}}
+{"type":"step_finish","sessionID":"ses_x","part":{"type":"step-finish","tokens":{"input":18000,"output":120},"cost":0.0123}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 100)
+	text := ReadStreamJSONOpencode(r, eventCh)
+	close(eventCh)
+
+	if text != "The magic number is 42." {
+		t.Errorf("text = %q, want 'The magic number is 42.'", text)
+	}
+
+	var events []StreamEvent
+	for e := range eventCh {
+		events = append(events, e)
+	}
+
+	var toolUse, result StreamEvent
+	for _, e := range events {
+		switch e.Type {
+		case "tool_use":
+			toolUse = e
+		case "result":
+			result = e
+		}
+	}
+	if toolUse.ToolName != "Read" {
+		t.Errorf("ToolName = %q, want Read (title-cased)", toolUse.ToolName)
+	}
+	if toolUse.ToolInputFirstArg != "/tmp/test.txt" {
+		t.Errorf("ToolInputFirstArg = %q, want /tmp/test.txt", toolUse.ToolInputFirstArg)
+	}
+	if result.CostUSD != 0.0123 {
+		t.Errorf("cost = %f, want 0.0123", result.CostUSD)
+	}
+	if result.InputTokens != 18000 {
+		t.Errorf("input_tokens = %d, want 18000", result.InputTokens)
+	}
+	if result.OutputTokens != 120 {
+		t.Errorf("output_tokens = %d, want 120", result.OutputTokens)
+	}
+}
+
+// TestReadStreamJSONOpencode_BashTool confirms `bash` tool's `command` input
+// key is recognized by extractFirstArg (shared with claude convention).
+func TestReadStreamJSONOpencode_BashTool(t *testing.T) {
+	input := `{"type":"tool_use","sessionID":"ses_x","part":{"type":"tool","tool":"bash","callID":"call_b","state":{"status":"completed","input":{"command":"echo hello-bash","description":"Print hello"}}}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	ReadStreamJSONOpencode(r, eventCh)
+	close(eventCh)
+
+	var got StreamEvent
+	for e := range eventCh {
+		if e.Type == "tool_use" {
+			got = e
+			break
+		}
+	}
+	if got.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want Bash", got.ToolName)
+	}
+	if got.ToolInputFirstArg != "echo hello-bash" {
+		t.Errorf("ToolInputFirstArg = %q, want 'echo hello-bash'", got.ToolInputFirstArg)
+	}
+}
+
+// TestReadStreamJSONOpencode_GrepTool confirms `grep` tool's `pattern` key
+// (shared with claude convention).
+func TestReadStreamJSONOpencode_GrepTool(t *testing.T) {
+	input := `{"type":"tool_use","sessionID":"ses_x","part":{"type":"tool","tool":"grep","callID":"call_c","state":{"status":"completed","input":{"pattern":"TODO"}}}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	ReadStreamJSONOpencode(r, eventCh)
+	close(eventCh)
+
+	var got StreamEvent
+	for e := range eventCh {
+		if e.Type == "tool_use" {
+			got = e
+			break
+		}
+	}
+	if got.ToolName != "Grep" {
+		t.Errorf("ToolName = %q, want Grep", got.ToolName)
+	}
+	if got.ToolInputFirstArg != "TODO" {
+		t.Errorf("ToolInputFirstArg = %q, want TODO", got.ToolInputFirstArg)
+	}
+}
+
+// TestReadStreamJSONOpencode_TokenAccumulation confirms tokens summed across
+// multiple step_finish events (opencode emits one per step, not one terminal
+// total like claude).
+func TestReadStreamJSONOpencode_TokenAccumulation(t *testing.T) {
+	input := `{"type":"step_finish","part":{"tokens":{"input":1000,"output":50},"cost":0.01}}
+{"type":"step_finish","part":{"tokens":{"input":200,"output":30},"cost":0.005}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	ReadStreamJSONOpencode(r, eventCh)
+	close(eventCh)
+
+	var result StreamEvent
+	for e := range eventCh {
+		if e.Type == "result" {
+			result = e
+		}
+	}
+	if result.InputTokens != 1200 {
+		t.Errorf("input_tokens = %d, want 1200 (1000+200)", result.InputTokens)
+	}
+	if result.OutputTokens != 80 {
+		t.Errorf("output_tokens = %d, want 80 (50+30)", result.OutputTokens)
+	}
+	if result.CostUSD != 0.015 {
+		t.Errorf("cost = %f, want 0.015 (0.01+0.005)", result.CostUSD)
+	}
+}
+
+// TestReadStreamJSONOpencode_TextReassembly confirms output text is built
+// from `text` events (opencode has no terminal result.result field).
+func TestReadStreamJSONOpencode_TextReassembly(t *testing.T) {
+	input := `{"type":"text","part":{"type":"text","text":"Hello "}}
+{"type":"text","part":{"type":"text","text":"World"}}`
+
+	r := strings.NewReader(input)
+	eventCh := make(chan StreamEvent, 10)
+	text := ReadStreamJSONOpencode(r, eventCh)
+	close(eventCh)
+
+	if text != "Hello World" {
+		t.Errorf("text = %q, want 'Hello World'", text)
 	}
 }
 
@@ -116,7 +261,8 @@ func TestExtractFirstArg_RecognizedKeys(t *testing.T) {
 		in   map[string]any
 		want string
 	}{
-		{"file_path (Read)", map[string]any{"file_path": "src/foo.go"}, "src/foo.go"},
+		{"file_path (claude Read)", map[string]any{"file_path": "src/foo.go"}, "src/foo.go"},
+		{"filePath (opencode read)", map[string]any{"filePath": "src/foo.go"}, "src/foo.go"},
 		{"command (Bash)", map[string]any{"command": "git status"}, "git status"},
 		{"pattern (Grep)", map[string]any{"pattern": "TODO"}, "TODO"},
 		{"path (LS)", map[string]any{"path": "/tmp"}, "/tmp"},
@@ -132,7 +278,7 @@ func TestExtractFirstArg_RecognizedKeys(t *testing.T) {
 }
 
 func TestExtractFirstArg_PriorityOrder(t *testing.T) {
-	// file_path takes priority over command and others. Real claude tool_use
+	// file_path takes priority over command and others. Real tool_use
 	// objects only carry one of these at a time, but ordering guards future
 	// shape drift.
 	in := map[string]any{
@@ -142,6 +288,20 @@ func TestExtractFirstArg_PriorityOrder(t *testing.T) {
 	}
 	if got := extractFirstArg(in); got != "src/foo.go" {
 		t.Errorf("got %q, want file_path winner", got)
+	}
+}
+
+// TestExtractFirstArg_SnakeBeatsCamel guards the snake-vs-camel priority. If
+// a tool input ever carries BOTH file_path and filePath (extremely
+// unlikely), claude's snake form wins because claude is the more
+// widely-tested upstream.
+func TestExtractFirstArg_SnakeBeatsCamel(t *testing.T) {
+	in := map[string]any{
+		"filePath":  "camel.go",
+		"file_path": "snake.go",
+	}
+	if got := extractFirstArg(in); got != "snake.go" {
+		t.Errorf("got %q, want snake.go (file_path wins)", got)
 	}
 }
 
@@ -171,6 +331,25 @@ func TestExtractFirstArg_Truncated(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, "…") {
 		t.Errorf("truncated value should end with marker: got %q", got)
+	}
+}
+
+func TestTitleCaseTool(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"read", "Read"},
+		{"bash", "Bash"},
+		{"grep", "Grep"},
+		{"webfetch", "Webfetch"}, // simple cap; not "WebFetch" — that's a known cosmetic loss
+		{"Read", "Read"},         // already title-cased
+		{"", ""},                 // empty pass-through
+		{"中文", "中文"},             // non-ASCII pass-through
+	}
+	for _, c := range cases {
+		if got := titleCaseTool(c.in); got != c.want {
+			t.Errorf("titleCaseTool(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -182,7 +182,7 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	// no events and would be killed prematurely. Disabled when timeout <= 0.
 	var inactivityKilled atomic.Bool
 	eventCallback := opts.OnEvent
-	if agent.InactivityTimeout > 0 && agent.Stream {
+	if agent.InactivityTimeout > 0 && agent.StreamFormat != "" {
 		inactivityTimer := time.AfterFunc(agent.InactivityTimeout, func() {
 			inactivityKilled.Store(true)
 			logger.Warn("Inactivity timeout 觸發，發送 SIGTERM",
@@ -206,7 +206,7 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		output = readOutput(ctx, stdoutPipe, agent.Stream, eventCallback)
+		output = readOutput(ctx, stdoutPipe, agent.StreamFormat, eventCallback)
 	}()
 	wg.Wait()
 
@@ -241,9 +241,14 @@ func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.A
 	return trimmed, nil
 }
 
-// readOutput routes stdout through the appropriate reader based on stream config.
-func readOutput(ctx context.Context, r io.Reader, stream bool, onEvent func(queue.StreamEvent)) string {
-	if !stream {
+// readOutput routes stdout through the appropriate reader based on the
+// stream format. Empty format is the non-streaming path; recognized formats
+// dispatch to per-CLI parsers in shared/queue. Unknown values fall back to
+// raw stdout — same observable output as a non-streaming agent, only the
+// live event channel is silent. Validate at config-load time to surface
+// typos before they reach here.
+func readOutput(ctx context.Context, r io.Reader, format string, onEvent func(queue.StreamEvent)) string {
+	if format == "" {
 		return queue.ReadRawOutput(r)
 	}
 
@@ -273,7 +278,17 @@ func readOutput(ctx context.Context, r io.Reader, stream bool, onEvent func(queu
 		}
 	}()
 
-	result = queue.ReadStreamJSON(r, eventCh)
+	switch format {
+	case config.StreamFormatClaude:
+		result = queue.ReadStreamJSONClaude(r, eventCh)
+	case config.StreamFormatOpencode:
+		result = queue.ReadStreamJSONOpencode(r, eventCh)
+	default:
+		// Unknown format — drain stdout into the raw reader so the agent's
+		// final answer still surfaces. eventCh stays empty; the forwarder
+		// goroutine exits on close.
+		result = queue.ReadRawOutput(r)
+	}
 	close(eventCh)
 	wg.Wait()
 	return result

--- a/worker/agent/runner_test.go
+++ b/worker/agent/runner_test.go
@@ -569,7 +569,7 @@ echo '`+streamResultLine+`'
 
 	runner := NewRunner([]config.AgentConfig{{
 		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
-		Stream: true,
+		StreamFormat: config.StreamFormatClaude,
 		// InactivityTimeout: 0 — explicitly disabled.
 	}})
 	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
@@ -597,7 +597,7 @@ exec sleep 3
 
 	runner := NewRunner([]config.AgentConfig{{
 		Command: script, Args: []string{"{prompt}"}, Timeout: 10 * time.Second,
-		Stream:            true,
+		StreamFormat:      config.StreamFormatClaude,
 		InactivityTimeout: 300 * time.Millisecond,
 	}})
 	start := time.Now()
@@ -633,7 +633,7 @@ echo '`+streamResultLine+`'
 
 	runner := NewRunner([]config.AgentConfig{{
 		Command: script, Args: []string{"{prompt}"}, Timeout: 10 * time.Second,
-		Stream:            true,
+		StreamFormat:      config.StreamFormatClaude,
 		InactivityTimeout: 500 * time.Millisecond,
 	}})
 	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})
@@ -657,7 +657,7 @@ echo "non-stream output with enough characters padding padding padding padding"
 
 	runner := NewRunner([]config.AgentConfig{{
 		Command: script, Args: []string{"{prompt}"}, Timeout: 5 * time.Second,
-		// Stream defaults to false
+		// StreamFormat defaults to "" (non-streaming)
 		InactivityTimeout: 100 * time.Millisecond, // would fire if applied
 	}})
 	output, err := runner.Run(context.Background(), slog.Default(), dir, "test", RunOptions{})

--- a/worker/config/builtin_agents.go
+++ b/worker/config/builtin_agents.go
@@ -17,20 +17,25 @@ import "time"
 //   - codex: `codex exec <flags> <prompt>`. `--skip-git-repo-check`/`--color
 //     never` are flags; prompt is positional. `{extra_args}` goes right before
 //     `{prompt}`.
-//   - opencode: `opencode run <flags> <prompt>`. `--pure` is a flag; `-m`,
-//     `--agent`, `--variant`, `-c`, `--session`, `-f` all live in this
-//     same pre-prompt flag slot. `{extra_args}` goes between `--pure` and
-//     `{prompt}`.
+//   - opencode: `opencode run <flags> <prompt>`. `--pure` and `--format json`
+//     are worker-managed flags; `-m`, `--agent`, `--variant`, `-c`,
+//     `--session`, `-f` all live in this same pre-prompt flag slot.
+//     `{extra_args}` goes between `--format json` and `{prompt}`.
+//
+// `--format json` is required for the StreamFormatOpencode parser to receive
+// NDJSON. Operators who override args via `extra_args` and accidentally
+// re-set `--format default` will silently lose tool-name visibility — the
+// runner falls back to a counter line, no regression in stdout capture.
 //
 // Runtime: nil/empty `extra_args` → the `{extra_args}` slot is dropped
 // entirely (NO empty string element). See runner.go expandExtraArgs.
 var BuiltinAgents = map[string]AgentConfig{
 	"claude": {
-		Command:  "claude",
-		Args:     []string{"--print", "--output-format", "stream-json", "{extra_args}", "-p", "{prompt}"},
-		Timeout:  30 * time.Minute,
-		SkillDir: ".claude/skills",
-		Stream:   true,
+		Command:      "claude",
+		Args:         []string{"--print", "--output-format", "stream-json", "{extra_args}", "-p", "{prompt}"},
+		Timeout:      30 * time.Minute,
+		SkillDir:     ".claude/skills",
+		StreamFormat: StreamFormatClaude,
 	},
 	"codex": {
 		Command: "codex",
@@ -47,8 +52,14 @@ var BuiltinAgents = map[string]AgentConfig{
 		// BackgroundManager cause `opencode run` to exit on the main agent's
 		// first "I dispatched" text — before the sub-agents return a parseable
 		// TRIAGE_RESULT. Internal auth plugins still load, so credentials stay intact.
-		Args:     []string{"run", "--pure", "{extra_args}", "{prompt}"},
-		Timeout:  30 * time.Minute,
-		SkillDir: ".opencode/skills",
+		//
+		// --format json switches stdout to NDJSON so the worker can surface
+		// tool-name activity into Slack progress. opencode 1.14.x and later;
+		// older versions silently fall through (parser sees no events,
+		// LastTool stays empty, Slack shows the counter line).
+		Args:         []string{"run", "--pure", "--format", "json", "{extra_args}", "{prompt}"},
+		Timeout:      30 * time.Minute,
+		SkillDir:     ".opencode/skills",
+		StreamFormat: StreamFormatOpencode,
 	},
 }

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -28,6 +28,15 @@ type Config struct {
 // count — the token must stand alone as its own arg slot.
 const ExtraArgsToken = "{extra_args}"
 
+// Stream parser identifiers wired to AgentConfig.StreamFormat. Empty means
+// "no streaming" (raw stdout). Adding a new format means: new constant
+// here, new parser branch in worker/agent/runner.go's readOutput, new
+// parser function in shared/queue/stream.go.
+const (
+	StreamFormatClaude   = "claude_stream_json" // claude --print --output-format stream-json
+	StreamFormatOpencode = "opencode_run_json"  // opencode run --format json
+)
+
 // AgentConfig is the worker's agent CLI description.
 //
 // ExtraArgs is a user-supplied flag list that's spliced into Args in place of
@@ -41,14 +50,19 @@ type AgentConfig struct {
 	Args      []string      `yaml:"args"`
 	ExtraArgs []string      `yaml:"extra_args"`
 	Timeout   time.Duration `yaml:"timeout"`
-	// InactivityTimeout: if > 0 and Stream is true, send SIGTERM when no
-	// stream event arrives within this duration. Default zero (disabled).
-	// Only meaningful for streaming agents — non-stream CLIs emit no events
-	// and would be killed prematurely if applied. Should be shorter than
-	// Timeout but long enough for a thinking-heavy turn (e.g. 2m).
+	// InactivityTimeout: if > 0 and StreamFormat is non-empty, send SIGTERM
+	// when no stream event arrives within this duration. Default zero
+	// (disabled). Only meaningful for streaming agents — non-stream CLIs
+	// emit no events and would be killed prematurely if applied. Should be
+	// shorter than Timeout but long enough for a thinking-heavy turn (e.g. 2m).
 	InactivityTimeout time.Duration `yaml:"inactivity_timeout"`
 	SkillDir          string        `yaml:"skill_dir"`
-	Stream            bool          `yaml:"stream"`
+	// StreamFormat picks the parser for stdout. Empty means non-streaming
+	// (raw stdout capture). Recognized values are the StreamFormat*
+	// constants above. Unknown values fall back to raw stdout at runtime,
+	// silently losing the live event stream — set this only to a known
+	// constant.
+	StreamFormat string `yaml:"stream_format"`
 }
 
 // PromptConfig is the worker-owned prompt extension (the extra_rules segment

--- a/worker/config/load.go
+++ b/worker/config/load.go
@@ -93,7 +93,7 @@ func mergeBuiltinAgents(cfg *Config) {
 			continue
 		}
 		// Partial entry: user wrote `extra_args` (and/or `timeout`, `skill_dir`,
-		// `stream`) but NOT `command` or `args`. Treat as layered override.
+		// `stream_format`) but NOT `command` or `args`. Treat as layered override.
 		if user.Command == "" && len(user.Args) == 0 {
 			merged := builtin
 			if user.Timeout > 0 {
@@ -102,9 +102,9 @@ func mergeBuiltinAgents(cfg *Config) {
 			if user.SkillDir != "" {
 				merged.SkillDir = user.SkillDir
 			}
-			// Stream is a bool; only override if user explicitly set something
-			// non-zero. We can't distinguish "false" from "unset" here, so
-			// stream stays at the built-in unless the user also set command/args.
+			if user.StreamFormat != "" {
+				merged.StreamFormat = user.StreamFormat
+			}
 			merged.ExtraArgs = user.ExtraArgs
 			cfg.Agents[name] = merged
 			continue


### PR DESCRIPTION
## Summary

- Closes the V8 plan's deferred opencode parser. `opencode 1.14.29 run --pure --format json` was empirically verified to emit per-tool NDJSON without permission relaxation; the earlier "cascade collapse" warning was a stdin-not-closed artifact, which the worker's `exec.Command` defaults already prevent.
- Slack now shows `:wrench: 正在 Read · ./test.txt` for opencode jobs, matching the claude experience landed in #233.
- Replaces `AgentConfig.Stream bool` with `StreamFormat string` + `StreamFormatClaude` / `StreamFormatOpencode` constants. Pre-launch rename, no migration shim.

## What changed

- **`shared/queue/stream.go`**: split `ReadStreamJSON` into `ReadStreamJSONClaude` (rename, behavior identical) and `ReadStreamJSONOpencode` (new, flat event shape with per-step token accumulation and one synthesized terminal `result` event).
- **`shared/queue/stream.go`**: `extractFirstArg` now accepts the camelCase `filePath` opencode uses for Read/Edit/Write; `titleCaseTool` normalizes opencode's lowercase tool names so `worker/pool/status.go`'s hardcoded `"Read"` filesRead match keeps working without an opencode special case.
- **`worker/config/{config,builtin_agents,load}.go`**: `Stream bool` → `StreamFormat string`; opencode args gain `--format json` before `{extra_args}`, mirroring claude's stream-json placement.
- **`worker/agent/runner.go`**: `readOutput` dispatches per format; unknown values fall back to `ReadRawOutput` so a typo never loses stdout.
- **`docs/ideas/worker-agent-progress-visibility.md`**: strike out the out-of-scope entry and record what unblocked it.

## Probe trail (what was verified before coding)

- `opencode 1.14.29 run --pure --format json "Read ./test.txt …" < /dev/null` → exit 0, NDJSON with `tool_use` event for `read`, no `OPENCODE_PERMISSION` env needed.
- `bash` and `grep` tools also emit `tool_use` cleanly. Token + cost accumulate per `step_finish` event (opencode has no terminal totals event like claude).
- Tool name shape: lowercase (`read`/`bash`/`grep`); input keys: `filePath` (read) / `command` (bash) / `pattern` (grep).
- The earlier silent-hang concern reproduced only when stdin was attached to an interactive shell — `exec.Command` in the worker passes child stdin = `/dev/null`, so this is not a worker-side regression.

## Test plan

- [x] `go test ./...` per module — root, shared, app, worker
- [x] `go test ./test/` — import-direction guard
- [x] Unit tests covering: opencode read/bash/grep tool_use surfacing, multi-step token accumulation, text reassembly across multiple `text` events, `extractFirstArg` snake-vs-camel priority
- [ ] End-to-end Slack verification: trigger an opencode triage in a thread, confirm progress line shows `正在 Read · …` (replaces the counter line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)