### PR TITLE
Harden GitHub App workflow coverage and PR review posting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,52 @@
+# AgentDock
+
+AgentDock is a Slack-driven orchestration tool that routes user requests into
+workflow-specific GitHub and worker execution paths. This context exists to
+keep workflow, auth, and repo-routing terms stable as the product grows.
+
+## Language
+
+**Repo-bound workflow entrypoint**:
+An app-side workflow step that already knows the target **Repository** and may touch GitHub before worker execution.
+_Avoid_: pre-submit hook, early GitHub call
+
+**Repository**:
+A target `owner/repo` that a workflow reads from, files against, or reviews against.
+_Avoid_: project, codebase target
+
+**App-covered repository**:
+A **Repository** that is included in the configured GitHub App installation's accessible repo set.
+_Avoid_: installed repo, App repo
+
+**PAT fallback**:
+The explicit use of `github.token` for a **Repository** that is not an **App-covered repository**.
+_Avoid_: legacy token path, hidden token dependency
+
+**PR base repository**:
+The `owner/repo` that owns the PR URL and receives review comments or review state changes.
+_Avoid_: target fork, clone repo
+
+**PR head repository**:
+The `owner/repo` that provides the head commit the worker actually clones for PR analysis.
+_Avoid_: reviewed repo, base fork
+
+## Relationships
+
+- A **Repo-bound workflow entrypoint** operates on exactly one primary **Repository**
+- An **App-covered repository** uses GitHub App auth as the primary path
+- A **Repository** outside the App installation may use **PAT fallback** if `github.token` is configured
+- A PR review validates access against the **PR base repository** before submit
+- A PR review executes against the **PR head repository** during worker clone and analysis
+
+## Example dialogue
+
+> **Dev:** "This PR URL validates before submit, so does it count as a **Repo-bound workflow entrypoint**?"
+> **Domain expert:** "Yes. It already knows the target **Repository**, so it must use App auth for an **App-covered repository** and only use **PAT fallback** when the repo is outside the installation."
+
+> **Dev:** "For a forked PR, which repo decides auth?"
+> **Domain expert:** "Pre-submit validation is against the **PR base repository**; worker execution routes against the **PR head repository** because that's what gets cloned."
+
+## Flagged ambiguities
+
+- "GitHub App support" was used to mean both "the app can mint installation tokens" and "every **Repo-bound workflow entrypoint** actually uses them" — resolved: those are different claims, and this repo tracks the second separately.
+- "the PR repo" was ambiguous between the **PR base repository** and the **PR head repository** — resolved: validation and review-target access use base; clone/execution access use head.

--- a/app/app.go
+++ b/app/app.go
@@ -213,9 +213,9 @@ func Run(cfg *config.Config, identity bot.Identity) (*Handle, error) {
 	// identity so FetchThreadContext always drops our own posts regardless of
 	// which workflow fires it.
 	slackPort := &slackAdapterPort{client: slackClient, logger: slackLogger, identity: identity}
-	issueWorkflow := workflow.NewIssueWorkflow(cfg, slackPort, issueClient, repoCache, repoDiscovery, agentLogger)
-	askWorkflow := workflow.NewAskWorkflow(cfg, slackPort, repoCache, agentLogger)
-	prReviewWorkflow := workflow.NewPRReviewWorkflow(cfg, slackPort, githubClient, repoCache, agentLogger)
+	issueWorkflow := workflow.NewIssueWorkflow(cfg, tokenSource, slackPort, issueClient, repoCache, repoDiscovery, agentLogger)
+	askWorkflow := workflow.NewAskWorkflow(cfg, tokenSource, slackPort, repoCache, agentLogger)
+	prReviewWorkflow := workflow.NewPRReviewWorkflow(cfg, tokenSource, slackPort, githubClient, repoCache, agentLogger)
 	reg := workflow.NewRegistry()
 	reg.Register(issueWorkflow)
 	reg.Register(askWorkflow)

--- a/app/githubapp/factory.go
+++ b/app/githubapp/factory.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
+	ghclient "github.com/Ivantseng123/agentdock/shared/github"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -75,7 +75,7 @@ func newAppInstallationSourceFromCredentials(app AppCredentials, logger *slog.Lo
 		appID:          app.AppID,
 		installationID: app.InstallationID,
 		privateKey:     key,
-		httpClient:     http.DefaultClient,
+		httpClient:     ghclient.NewHTTPClient(ghclient.ProfileBackground),
 		baseURL:        productionMintBaseURL,
 		logger:         logger,
 		now:            time.Now,

--- a/app/githubapp/preflight.go
+++ b/app/githubapp/preflight.go
@@ -9,7 +9,8 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
+
+	ghclient "github.com/Ivantseng123/agentdock/shared/github"
 )
 
 // requiredPermissions encodes the App permission set this codebase
@@ -22,15 +23,6 @@ var requiredPermissions = map[string]string{
 	"pull_requests": "write",
 }
 
-// preflightRetryDelays implements §7's transient-error retry schedule:
-// 3 retries with 500ms / 1s / 2s back-off. 4xx errors fail fast (no
-// retry); 5xx and network errors retry through the full schedule.
-var preflightRetryDelays = []time.Duration{
-	500 * time.Millisecond,
-	1 * time.Second,
-	2 * time.Second,
-}
-
 // PreflightApp validates that the configured GitHub App can mint
 // installation tokens with the required permissions and is reachable.
 // Maps every failure mode to a user-facing error string per spec §4.13.
@@ -39,6 +31,7 @@ func PreflightApp(app AppCredentials, logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+	src.httpClient = ghclient.NewHTTPClient(ghclient.ProfilePreflight)
 	return preflightAppWithSource(src)
 }
 
@@ -46,10 +39,10 @@ func PreflightApp(app AppCredentials, logger *slog.Logger) error {
 // already-built source so tests can wire an httptest server without
 // going through the production base-URL constant.
 func preflightAppWithSource(src *appInstallationSource) error {
-	if _, err := mintWithRetry(src); err != nil {
+	if _, err := src.MintFresh(); err != nil {
 		return classifyMintError(err, src.installationID)
 	}
-	if err := checkPermissionsWithRetry(src); err != nil {
+	if err := checkPermissionsOnce(src); err != nil {
 		return err
 	}
 	src.logger.Info("github app preflight passed",
@@ -60,34 +53,14 @@ func preflightAppWithSource(src *appInstallationSource) error {
 	return nil
 }
 
-// mintWithRetry calls MintFresh with the retry schedule. Transient
-// errors (5xx, network) retry through; 4xx fail-fast.
-func mintWithRetry(src *appInstallationSource) (string, error) {
-	var lastErr error
-	for attempt := 0; attempt <= len(preflightRetryDelays); attempt++ {
-		token, err := src.MintFresh()
-		if err == nil {
-			return token, nil
-		}
-		lastErr = err
-		if !errors.Is(err, errMintTransient) {
-			return "", err
-		}
-		if attempt < len(preflightRetryDelays) {
-			time.Sleep(preflightRetryDelays[attempt])
-		}
-	}
-	return "", lastErr
-}
-
 func classifyMintError(err error, installationID int64) error {
 	switch {
 	case errors.Is(err, errInvalidAppCredentials):
 		return fmt.Errorf("github app credentials rejected: check github.app.app_id and private_key_path match")
 	case errors.Is(err, errInstallationNotFound):
 		return fmt.Errorf("github app installation not found: id=%d; verify github.app.installation_id", installationID)
-	case errors.Is(err, errMintTransient):
-		return fmt.Errorf("github api unavailable during preflight (after %d retries): %w; this is an infrastructure issue, not a config issue", len(preflightRetryDelays), err)
+	case errors.Is(err, errMintTransient), errors.Is(err, ghclient.ErrGitHubUnavailable):
+		return fmt.Errorf("github api unavailable during preflight: %w; this is an infrastructure issue, not a config issue", err)
 	default:
 		return err
 	}
@@ -95,24 +68,6 @@ func classifyMintError(err error, installationID int64) error {
 
 type installationDetails struct {
 	Permissions map[string]string `json:"permissions"`
-}
-
-func checkPermissionsWithRetry(src *appInstallationSource) error {
-	var lastErr error
-	for attempt := 0; attempt <= len(preflightRetryDelays); attempt++ {
-		err := checkPermissionsOnce(src)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if !errors.Is(err, errMintTransient) {
-			return err
-		}
-		if attempt < len(preflightRetryDelays) {
-			time.Sleep(preflightRetryDelays[attempt])
-		}
-	}
-	return lastErr
 }
 
 func checkPermissionsOnce(src *appInstallationSource) error {

--- a/app/githubapp/preflight_test.go
+++ b/app/githubapp/preflight_test.go
@@ -26,15 +26,6 @@ func newPreflightSource(t *testing.T, srv *httptest.Server, key *rsa.PrivateKey)
 	}
 }
 
-// fastDelays overrides preflightRetryDelays for the duration of a test
-// so the suite isn't dragging out 3.5s on every retry case.
-func fastDelays(t *testing.T) {
-	t.Helper()
-	prev := preflightRetryDelays
-	preflightRetryDelays = []time.Duration{1 * time.Millisecond, 2 * time.Millisecond, 4 * time.Millisecond}
-	t.Cleanup(func() { preflightRetryDelays = prev })
-}
-
 func happyHandler(t *testing.T, fullPermissions bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -61,7 +52,6 @@ func happyHandler(t *testing.T, fullPermissions bool) http.HandlerFunc {
 }
 
 func TestPreflightApp_HappyPath(t *testing.T) {
-	fastDelays(t)
 	srv := httptest.NewServer(happyHandler(t, true))
 	defer srv.Close()
 
@@ -72,7 +62,6 @@ func TestPreflightApp_HappyPath(t *testing.T) {
 }
 
 func TestPreflightApp_MissingPermissions(t *testing.T) {
-	fastDelays(t)
 	srv := httptest.NewServer(happyHandler(t, false))
 	defer srv.Close()
 
@@ -94,7 +83,6 @@ func TestPreflightApp_MissingPermissions(t *testing.T) {
 }
 
 func TestPreflightApp_Mint401_CredentialsRejected(t *testing.T) {
-	fastDelays(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
@@ -112,7 +100,6 @@ func TestPreflightApp_Mint401_CredentialsRejected(t *testing.T) {
 }
 
 func TestPreflightApp_Mint404_InstallationNotFound(t *testing.T) {
-	fastDelays(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
@@ -133,7 +120,6 @@ func TestPreflightApp_Mint404_InstallationNotFound(t *testing.T) {
 }
 
 func TestPreflightApp_Mint5xxExhausted_InfrastructureError(t *testing.T) {
-	fastDelays(t)
 	hits := atomic.Int32{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
@@ -149,55 +135,8 @@ func TestPreflightApp_Mint5xxExhausted_InfrastructureError(t *testing.T) {
 	if !strings.Contains(err.Error(), "infrastructure") {
 		t.Errorf("error = %v, want 'infrastructure issue'", err)
 	}
-	// 1 initial + 3 retries = 4 calls
-	if got := hits.Load(); got != 4 {
-		t.Errorf("hits = %d, want 4 (initial + 3 retries)", got)
-	}
-}
-
-func TestPreflightApp_Mint5xxThenSuccess_RetryWorks(t *testing.T) {
-	fastDelays(t)
-	hits := atomic.Int32{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.Contains(r.URL.Path, "/access_tokens"):
-			n := hits.Add(1)
-			if n == 1 {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			w.WriteHeader(http.StatusCreated)
-			expires := time.Date(2026, 5, 2, 13, 0, 0, 0, time.UTC).Format(time.RFC3339)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"token":"ghs_after_retry","expires_at":%q}`, expires)))
-		case strings.Contains(r.URL.Path, "/installation/repositories"):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"repositories":[]}`))
-		case strings.Contains(r.URL.Path, "/app/installations/5678"):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"permissions":{"issues":"write","contents":"read","metadata":"read","pull_requests":"write"}}`))
-		}
-	}))
-	defer srv.Close()
-
-	src := newPreflightSource(t, srv, generateTestKey(t))
-	if err := preflightAppWithSource(src); err != nil {
-		t.Fatalf("preflight should succeed after retry: %v", err)
-	}
-}
-
-// TestPreflightRetryDelays_MatchesSpec pins the retry schedule from
-// spec §7. Other preflight tests override preflightRetryDelays via
-// fastDelays() to keep the suite under a second; without this pin a
-// typo in the production schedule would slip through unnoticed.
-func TestPreflightRetryDelays_MatchesSpec(t *testing.T) {
-	want := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
-	if len(preflightRetryDelays) != len(want) {
-		t.Fatalf("preflightRetryDelays has %d entries, want %d (spec §7)", len(preflightRetryDelays), len(want))
-	}
-	for i, d := range want {
-		if preflightRetryDelays[i] != d {
-			t.Errorf("preflightRetryDelays[%d] = %v, want %v", i, preflightRetryDelays[i], d)
-		}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("hits = %d, want 1 in direct preflight unit test", got)
 	}
 }
 

--- a/app/workflow/ask.go
+++ b/app/workflow/ask.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Ivantseng123/agentdock/app/config"
+	"github.com/Ivantseng123/agentdock/app/githubapp"
 	ghclient "github.com/Ivantseng123/agentdock/shared/github"
 	"github.com/Ivantseng123/agentdock/shared/logging"
 	"github.com/Ivantseng123/agentdock/shared/metrics"
@@ -25,6 +26,7 @@ const AskPriorAnswerOptIn = "帶上次回覆"
 // bot message in the thread.
 type AskWorkflow struct {
 	cfg       *config.Config
+	source    githubapp.TokenSource
 	slack     SlackPort
 	repoCache *ghclient.RepoCache
 	logger    *slog.Logger
@@ -89,11 +91,11 @@ func (s *askState) RefExclusions() []string {
 }
 
 // NewAskWorkflow constructs a workflow instance.
-func NewAskWorkflow(cfg *config.Config, slack SlackPort, repoCache *ghclient.RepoCache, logger *slog.Logger) *AskWorkflow {
+func NewAskWorkflow(cfg *config.Config, source githubapp.TokenSource, slack SlackPort, repoCache *ghclient.RepoCache, logger *slog.Logger) *AskWorkflow {
 	if cfg == nil || slack == nil || logger == nil {
 		panic("workflow: NewAskWorkflow missing required dep")
 	}
-	return &AskWorkflow{cfg: cfg, slack: slack, repoCache: repoCache, logger: logger}
+	return &AskWorkflow{cfg: cfg, source: source, slack: slack, repoCache: repoCache, logger: logger}
 }
 
 // Type returns the TaskType discriminator.
@@ -345,11 +347,15 @@ func (w *AskWorkflow) afterRepoSelectedStep(p *Pending) NextStep {
 	if len(channelCfg.Branches) > 0 {
 		branches = channelCfg.Branches
 	} else if w.repoCache != nil {
-		// Empty token → RepoCache falls through to its tokenFn (PAT mode:
-		// staticPATSource.Get; App mode: appInstallationSource.Get).
-		// Reading cfg.Secrets here would risk a stale dispatch-time token
-		// in App mode (issue #212).
-		if repoPath, err := w.repoCache.EnsureRepo(st.SelectedRepo, ""); err == nil {
+		choice, err := chooseRepoAuth(st.SelectedRepo, w.cfg.GitHub.Token, w.source)
+		if err != nil {
+			return NextStep{
+				Kind:      NextStepError,
+				ErrorText: repoAccessError(st.SelectedRepo),
+				Pending:   p,
+			}
+		}
+		if repoPath, err := w.repoCache.EnsureRepo(st.SelectedRepo, choice.perCallToken); err == nil {
 			if lb, listErr := w.repoCache.ListBranches(repoPath); listErr == nil {
 				branches = lb
 			}
@@ -575,8 +581,15 @@ func (w *AskWorkflow) nextRefBranchStep(p *Pending) NextStep {
 	if len(cc.Branches) > 0 {
 		branches = cc.Branches
 	} else if w.repoCache != nil {
-		// See note above on EnsureRepo(..., "") + tokenFn fallback.
-		if rp, err := w.repoCache.EnsureRepo(target, ""); err == nil {
+		choice, err := chooseRepoAuth(target, w.cfg.GitHub.Token, w.source)
+		if err != nil {
+			return NextStep{
+				Kind:      NextStepError,
+				ErrorText: repoAccessError(target),
+				Pending:   p,
+			}
+		}
+		if rp, err := w.repoCache.EnsureRepo(target, choice.perCallToken); err == nil {
 			if lb, lerr := w.repoCache.ListBranches(rp); lerr == nil {
 				branches = lb
 			}

--- a/app/workflow/ask_test.go
+++ b/app/workflow/ask_test.go
@@ -45,7 +45,7 @@ func newTestAskWorkflow(t *testing.T) (*AskWorkflow, *fakeSlackPort) {
 	cfg := &config.Config{}
 	config.ApplyDefaults(cfg)
 	slack := newFakeSlackPort()
-	return NewAskWorkflow(cfg, slack, nil, slog.Default()), slack
+	return NewAskWorkflow(cfg, nil, slack, nil, slog.Default()), slack
 }
 
 func TestAskWorkflow_Selection_SkipRoutesToDescriptionPrompt(t *testing.T) {

--- a/app/workflow/auth.go
+++ b/app/workflow/auth.go
@@ -1,0 +1,46 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/Ivantseng123/agentdock/app/dispatch"
+	"github.com/Ivantseng123/agentdock/app/githubapp"
+)
+
+type repoAuthChoice struct {
+	source        githubapp.TokenSource
+	authSource    string
+	perCallToken  string
+	patFallback   bool
+}
+
+func chooseRepoAuth(repo, patToken string, source githubapp.TokenSource) (repoAuthChoice, error) {
+	if source == nil {
+		return repoAuthChoice{}, fmt.Errorf("github auth source not configured")
+	}
+	chosen, fallback, err := dispatch.ChooseJobSource(patToken, source, repo)
+	if err != nil {
+		return repoAuthChoice{}, err
+	}
+	choice := repoAuthChoice{
+		source:      chosen,
+		authSource:  "app",
+		patFallback: fallback,
+	}
+	if githubapp.IsPATSource(chosen) {
+		choice.authSource = "pat"
+	}
+	if fallback {
+		choice.authSource = "pat_fallback"
+		choice.perCallToken = patToken
+	}
+	return choice, nil
+}
+
+func repoAccessError(repo string) string {
+	return fmt.Sprintf("無法存取 repo %s：GitHub App 未涵蓋此 repo，且未設定 PAT fallback", repo)
+}
+
+func headRepoAccessError(repo string) error {
+	return fmt.Errorf("PR 可讀，但無法存取 head repo %s；請安裝 GitHub App 到該 repo 擁有者或設定 PAT fallback", repo)
+}

--- a/app/workflow/auth_test.go
+++ b/app/workflow/auth_test.go
@@ -1,0 +1,68 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/Ivantseng123/agentdock/app/githubapp"
+)
+
+type fakeTokenSource struct {
+	token      string
+	accessible map[string]bool
+}
+
+func (f *fakeTokenSource) Get() (string, error)       { return f.token, nil }
+func (f *fakeTokenSource) MintFresh() (string, error) { return f.token, nil }
+func (f *fakeTokenSource) IsAccessible(repo string) bool {
+	if f.accessible == nil {
+		return true
+	}
+	return f.accessible[repo]
+}
+
+func TestChooseRepoAuth_AppCovered(t *testing.T) {
+	src := &fakeTokenSource{
+		token:      "ghs_app",
+		accessible: map[string]bool{"org/repo": true},
+	}
+	got, err := chooseRepoAuth("org/repo", "", src)
+	if err != nil {
+		t.Fatalf("chooseRepoAuth: %v", err)
+	}
+	if got.authSource != "app" {
+		t.Fatalf("authSource = %q, want app", got.authSource)
+	}
+	if got.perCallToken != "" {
+		t.Fatalf("perCallToken = %q, want empty", got.perCallToken)
+	}
+}
+
+func TestChooseRepoAuth_PATFallback(t *testing.T) {
+	src := &fakeTokenSource{
+		token:      "ghs_app",
+		accessible: map[string]bool{"org/repo": false},
+	}
+	got, err := chooseRepoAuth("org/repo", "ghp_fallback", src)
+	if err != nil {
+		t.Fatalf("chooseRepoAuth: %v", err)
+	}
+	if got.authSource != "pat_fallback" {
+		t.Fatalf("authSource = %q, want pat_fallback", got.authSource)
+	}
+	if got.perCallToken != "ghp_fallback" {
+		t.Fatalf("perCallToken = %q, want ghp_fallback", got.perCallToken)
+	}
+	if !githubapp.IsPATSource(got.source) {
+		t.Fatal("expected PAT source on fallback")
+	}
+}
+
+func TestChooseRepoAuth_NoPATFails(t *testing.T) {
+	src := &fakeTokenSource{
+		token:      "ghs_app",
+		accessible: map[string]bool{"org/repo": false},
+	}
+	if _, err := chooseRepoAuth("org/repo", "", src); err == nil {
+		t.Fatal("expected error without PAT fallback")
+	}
+}

--- a/app/workflow/issue.go
+++ b/app/workflow/issue.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Ivantseng123/agentdock/app/config"
+	"github.com/Ivantseng123/agentdock/app/githubapp"
 	ghclient "github.com/Ivantseng123/agentdock/shared/github"
 	"github.com/Ivantseng123/agentdock/shared/logging"
 	"github.com/Ivantseng123/agentdock/shared/metrics"
@@ -67,6 +68,7 @@ func formatRefLine(repo, branch, role string) string {
 // implementation — users see no change.
 type IssueWorkflow struct {
 	cfg           *config.Config
+	source        githubapp.TokenSource
 	slack         SlackPort
 	github        IssueCreator
 	repoCache     *ghclient.RepoCache
@@ -122,6 +124,7 @@ func (s *issueState) RefExclusions() []string {
 // required. Panics on nil pointers to fail fast at startup.
 func NewIssueWorkflow(
 	cfg *config.Config,
+	source githubapp.TokenSource,
 	slack SlackPort,
 	github IssueCreator,
 	repoCache *ghclient.RepoCache,
@@ -133,6 +136,7 @@ func NewIssueWorkflow(
 	}
 	return &IssueWorkflow{
 		cfg:           cfg,
+		source:        source,
 		slack:         slack,
 		github:        github,
 		repoCache:     repoCache,
@@ -697,13 +701,16 @@ func (w *IssueWorkflow) afterRepoSelected(p *Pending, channelCfg config.ChannelC
 	if len(channelCfg.Branches) > 0 {
 		branches = channelCfg.Branches
 	} else if w.repoCache != nil {
-		// Empty token → RepoCache falls through to its tokenFn, which is
-		// staticPATSource.Get in PAT mode and appInstallationSource.Get in
-		// App mode. Reading cfg.Secrets here would steal a stale token from
-		// the dispatch-time encrypted blob in App mode (issue #212).
-		repoPath, err := w.repoCache.EnsureRepo(st.SelectedRepo, "")
+		choice, err := chooseRepoAuth(st.SelectedRepo, w.cfg.GitHub.Token, w.source)
 		if err != nil {
-			// Surface the error so operators know repo access failed.
+			return NextStep{
+				Kind:      NextStepError,
+				ErrorText: repoAccessError(st.SelectedRepo),
+				Pending:   p,
+			}
+		}
+		repoPath, err := w.repoCache.EnsureRepo(st.SelectedRepo, choice.perCallToken)
+		if err != nil {
 			return NextStep{
 				Kind:      NextStepError,
 				ErrorText: fmt.Sprintf(":x: Failed to access repo %s: %v", st.SelectedRepo, err),
@@ -1038,8 +1045,15 @@ func (w *IssueWorkflow) nextRefBranchStep(p *Pending) NextStep {
 	if len(cc.Branches) > 0 {
 		branches = cc.Branches
 	} else if w.repoCache != nil {
-		// See note above on EnsureRepo(..., "") + tokenFn fallback.
-		if rp, err := w.repoCache.EnsureRepo(target, ""); err == nil {
+		choice, err := chooseRepoAuth(target, w.cfg.GitHub.Token, w.source)
+		if err != nil {
+			return NextStep{
+				Kind:      NextStepError,
+				ErrorText: repoAccessError(target),
+				Pending:   p,
+			}
+		}
+		if rp, err := w.repoCache.EnsureRepo(target, choice.perCallToken); err == nil {
 			if lb, lerr := w.repoCache.ListBranches(rp); lerr == nil {
 				branches = lb
 			}

--- a/app/workflow/issue_test.go
+++ b/app/workflow/issue_test.go
@@ -585,7 +585,7 @@ func newTestIssueWorkflow(t *testing.T, opts ...issueOpt) (*IssueWorkflow, *fake
 	}
 	slack := newFakeSlackPort()
 	ic := &fakeIssueCreator{}
-	w := NewIssueWorkflow(cfg, slack, ic, nil, nil, slog.Default())
+	w := NewIssueWorkflow(cfg, nil, slack, ic, nil, nil, slog.Default())
 	return w, slack, ic
 }
 

--- a/app/workflow/pr_review.go
+++ b/app/workflow/pr_review.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Ivantseng123/agentdock/app/config"
+	"github.com/Ivantseng123/agentdock/app/githubapp"
 	ghclient "github.com/Ivantseng123/agentdock/shared/github"
 	"github.com/Ivantseng123/agentdock/shared/logging"
 	"github.com/Ivantseng123/agentdock/shared/metrics"
@@ -22,8 +24,10 @@ import (
 //   - D-path modal: scan miss → open modal asking for URL.
 type PRReviewWorkflow struct {
 	cfg       *config.Config
+	source    githubapp.TokenSource
 	slack     SlackPort
 	github    GitHubPR
+	newGitHub func(func() (string, error)) GitHubPR
 	repoCache *ghclient.RepoCache
 	logger    *slog.Logger
 }
@@ -45,11 +49,19 @@ type prReviewState struct {
 
 // NewPRReviewWorkflow constructs a workflow instance. cfg/slack/logger are
 // required; github and repoCache may be nil (tests / degraded env).
-func NewPRReviewWorkflow(cfg *config.Config, slack SlackPort, gh GitHubPR, repoCache *ghclient.RepoCache, logger *slog.Logger) *PRReviewWorkflow {
+func NewPRReviewWorkflow(cfg *config.Config, source githubapp.TokenSource, slack SlackPort, gh GitHubPR, repoCache *ghclient.RepoCache, logger *slog.Logger) *PRReviewWorkflow {
 	if cfg == nil || slack == nil || logger == nil {
 		panic("workflow: NewPRReviewWorkflow missing required dep")
 	}
-	return &PRReviewWorkflow{cfg: cfg, slack: slack, github: gh, repoCache: repoCache, logger: logger}
+	return &PRReviewWorkflow{
+		cfg:       cfg,
+		source:    source,
+		slack:     slack,
+		github:    gh,
+		newGitHub: func(tokenFn func() (string, error)) GitHubPR { return ghclient.NewClient(tokenFn) },
+		repoCache: repoCache,
+		logger:    logger,
+	}
 }
 
 // Type returns the TaskType discriminator.
@@ -146,11 +158,32 @@ func (w *PRReviewWorkflow) validateAndBuild(ctx context.Context, ev TriggerEvent
 		return NextStep{Kind: NextStepError, ErrorText: "請貼完整 PR URL"}, nil
 	}
 
-	if w.github == nil {
+	client := w.github
+	authSource := ""
+	if w.source != nil {
+		choice, authErr := chooseRepoAuth(parts.Owner+"/"+parts.Repo, w.cfg.GitHub.Token, w.source)
+		if authErr != nil {
+			return NextStep{Kind: NextStepError, ErrorText: repoAccessError(parts.Owner + "/" + parts.Repo)}, nil
+		}
+		authSource = choice.authSource
+		if w.newGitHub != nil {
+			client = w.newGitHub(choice.source.Get)
+		}
+	}
+
+	if client == nil {
 		return NextStep{Kind: NextStepError, ErrorText: "GitHub client not configured"}, nil
 	}
 
-	pr, err := w.github.GetPullRequest(ctx, parts.Owner, parts.Repo, parts.Number)
+	if authSource != "" {
+		w.logger.Info("pr review validation auth selected",
+			"phase", "validation",
+			"repo", parts.Owner+"/"+parts.Repo,
+			"auth_source", authSource,
+		)
+	}
+
+	pr, err := client.GetPullRequest(ctx, parts.Owner, parts.Repo, parts.Number)
 	if err != nil {
 		msg := mapGitHubErrorToSlack(err)
 		return NextStep{Kind: NextStepError, ErrorText: msg}, nil
@@ -188,13 +221,17 @@ func (w *PRReviewWorkflow) validateAndBuild(ctx context.Context, ev TriggerEvent
 // check would misclassify a 500 whose body happens to contain "404". Network
 // errors (dial/timeout) stay on Contains since they have no structured prefix.
 func mapGitHubErrorToSlack(err error) string {
+	if errors.Is(err, ghclient.ErrGitHubUnavailable) {
+		return "GitHub 不可達，請稍後重試"
+	}
 	msg := err.Error()
+	msgLower := strings.ToLower(msg)
 	switch {
 	case strings.HasPrefix(msg, "404"):
 		return "找不到 PR"
 	case strings.HasPrefix(msg, "403"):
 		return "沒權限存取 PR"
-	case strings.Contains(msg, "dial"), strings.Contains(msg, "timeout"):
+	case strings.Contains(msgLower, "dial"), strings.Contains(msgLower, "timeout"), strings.Contains(msgLower, "deadline exceeded"):
 		return "GitHub 不可達，請稍後重試"
 	default:
 		return "GitHub API 錯誤: " + msg
@@ -249,6 +286,11 @@ func (w *PRReviewWorkflow) BuildJob(ctx context.Context, p *Pending) (*queue.Job
 
 	if st.HeadRepo == "" {
 		return nil, "", fmt.Errorf("empty repo reference")
+	}
+	if w.source != nil {
+		if _, err := chooseRepoAuth(st.HeadRepo, w.cfg.GitHub.Token, w.source); err != nil {
+			return nil, "", headRepoAccessError(st.HeadRepo)
+		}
 	}
 
 	reqID := p.RequestID

--- a/app/workflow/pr_review_test.go
+++ b/app/workflow/pr_review_test.go
@@ -54,6 +54,50 @@ func TestPRReviewWorkflow_TriggerAPath_Valid(t *testing.T) {
 	}
 }
 
+func TestPRReviewWorkflow_TriggerAPath_UsesPATFallbackForBaseRepo(t *testing.T) {
+	pr := &ghclient.PullRequest{Number: 7, State: "open", Title: "T"}
+	pr.Head.Ref = "feature-x"
+	pr.Head.SHA = "abc123"
+	pr.Head.Repo.FullName = "forker/bar"
+	pr.Base.Ref = "main"
+
+	w, _ := newTestPRReviewWorkflow(t)
+	w.cfg.GitHub.Token = "ghp_fallback"
+	w.source = &fakeTokenSource{token: "ghs_app", accessible: map[string]bool{"foo/bar": false}}
+	var seenToken string
+	w.newGitHub = func(tokenFn func() (string, error)) GitHubPR {
+		seenToken, _ = tokenFn()
+		return &fakeGitHubPR{pr: pr}
+	}
+
+	step, err := w.Trigger(context.Background(), TriggerEvent{ChannelID: "C1", ThreadTS: "1.0"}, "https://github.com/foo/bar/pull/7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if step.Kind != NextStepSubmit {
+		t.Fatalf("expected submit, got %v", step.Kind)
+	}
+	if seenToken != "ghp_fallback" {
+		t.Fatalf("validation token = %q, want ghp_fallback", seenToken)
+	}
+}
+
+func TestPRReviewWorkflow_TriggerAPath_NoPATFailsForBaseRepo(t *testing.T) {
+	w, _ := newTestPRReviewWorkflow(t)
+	w.source = &fakeTokenSource{token: "ghs_app", accessible: map[string]bool{"foo/bar": false}}
+
+	step, err := w.Trigger(context.Background(), TriggerEvent{ChannelID: "C1", ThreadTS: "1.0"}, "https://github.com/foo/bar/pull/7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if step.Kind != NextStepError {
+		t.Fatalf("expected error, got %v", step.Kind)
+	}
+	if !strings.Contains(step.ErrorText, "GitHub App 未涵蓋此 repo") {
+		t.Fatalf("errorText = %q", step.ErrorText)
+	}
+}
+
 func TestPRReviewWorkflow_TriggerAPath_404(t *testing.T) {
 	w, slack := newTestPRReviewWorkflow(t)
 	w.github = &fakeGitHubPR{err: errors.New("404 not found")}
@@ -344,6 +388,35 @@ func TestPRReviewWorkflow_BuildJob_RejectsEmptyHeadRepo(t *testing.T) {
 	}
 }
 
+func TestPRReviewWorkflow_BuildJob_RejectsInaccessibleHeadRepo(t *testing.T) {
+	w, _ := newTestPRReviewWorkflow(t)
+	w.source = &fakeTokenSource{token: "ghs_app", accessible: map[string]bool{"forker/bar": false}}
+	pending := &Pending{
+		ChannelID: "C1",
+		ThreadTS:  "1.0",
+		TaskType:  "pr_review",
+		State: &prReviewState{
+			URL:      "https://github.com/foo/bar/pull/7",
+			Owner:    "foo",
+			Repo:     "bar",
+			Number:   7,
+			HeadRepo: "forker/bar",
+			HeadSHA:  "abc123",
+			BaseRef:  "main",
+		},
+	}
+	job, status, err := w.BuildJob(context.Background(), pending)
+	if err == nil {
+		t.Fatal("expected head repo access error")
+	}
+	if !strings.Contains(err.Error(), "head repo") {
+		t.Fatalf("err = %v", err)
+	}
+	if job != nil || status != "" {
+		t.Fatalf("job=%v status=%q, want nil/empty", job, status)
+	}
+}
+
 func newTestPRReviewWorkflow(t *testing.T) (*PRReviewWorkflow, *fakeSlackPort) {
 	t.Helper()
 	cfg := &config.Config{}
@@ -353,6 +426,6 @@ func newTestPRReviewWorkflow(t *testing.T) (*PRReviewWorkflow, *fakeSlackPort) {
 	tp := true
 	cfg.Workflows.PRReview.Enabled = &tp
 	slack := newFakeSlackPort()
-	w := NewPRReviewWorkflow(cfg, slack, &fakeGitHubPR{}, nil, slog.Default())
+	w := NewPRReviewWorkflow(cfg, nil, slack, &fakeGitHubPR{}, nil, slog.Default())
 	return w, slack
 }

--- a/app/workflow/redact_log_test.go
+++ b/app/workflow/redact_log_test.go
@@ -37,7 +37,7 @@ func TestIssueHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 	const fakeSecret = "supersecret-ghp-abc123"
 	cfg := cfgWithSecret(fakeSecret)
 	var buf bytes.Buffer
-	w := NewIssueWorkflow(cfg, newFakeSlackPort(), &fakeIssueCreator{}, nil, nil, captureLogger(&buf))
+	w := NewIssueWorkflow(cfg, nil, newFakeSlackPort(), &fakeIssueCreator{}, nil, nil, captureLogger(&buf))
 
 	state := &queue.JobState{Job: &queue.Job{TaskType: "issue"}}
 	result := &queue.JobResult{
@@ -58,7 +58,7 @@ func TestIssueHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 func TestIssueHandleResult_ParseFail_NoSecret_Unchanged(t *testing.T) {
 	cfg := cfgWithSecret("supersecret-ghp-abc123")
 	var buf bytes.Buffer
-	w := NewIssueWorkflow(cfg, newFakeSlackPort(), &fakeIssueCreator{}, nil, nil, captureLogger(&buf))
+	w := NewIssueWorkflow(cfg, nil, newFakeSlackPort(), &fakeIssueCreator{}, nil, nil, captureLogger(&buf))
 
 	const harmlessOutput = "not valid json at all - totally normal debug text"
 	state := &queue.JobState{Job: &queue.Job{TaskType: "issue"}}
@@ -86,7 +86,7 @@ func TestAskHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 	const fakeSecret = "ASKXYZ"
 	cfg := cfgWithSecret(fakeSecret)
 	var buf bytes.Buffer
-	w := NewAskWorkflow(cfg, newFakeSlackPort(), nil, captureLogger(&buf))
+	w := NewAskWorkflow(cfg, nil, newFakeSlackPort(), nil, captureLogger(&buf))
 
 	state := &queue.JobState{Job: &queue.Job{TaskType: "ask"}}
 	result := &queue.JobResult{
@@ -107,7 +107,7 @@ func TestAskHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 func TestAskHandleResult_ParseFail_NoSecret_Unchanged(t *testing.T) {
 	cfg := cfgWithSecret("ASKXYZ")
 	var buf bytes.Buffer
-	w := NewAskWorkflow(cfg, newFakeSlackPort(), nil, captureLogger(&buf))
+	w := NewAskWorkflow(cfg, nil, newFakeSlackPort(), nil, captureLogger(&buf))
 
 	// Short stdout with no secret. Same gate constraint as the redaction test
 	// above: the parse-fail path is now reserved for sub-min-length stdout.
@@ -140,7 +140,7 @@ func TestPRReviewHandleResult_ParseFail_RedactsSecret(t *testing.T) {
 	cfg := cfgWithSecretPRReview(fakeSecret)
 
 	var buf bytes.Buffer
-	w := NewPRReviewWorkflow(cfg, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
+	w := NewPRReviewWorkflow(cfg, nil, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
 
 	state := &queue.JobState{Job: &queue.Job{TaskType: "pr_review", WorkflowArgs: map[string]string{"pr_url": "https://github.com/foo/bar/pull/1"}}}
 	result := &queue.JobResult{
@@ -166,7 +166,7 @@ func TestPRReviewHandleResult_ParseFail_RedactsSecretPastTruncation(t *testing.T
 	cfg := cfgWithSecretPRReview(fakeSecret)
 
 	var buf bytes.Buffer
-	w := NewPRReviewWorkflow(cfg, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
+	w := NewPRReviewWorkflow(cfg, nil, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
 
 	padding := strings.Repeat("a", 2500) // push secret past the 2000-byte cut
 	state := &queue.JobState{Job: &queue.Job{TaskType: "pr_review", WorkflowArgs: map[string]string{"pr_url": "https://github.com/foo/bar/pull/1"}}}
@@ -186,7 +186,7 @@ func TestPRReviewHandleResult_ParseFail_NoSecret_Unchanged(t *testing.T) {
 	cfg := cfgWithSecretPRReview("supersecret-pr-review-qwe456")
 
 	var buf bytes.Buffer
-	w := NewPRReviewWorkflow(cfg, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
+	w := NewPRReviewWorkflow(cfg, nil, newFakeSlackPort(), &fakeGitHubPR{}, nil, captureLogger(&buf))
 
 	const harmlessOutput = "plain output string with no secrets inside"
 	state := &queue.JobState{Job: &queue.Job{TaskType: "pr_review", WorkflowArgs: map[string]string{"pr_url": "https://github.com/foo/bar/pull/1"}}}

--- a/cmd/agentdock/init.go
+++ b/cmd/agentdock/init.go
@@ -146,7 +146,7 @@ func marshalAppYAML(cfg *appconfig.Config, path string) ([]byte, error) {
 		text = insertBefore(text, "slack:", "# REQUIRED for `agentdock app`: Slack bot+app tokens")
 	}
 	if cfg.GitHub.Token == "" {
-		text = insertBefore(text, "github:", "# REQUIRED for both subcommands: GitHub token")
+		text = insertBefore(text, "github:", "# OPTIONAL PAT fallback: set github.token only if you need PAT mode or cross-installation fallback; pure GitHub App deployments use github.app.*")
 	}
 	if cfg.Redis.Addr == "" {
 		text = insertBefore(text, "redis:", "# REQUIRED when queue.transport=redis: Redis address")
@@ -175,7 +175,7 @@ func marshalWorkerYAML(cfg *workerconfig.Config, path string) ([]byte, error) {
 	}
 	text := string(raw)
 	if cfg.GitHub.Token == "" {
-		text = insertBefore(text, "github:", "# REQUIRED: GitHub token")
+		text = insertBefore(text, "github:", "# OPTIONAL worker override: set github.token only for PAT-only or deliberate worker-local override deployments")
 	}
 	if cfg.Redis.Addr == "" {
 		text = insertBefore(text, "redis:", "# REQUIRED when queue.transport=redis: Redis address")

--- a/docs/superpowers/specs/2026-05-04-github-app-workflow-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-04-github-app-workflow-coverage-design.md
@@ -1,0 +1,473 @@
+# GitHub App Coverage for Repo-Bound Workflow Entrypoints
+
+**Date:** 2026-05-04
+**Status:** Draft
+**Issue:** TBD
+**Builds on:** [`2026-05-02-github-app-auth-design.md`](./2026-05-02-github-app-auth-design.md)
+
+## Objective
+
+Close the remaining gaps between "GitHub App auth exists" and "all repo-bound
+workflow entrypoints behave correctly without a PAT when the target repo is
+covered by the App installation."
+
+Success means:
+
+1. App-covered repos work end-to-end for `issue`, `ask`, and `pr_review`
+   without relying on `secrets["GH_TOKEN"]` or `github.token`.
+2. Repos outside the App installation use PAT only as an explicit fallback,
+   not as an implicit hidden dependency.
+3. Pre-dispatch app-side GitHub calls use the same repo-aware auth decision as
+   dispatch/retry.
+4. Operators get clear signals when configuration will override or bypass
+   app-minted installation tokens.
+
+## Assumptions
+
+1. `origin/main` is the source of truth for current behavior; the local
+   checkout may lag and may carry unrelated uncommitted edits.
+2. The 2026-05-02 GitHub App work already landed for the core token-source,
+   dispatch, retry, and app-internal client paths.
+3. The desired end state is **App first, PAT fallback**, not "remove PAT
+   support entirely."
+4. Worker processes must continue to receive plain `GH_TOKEN` strings only;
+   private keys remain app-only.
+
+## Problem
+
+As of `origin/main`, the system is in a partially converged state:
+
+- Core app-side auth construction already uses `githubapp.TokenSource`.
+- Dispatch and retry already mint per-job `GH_TOKEN` bundles and support
+  cross-installation PAT fallback via `dispatch.ChooseJobSource(...)`.
+- Worker-side repo preparation still correctly consumes only the encrypted
+  per-job token bundle.
+
+But the remaining repo-bound entrypoints are inconsistent:
+
+1. **PR Review pre-submit validation is not routed through repo-aware auth
+   selection.**
+   `app/workflow/pr_review.go` validates the PR URL by calling
+   `GetPullRequest(...)` before job submission. This path currently depends on
+   the app-wide PR client, not the same repo-aware source choice that dispatch
+   and retry use.
+
+2. **Interactive app-side repo access can still hit App-only blind spots.**
+   `issue` / `ask` branch listing uses `RepoCache.EnsureRepo(...)` before job
+   dispatch. Those paths already avoid stale `cfg.Secrets["GH_TOKEN"]`, but
+   they still need an explicit per-repo fallback decision when a selected repo
+   is outside the App installation.
+
+3. **Operator-facing config signals still imply PAT is required even in pure
+   App deployments.**
+   Init/config comments and some defaults still reflect the older PAT-first
+   mental model.
+
+4. **Worker secret overlay remains a deployment landmine.**
+   Any `worker.yaml` value for `secrets.GH_TOKEN` overrides the app-minted job
+   token because worker secrets win during merge.
+
+The practical consequence is that "PAT removed from secrets" can look like the
+root cause, even when the real issue is a pre-dispatch auth-routing gap or an
+entrypoint-level transport timeout.
+
+## Non-Goals
+
+- Redesigning the `githubapp.TokenSource` abstraction.
+- Moving GitHub App private keys or JWT signing into worker code.
+- Removing PAT fallback support.
+- Solving multi-installation routing across multiple orgs.
+- Replacing the current encrypted secret transport between app and worker.
+- Reworking workflow UX beyond what is required to make auth behavior correct
+  and diagnosable.
+
+## Current Commands
+
+Build:
+
+```bash
+go test ./workflow ./dispatch ./githubapp
+```
+
+From `shared/`:
+
+```bash
+go test ./github
+```
+
+From `worker/`:
+
+```bash
+go test ./config ./pool
+```
+
+Repo-wide targeted grep while implementing:
+
+```bash
+git grep -n "cfg.GitHub.Token\|cfg.Secrets\\[\"GH_TOKEN\"\\]\|GetPullRequest\|EnsureRepo" origin/main -- app shared worker
+```
+
+## Project Structure
+
+- `app/githubapp/`
+  App-side GitHub App token source, minting, preflight, accessible-repo cache.
+- `app/dispatch/`
+  Per-job source choice and encrypted secret bundle construction.
+- `app/workflow/`
+  Workflow entrypoints that may touch GitHub before job dispatch.
+- `shared/github/`
+  Repo cache, PR client, issue client, discovery client.
+- `worker/`
+  Repo preparation and secret overlay behavior on the execution side.
+- `docs/superpowers/specs/`
+  Design artifacts used to drive issue creation and follow-up plans.
+
+## Code Style
+
+Prefer small auth-routing helpers over introducing another generic framework.
+The target shape is:
+
+```go
+source, fallback, err := dispatch.ChooseJobSource(cfg.GitHub.Token, tokenSource, repo)
+if err != nil {
+    return NextStep{Kind: NextStepError, ErrorText: "..."} , nil
+}
+
+client := ghclient.NewClient(source.Get)
+pr, err := client.GetPullRequest(ctx, owner, repo, number)
+```
+
+Key conventions:
+
+- Keep repo-aware auth choice near the workflow entrypoint that knows the repo.
+- Reuse existing `ChooseJobSource(...)` semantics rather than creating a second
+  fallback policy.
+- Use per-call token overrides for `RepoCache.EnsureRepo(...)` where possible
+  instead of adding more cache variants.
+
+## Design
+
+### 1. Define the exact surface area
+
+This spec covers **repo-bound app-side GitHub operations**, meaning any app
+operation that:
+
+- knows the target `owner/repo`, and
+- touches GitHub before worker execution, or
+- resolves repo access on behalf of a workflow before dispatch.
+
+In-scope examples:
+
+- PR URL validation in `pr_review`
+- app-side branch listing / repo ensure in `issue` and `ask`
+- retry-time source selection
+
+Out-of-scope examples:
+
+- GitHub App preflight against installation metadata
+- worker-side git fetch after the job already has a minted token
+
+### 2. Unify repo-aware auth choice for pre-dispatch flows
+
+All app-side repo-bound flows must use the same source decision that dispatch
+already uses:
+
+- if the App installation covers the repo: use App token source
+- else if PAT is configured: use PAT fallback
+- else: fail loudly with a repo/install-specific error
+
+No app-side repo-bound path may directly assume that the global app client is
+sufficient for every repo.
+
+This is the canonical rule for this repo: **any known-target repo-bound
+workflow entrypoint must share the same App-first, PAT-fallback routing
+semantics as dispatch.**
+
+### 3. PR Review: fix the pre-submit gap
+
+`app/workflow/pr_review.go` must stop treating PR URL validation as a generic
+GitHub call. It is repo-bound and must choose auth based on the PR's base repo.
+
+Implementation direction:
+
+- parse the PR URL first
+- run repo-aware source selection for `owner/repo`
+- build a short-lived PR client from the selected source
+- validate with that client
+
+This keeps behavior aligned with dispatch/retry and avoids a separate fallback
+policy just for `pr_review`.
+
+For forked PRs, the auth decision is intentionally split:
+
+- **pre-submit validation** routes against the PR's **base repo**
+- **dispatch / worker execution** routes against the PR's **head repo**
+
+These are different repository concepts and must not be collapsed into a
+single "PR repo" term.
+
+### 4. Ask / Issue: make branch-listing fallback explicit
+
+`issue` and `ask` already pass `""` into `EnsureRepo(...)` to avoid stale
+dispatch-time secrets. That is correct for App-covered repos, but it is not
+sufficient for repos outside the installation.
+
+Implementation direction:
+
+- before `EnsureRepo(...)`, resolve whether the selected repo requires PAT
+  fallback
+- if App-covered: keep per-call token empty and let `RepoCache.tokenFn` use
+  App auth
+- if PAT fallback required: pass the PAT string as the per-call token override
+- if neither App coverage nor PAT exists: fail with a user-safe repo access
+  error
+
+This keeps `RepoCache` unchanged at the abstraction level and uses the
+per-call token escape hatch that already exists.
+
+Implementation should use a small shared workflow helper that wraps the
+existing `dispatch.ChooseJobSource(...)` policy and returns the correct
+per-call token override / failure result for repo access. The helper is a
+call-site deduplication aid, not a second auth policy abstraction.
+
+This failure is deterministic, not transient. The interactive workflow must
+fail loudly as soon as the target repo is known to be unreachable, rather than
+letting the user finish the wizard and only failing at submit time.
+
+User-facing Slack wording should be explicit but safe, for example:
+
+`無法存取 repo <owner/repo>：GitHub App 未涵蓋此 repo，且未設定 PAT fallback`
+
+### 5. App-side GitHub transport resilience
+
+The current incident should not be treated as a "10s timeout only" bug. Auth
+routing and transport resilience are separate concerns, but the user-facing
+failure sits at their intersection, so this spec keeps them in one
+implementation round.
+
+This transport work applies to **app-side GitHub REST entrypoints** that run
+before or around workflow dispatch, including:
+
+- PR validation / metadata fetch
+- issue creation
+- repo discovery / installation repo listing
+- App preflight metadata fetches
+
+Required hardening:
+
+- replace the current PR-only 10s assumption with transport settings that fit
+  real GitHub latency
+- classify `context deadline exceeded` / `Client.Timeout exceeded while
+  awaiting headers` as transient GitHub unavailability
+- make timeout / retry / error-shaping behavior consistent across app-side
+  GitHub REST clients where the user or operator would otherwise see divergent
+  failure modes for the same underlying outage
+
+Retry classes are explicitly:
+
+- `429`
+- `403` only when the body indicates secondary rate limit / abuse detection
+- `5xx`
+- network / timeout failures
+
+Fail-fast classes are explicitly:
+
+- ordinary `401`
+- ordinary permission `403`
+- `404`
+- ordinary `422`
+
+This scope still excludes worker-side git clone/fetch transport and does not
+attempt a repo-wide networking redesign outside app-side GitHub REST paths.
+
+This is an explicit same-round implementation decision: workflow-facing and
+non-workflow app-side GitHub REST paths must converge on one transport
+resilience policy in this change, rather than fixing `pr_review` alone and
+leaving preflight / discovery / installation refresh on a separate model.
+
+The policy primitives should live in `shared/github/`, extending the existing
+GitHub HTTP plumbing layer beyond token injection to also cover timeout,
+retry classification, and retry-capable client construction. Callers in
+`app/githubapp/`, workflow-facing clients, and discovery/preflight paths
+consume that shared policy rather than carrying independent retry logic.
+
+The shared policy exposes a small fixed set of named profiles rather than
+letting each caller invent its own timing model:
+
+- `interactive`
+- `background`
+- `preflight`
+
+Each profile defines:
+
+- per-attempt timeout
+- retry delays
+- max wall time
+
+For the `interactive` profile, transient retries remain invisible to Slack
+users. Retry detail belongs in logs and metrics; user-facing workflow text only
+surfaces the final success or the final user-safe failure once the wall-time
+budget is exhausted.
+
+### 6. Guardrails for worker secret override
+
+`worker.yaml` `secrets.GH_TOKEN` is not inherently invalid, but in App mode it
+is dangerous because it overrides app-minted job tokens.
+
+Required guardrail:
+
+- when App mode is enabled, worker preflight must fail if `secrets.GH_TOKEN`
+  is set
+- in PAT-only deployments, worker preflight may warn but must not fail
+- docs must state that this is only acceptable for PAT-only deployments or
+  deliberate worker-local override scenarios
+
+This keeps App-mode semantics strict without breaking legitimate PAT-only
+deployments.
+
+### 7. Operator-facing config/docs cleanup
+
+Pure App deployment must stop looking incomplete in generated config comments.
+
+Required cleanup:
+
+- `init`, generated config comments, and preflight prompts must stop implying
+  `github.token` is always required
+- docs must distinguish:
+  - App-covered repo path
+  - PAT fallback path
+  - no-PAT / no-installation failure path
+
+This round does **not** change the legacy config default that auto-merges
+`github.token` into `secrets["GH_TOKEN"]`; that compatibility behavior remains
+in place and is handled through clearer warnings/docs rather than a semantic
+change.
+
+### 8. PR Review fork-specific failure contract
+
+Forked PRs use different repositories for validation and execution:
+
+- validation/auth-to-review-target uses the **PR base repository**
+- clone/auth-to-execution-source uses the **PR head repository**
+
+When validation succeeds against the base repo but execution cannot proceed
+because the head repo is outside the installation and no PAT fallback exists,
+the system must report this explicitly as a **head repo access failure**.
+
+Slack/log messaging must not collapse this into generic GitHub unavailability.
+The operator-facing remediation must name both valid fixes:
+
+1. install the App for the head-repo owner
+2. configure PAT fallback
+
+### 9. Logging requirements
+
+`pr_review` pre-submit validation must log which auth source was chosen:
+
+- `phase=validation`
+- `repo=<base owner/repo>`
+- `auth_source=app|pat_fallback`
+
+This is required so operators can diagnose incidents where pre-submit behavior
+and dispatch behavior diverge.
+
+## Testing Strategy
+
+Unit/integration coverage should prove auth routing, not just token minting.
+
+### Required tests
+
+1. `pr_review` validation:
+   - App-covered repo uses App source
+   - repo outside installation + PAT uses PAT fallback
+   - repo outside installation + no PAT fails before submit
+
+2. `issue` / `ask` branch-listing path:
+   - App-covered repo branch listing succeeds without PAT
+   - PAT fallback path succeeds when repo is not App-covered
+   - no-PAT fallback path yields explicit repo access error
+
+3. PR client resilience:
+   - timeout-class errors map to `GitHub 不可達，請稍後重試`
+   - longer timeout is pinned by a focused test
+
+4. App-side non-workflow transport:
+   - preflight / installation refresh / repo discovery use the same timeout /
+     retry policy family as workflow-facing app-side GitHub REST clients
+
+5. Worker guardrail:
+   - App mode + `secrets.GH_TOKEN` set => preflight fail
+   - PAT-only mode + `secrets.GH_TOKEN` set => preflight warn
+
+6. Forked `pr_review` failure shape:
+   - base repo accessible + head repo inaccessible + no PAT fallback =>
+     explicit head-repo access failure
+
+7. Logging:
+   - pre-submit `pr_review` validation logs `auth_source=app|pat_fallback`
+   - interactive retry activity is observable in logs/metrics, not Slack thread
+
+### Verification commands
+
+From `app/`:
+
+```bash
+go test ./workflow ./dispatch ./githubapp
+```
+
+From `shared/`:
+
+```bash
+go test ./github
+```
+
+From `worker/`:
+
+```bash
+go test ./config ./pool
+```
+
+## Boundaries
+
+### Always do
+
+- Reuse existing `dispatch.ChooseJobSource(...)` semantics.
+- Keep private key handling app-only.
+- Keep worker token delivery through encrypted per-job secrets.
+- Add focused tests for each new repo-aware path.
+
+### Ask first
+
+- Changing worker secret merge precedence.
+- Removing PAT fallback support.
+- Turning worker `secrets.GH_TOKEN` warning into a hard startup failure.
+- Broadening timeout/retry behavior beyond the PR validation path.
+
+### Never do
+
+- Introduce a second, competing App-vs-PAT routing policy.
+- Read GitHub App private keys from worker code.
+- Mutate `cfg.Secrets` in place per request.
+- Hide cross-installation failures behind generic "GitHub error" wording.
+
+## Success Criteria
+
+1. A pure App deployment can run `issue`, `ask`, and `pr_review` against an
+   App-covered private repo without PAT.
+2. Any repo outside the installation uses PAT only through explicit fallback
+   selection, never via accidental legacy dependency.
+3. `pr_review` no longer has a unique pre-submit auth-routing path that can
+   diverge from dispatch/retry.
+4. Worker-side `secrets.GH_TOKEN` override risk is visible to operators before
+   a production incident.
+5. Generated config/docs no longer imply that PAT is mandatory for App-capable
+   deployments.
+6. Forked PR failures distinguish base-repo validation success from head-repo
+   execution-source access failure.
+7. App-side GitHub REST paths no longer split into unrelated timeout/retry
+   behaviors between workflow-facing and non-workflow code.
+
+## Open Questions
+
+None at this stage. The remaining work is implementation planning and task
+breakdown, not unresolved product or terminology decisions.

--- a/shared/github/discovery.go
+++ b/shared/github/discovery.go
@@ -35,7 +35,7 @@ type RepoDiscovery struct {
 // outbound request via tokenTransport so the underlying gh.Client can
 // keep up with installation-token rotation without rebuilding.
 func NewRepoDiscovery(tokenFn func() (string, error), logger *slog.Logger) *RepoDiscovery {
-	httpClient := &http.Client{Transport: newTokenTransport(tokenFn, nil)}
+	httpClient := NewHTTPClientWithTokenFn(tokenFn, ProfileBackground)
 	return &RepoDiscovery{
 		client: gh.NewClient(httpClient),
 		ttl:    5 * time.Minute,
@@ -52,7 +52,7 @@ func NewInstallationRepoDiscovery(tokenFn func() (string, error), logger *slog.L
 
 func newInstallationRepoDiscoveryWithBaseURL(tokenFn func() (string, error), logger *slog.Logger, baseURL string) *RepoDiscovery {
 	return &RepoDiscovery{
-		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		httpClient:   NewHTTPClient(ProfileBackground),
 		tokenFn:      tokenFn,
 		baseURL:      strings.TrimRight(baseURL, "/"),
 		installation: true,

--- a/shared/github/http_policy.go
+++ b/shared/github/http_policy.go
@@ -1,0 +1,259 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type TransportProfile string
+
+const (
+	ProfileInteractive TransportProfile = "interactive"
+	ProfileBackground  TransportProfile = "background"
+	ProfilePreflight   TransportProfile = "preflight"
+)
+
+var ErrGitHubUnavailable = errors.New("github unavailable")
+
+type transportProfile struct {
+	perAttemptTimeout time.Duration
+	maxWallTime       time.Duration
+	retryDelays       []time.Duration
+}
+
+func profileConfig(profile TransportProfile) transportProfile {
+	switch profile {
+	case ProfileBackground:
+		return transportProfile{
+			perAttemptTimeout: 15 * time.Second,
+			maxWallTime:       45 * time.Second,
+			retryDelays:       []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second},
+		}
+	case ProfilePreflight:
+		return transportProfile{
+			perAttemptTimeout: 15 * time.Second,
+			maxWallTime:       45 * time.Second,
+			retryDelays:       []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second},
+		}
+	default:
+		return transportProfile{
+			perAttemptTimeout: 12 * time.Second,
+			maxWallTime:       30 * time.Second,
+			retryDelays:       []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second},
+		}
+	}
+}
+
+func NewHTTPClient(profile TransportProfile) *http.Client {
+	return NewHTTPClientWithTokenFn(nil, profile)
+}
+
+func NewHTTPClientWithTokenFn(tokenFn func() (string, error), profile TransportProfile) *http.Client {
+	var delegate http.RoundTripper = http.DefaultTransport
+	if tokenFn != nil {
+		delegate = newTokenTransport(tokenFn, delegate)
+	}
+	return &http.Client{
+		Transport: newRetryTransport(profileConfig(profile), delegate),
+	}
+}
+
+type retryTransport struct {
+	profile  transportProfile
+	delegate http.RoundTripper
+}
+
+func newRetryTransport(profile transportProfile, delegate http.RoundTripper) *retryTransport {
+	if delegate == nil {
+		delegate = http.DefaultTransport
+	}
+	return &retryTransport{profile: profile, delegate: delegate}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	deadline := time.Now().Add(t.profile.maxWallTime)
+	if d, ok := req.Context().Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
+	attempts := len(t.profile.retryDelays) + 1
+	var lastErr error
+	var lastStatus int
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			delay := t.profile.retryDelays[attempt-1]
+			if err := sleepWithinDeadline(req.Context(), deadline, delay); err != nil {
+				return nil, transientError(lastStatus, attempt, lastErr)
+			}
+		}
+
+		attemptReq, cancel, err := cloneRequestForAttempt(req, deadline, t.profile.perAttemptTimeout, attempt > 0)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, roundTripErr := t.delegate.RoundTrip(attemptReq)
+		if roundTripErr != nil {
+			cancel()
+			if errors.Is(roundTripErr, context.Canceled) && !errors.Is(req.Context().Err(), context.DeadlineExceeded) {
+				return nil, roundTripErr
+			}
+			lastErr = roundTripErr
+			if !isRetryableTransportError(roundTripErr) || attempt == attempts-1 {
+				if isRetryableTransportError(roundTripErr) {
+					return nil, transientError(lastStatus, attempt+1, lastErr)
+				}
+				return nil, roundTripErr
+			}
+			continue
+		}
+
+		retryable, statusCode, bodyBytes := isRetryableGitHubResponse(resp)
+		if !retryable || !requestCanRetry(req) {
+			resp.Body = &cancelOnCloseReadCloser{ReadCloser: resp.Body, cancel: cancel}
+			return resp, nil
+		}
+
+		lastStatus = statusCode
+		lastErr = fmt.Errorf("status %d", statusCode)
+		_ = resp.Body.Close()
+		cancel()
+
+		if attempt == attempts-1 {
+			_ = bodyBytes
+			return nil, transientError(lastStatus, attempt+1, lastErr)
+		}
+	}
+
+	return nil, transientError(lastStatus, attempts, lastErr)
+}
+
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel func()
+}
+
+func (c *cancelOnCloseReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	return err
+}
+
+func cloneRequestForAttempt(req *http.Request, deadline time.Time, perAttemptTimeout time.Duration, resetBody bool) (*http.Request, func(), error) {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return nil, nil, context.DeadlineExceeded
+	}
+	timeout := perAttemptTimeout
+	if timeout <= 0 || timeout > remaining {
+		timeout = remaining
+	}
+	ctx, cancel := context.WithTimeout(req.Context(), timeout)
+	cloned := req.Clone(ctx)
+	if resetBody && req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			cancel()
+			return nil, nil, fmt.Errorf("reset request body: %w", err)
+		}
+		cloned.Body = body
+	}
+	return cloned, cancel, nil
+}
+
+func requestCanRetry(req *http.Request) bool {
+	return req.Body == nil || req.GetBody != nil
+}
+
+func sleepWithinDeadline(ctx context.Context, deadline time.Time, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	if time.Now().Add(delay).After(deadline) {
+		return context.DeadlineExceeded
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isRetryableTransportError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "dial tcp") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "unexpected eof")
+}
+
+func isRetryableGitHubResponse(resp *http.Response) (bool, int, []byte) {
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return true, resp.StatusCode, nil
+	case http.StatusForbidden:
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		body := strings.ToLower(string(bodyBytes))
+		return strings.Contains(body, "secondary rate limit") || strings.Contains(body, "abuse detection"), resp.StatusCode, bodyBytes
+	default:
+		if resp.StatusCode >= 500 {
+			return true, resp.StatusCode, nil
+		}
+		return false, resp.StatusCode, nil
+	}
+}
+
+type githubTransientError struct {
+	statusCode int
+	attempts   int
+	cause      error
+}
+
+func transientError(statusCode, attempts int, cause error) error {
+	return &githubTransientError{statusCode: statusCode, attempts: attempts, cause: cause}
+}
+
+func (e *githubTransientError) Error() string {
+	if e == nil {
+		return ErrGitHubUnavailable.Error()
+	}
+	if e.statusCode != 0 {
+		return fmt.Sprintf("github unavailable after %d attempts: status=%d", e.attempts, e.statusCode)
+	}
+	if e.cause != nil {
+		return fmt.Sprintf("github unavailable after %d attempts: %v", e.attempts, e.cause)
+	}
+	return fmt.Sprintf("github unavailable after %d attempts", e.attempts)
+}
+
+func (e *githubTransientError) Unwrap() error { return e.cause }
+
+func (e *githubTransientError) Is(target error) bool {
+	return target == ErrGitHubUnavailable
+}

--- a/shared/github/http_policy_test.go
+++ b/shared/github/http_policy_test.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryTransport_RetriesTransient5xx(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: newRetryTransport(transportProfile{
+			perAttemptTimeout: 200 * time.Millisecond,
+			maxWallTime:       500 * time.Millisecond,
+			retryDelays:       []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+		}, http.DefaultTransport),
+	}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
+	}
+	if got := hits.Load(); got != 3 {
+		t.Fatalf("hits = %d, want 3", got)
+	}
+}
+
+func TestRetryTransport_ExhaustsAsGitHubUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGatewayTimeout)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: newRetryTransport(transportProfile{
+			perAttemptTimeout: 200 * time.Millisecond,
+			maxWallTime:       500 * time.Millisecond,
+			retryDelays:       []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+		}, http.DefaultTransport),
+	}
+
+	resp, err := client.Get(srv.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrGitHubUnavailable) {
+		t.Fatalf("err = %v, want ErrGitHubUnavailable", err)
+	}
+}
+
+func TestProfileConfig_InteractivePinsLongerThanLegacy10s(t *testing.T) {
+	cfg := profileConfig(ProfileInteractive)
+	if cfg.perAttemptTimeout <= 10*time.Second {
+		t.Fatalf("interactive per-attempt timeout = %v, want > 10s", cfg.perAttemptTimeout)
+	}
+	if cfg.maxWallTime != 30*time.Second {
+		t.Fatalf("interactive maxWallTime = %v, want 30s", cfg.maxWallTime)
+	}
+}

--- a/shared/github/issue.go
+++ b/shared/github/issue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"time"
 
 	"github.com/Ivantseng123/agentdock/shared/metrics"
@@ -22,7 +21,7 @@ type IssueClient struct {
 // per outbound request via tokenTransport so the underlying gh.Client
 // can keep up with installation-token rotation without rebuilding.
 func NewIssueClient(tokenFn func() (string, error), logger *slog.Logger) *IssueClient {
-	httpClient := &http.Client{Transport: newTokenTransport(tokenFn, nil)}
+	httpClient := NewHTTPClientWithTokenFn(tokenFn, ProfileInteractive)
 	return &IssueClient{
 		client: gh.NewClient(httpClient),
 		logger: logger,

--- a/shared/github/pr.go
+++ b/shared/github/pr.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 )
 
 // Client is a thin GitHub REST client for endpoints that need precise HTTP
@@ -23,15 +22,12 @@ type Client struct {
 // NewClient builds a Client. tokenFn is invoked per outbound request via
 // tokenTransport so the client keeps up with installation-token rotation
 // without rebuilding. Pass a tokenFn that returns "" for unauthenticated
-// requests (rate-limited). Uses a dedicated http.Client with a 10s timeout —
-// never share http.DefaultClient because callers mutating its Timeout would
-// affect unrelated packages.
+// requests (rate-limited). Uses the shared interactive GitHub transport policy
+// so timeout / retry behavior stays aligned with other app-side GitHub REST
+// callers.
 func NewClient(tokenFn func() (string, error)) *Client {
 	return &Client{
-		http: &http.Client{
-			Timeout:   10 * time.Second,
-			Transport: newTokenTransport(tokenFn, nil),
-		},
+		http: NewHTTPClientWithTokenFn(tokenFn, ProfileInteractive),
 	}
 }
 

--- a/shared/prreview/github.go
+++ b/shared/prreview/github.go
@@ -283,11 +283,12 @@ func createReview(ctx context.Context, apiBase, prURL, token string, payload *Cr
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(bodyBytes)), nil
-	}
 
-	resp, err := httpCallWithRetry(ctx, req, maxWallTime)
+	// Creating a review is a non-idempotent write. If GitHub accepts the first
+	// POST but the response is lost or times out locally, retrying would create
+	// a duplicate review with the same summary and inline comments.
+	client := &http.Client{Timeout: minDuration(10 * time.Second, maxWallTime)}
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/shared/prreview/github_test.go
+++ b/shared/prreview/github_test.go
@@ -1,6 +1,7 @@
 package prreview
 
 import (
+	"encoding/json"
 	"context"
 	"io"
 	"net/http"
@@ -131,6 +132,64 @@ func TestHTTPCallRetry_403RateLimitRetries(t *testing.T) {
 	resp.Body.Close()
 	if hits != 2 {
 		t.Errorf("want 2 hits, got %d", hits)
+	}
+}
+
+func TestCreateReview_DoesNotRetryNonIdempotentPost(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(503)
+		_, _ = io.WriteString(w, `{"message":"temporary outage"}`)
+	}))
+	defer srv.Close()
+
+	id, err := createReview(context.Background(), srv.URL, "https://github.com/foo/bar/pull/1", "ghs_test", &CreateReviewReq{
+		CommitID: "abc123",
+		Body:     "summary",
+		Event:    "COMMENT",
+		Comments: []CreateReviewReqInline{{Path: "a.go", Line: 1, Side: "RIGHT", Body: "body"}},
+	}, 30*time.Second)
+	if err == nil {
+		t.Fatalf("want error, got nil (review id=%d)", id)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("createReview retried POST %d times, want exactly 1", got)
+	}
+	if !strings.Contains(err.Error(), "create review: 503") {
+		t.Fatalf("error = %v, want 503 create review error", err)
+	}
+}
+
+func TestCreateReview_SuccessSinglePost(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]int64{"id": 42})
+	}))
+	defer srv.Close()
+
+	id, err := createReview(context.Background(), srv.URL, "https://github.com/foo/bar/pull/1", "ghs_test", &CreateReviewReq{
+		CommitID: "abc123",
+		Body:     "summary",
+		Event:    "COMMENT",
+		Comments: []CreateReviewReqInline{{Path: "a.go", Line: 1, Side: "RIGHT", Body: "body"}},
+	}, 30*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("review id = %d, want 42", id)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("createReview hit count = %d, want 1", got)
 	}
 }
 

--- a/worker/config/config_test.go
+++ b/worker/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -100,5 +101,35 @@ github:
 `)
 	if cfg.Secrets["GH_TOKEN"] != "ghp-worker" {
 		t.Errorf("GH_TOKEN = %q", cfg.Secrets["GH_TOKEN"])
+	}
+}
+
+func TestPreflightWorkerGHTokenOverride_FailsWhenAppDeliversSecrets(t *testing.T) {
+	cfg := loadFromString(t, `
+queue:
+  transport: redis
+secret_key: abc
+secrets:
+  GH_TOKEN: ghp-worker-override
+`)
+	err := preflightWorkerGHTokenOverride(cfg)
+	if err == nil {
+		t.Fatal("expected override error")
+	}
+	if !strings.Contains(err.Error(), "overrides app-minted per-job token") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPreflightWorkerGHTokenOverride_AllowsPATOnlyOverride(t *testing.T) {
+	cfg := loadFromString(t, `
+queue:
+  transport: redis
+secret_key: abc
+github:
+  token: ghp-worker
+`)
+	if err := preflightWorkerGHTokenOverride(cfg); err != nil {
+		t.Fatalf("expected PAT-shaped override warning only, got %v", err)
 	}
 }

--- a/worker/config/preflight.go
+++ b/worker/config/preflight.go
@@ -42,6 +42,9 @@ func RunPreflight(cfg *Config) (map[string]any, error) {
 			return prompted, err
 		}
 	}
+	if err := preflightWorkerGHTokenOverride(cfg); err != nil {
+		return prompted, err
+	}
 
 	if err := preflightGitHub(cfg, interactive, prompted); err != nil {
 		return prompted, err
@@ -70,6 +73,20 @@ func preflightGit() error {
 		return err
 	}
 	prompt.OK("Git binary supports env-based auth")
+	return nil
+}
+
+func preflightWorkerGHTokenOverride(cfg *Config) error {
+	token, ok := cfg.Secrets["GH_TOKEN"]
+	if !ok || token == "" {
+		return nil
+	}
+	if cfg.Queue.Transport == "redis" && cfg.SecretKey != "" && cfg.GitHub.Token == "" {
+		err := fmt.Errorf("worker secrets.GH_TOKEN overrides app-minted per-job token; remove secrets.GH_TOKEN for GitHub App deployments")
+		prompt.Fail("%v", err)
+		return err
+	}
+	prompt.Warn("worker secrets.GH_TOKEN overrides app-provided GH_TOKEN; keep this only for PAT-only or deliberate worker-local override deployments")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- route app-side repo-bound GitHub calls through App-first, PAT-fallback auth selection
- unify app-side GitHub REST transport policy and tighten worker/app GitHub App guardrails
- stop retrying non-idempotent PR review POSTs to avoid duplicate review summaries and inline comments

## Testing
- go test ./workflow ./githubapp
- go test ./github ./prreview
- go test ./config
- local Slack PR review test with GitHub App-only config