### PR TITLE
fix(worker/pool): propagate cost and tokens into JobResult

### DIFF
--- a/worker/pool/pool.go
+++ b/worker/pool/pool.go
@@ -239,6 +239,7 @@ func (p *Pool) executeWithTracking(ctx context.Context, workerIndex int, job *qu
 	}
 
 	result := executeJob(jobCtx, job, deps, opts, logger)
+	status.applyTotalsTo(result)
 	status.setPrepareSeconds(result.PrepareSeconds)
 
 	// Promote the worker-side store to the terminal status BEFORE the final

--- a/worker/pool/pool_test.go
+++ b/worker/pool/pool_test.go
@@ -20,9 +20,15 @@ import (
 type mockRunner struct {
 	output string
 	err    error
+	events []queue.StreamEvent
 }
 
 func (m *mockRunner) Run(ctx context.Context, workDir, prompt string, opts agent.RunOptions) (string, error) {
+	if opts.OnEvent != nil {
+		for _, evt := range m.events {
+			opts.OnEvent(evt)
+		}
+	}
 	return m.output, m.err
 }
 
@@ -801,5 +807,75 @@ func TestPool_FinalStatusReportCarriesTerminalJobStatus(t *testing.T) {
 	if final.JobStatus != queue.JobCompleted {
 		t.Errorf("final status report JobStatus=%q, want %q (otherwise app StatusListener races ResultListener and clobbers the answer)",
 			final.JobStatus, queue.JobCompleted)
+	}
+}
+
+func TestHandleJob_PublishesCostAndTokensInJobResult(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	store := queue.NewMemJobStore()
+	bundle := queuetest.NewBundle(10, 3, store)
+	defer bundle.Close()
+
+	agentOutput := "Analysis done."
+
+	runner := &mockRunner{
+		output: agentOutput,
+		events: []queue.StreamEvent{
+			{Type: "result", CostUSD: 0.05, InputTokens: 100, OutputTokens: 50},
+		},
+	}
+
+	pool := NewPool(Config{
+		Queue:       bundle.Queue,
+		Attachments: bundle.Attachments,
+		Results:     bundle.Results,
+		Store:       store,
+		Runner:      runner,
+		RepoCache:   &mockRepo{path: "/tmp/r"},
+		Commands:    bundle.Commands,
+		WorkerCount: 1,
+		Hostname:    "test-host",
+		Logger:      slog.Default(),
+	})
+	pool.Start(ctx)
+
+	bundle.Attachments.Prepare(ctx, "jcost", nil)
+
+	if err := bundle.Queue.Submit(ctx, &queue.Job{
+		ID:       "jcost",
+		Priority: 50,
+		Repo:     "owner/repo",
+		PromptContext: &queue.PromptContext{
+			ThreadMessages: []queue.ThreadMessage{{User: "T", Timestamp: "1", Text: "test"}},
+			Channel:        "test",
+			Reporter:       "tester",
+			Goal:           "test goal",
+		},
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	ch, _ := bundle.Results.Subscribe(ctx)
+	select {
+	case result := <-ch:
+		if result.JobID != "jcost" {
+			t.Errorf("jobID = %q, want jcost", result.JobID)
+		}
+		if result.Status != "completed" {
+			t.Errorf("status = %q, want completed", result.Status)
+		}
+		if result.CostUSD != 0.05 {
+			t.Errorf("CostUSD = %v, want 0.05", result.CostUSD)
+		}
+		if result.InputTokens != 100 {
+			t.Errorf("InputTokens = %d, want 100", result.InputTokens)
+		}
+		if result.OutputTokens != 50 {
+			t.Errorf("OutputTokens = %d, want 50", result.OutputTokens)
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for result")
 	}
 }

--- a/worker/pool/status.go
+++ b/worker/pool/status.go
@@ -89,3 +89,17 @@ func (s *statusAccumulator) toReport() queue.StatusReport {
 		PrepareSeconds: s.prepareSeconds,
 	}
 }
+
+// applyTotalsTo overwrites cost/token fields on result with the totals the
+// accumulator captured from the agent stream. Safe to call regardless of
+// result.Status: when the run ended before any "result" event landed, the
+// fields stay at zero, which is the correct semantic. Worker is the sole
+// writer of these fields on the success / cancelled / failed paths, so
+// overwriting any caller-set value is intentional.
+func (s *statusAccumulator) applyTotalsTo(result *queue.JobResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result.CostUSD = s.costUSD
+	result.InputTokens = s.inputTokens
+	result.OutputTokens = s.outputTokens
+}

--- a/worker/pool/status.go
+++ b/worker/pool/status.go
@@ -96,6 +96,12 @@ func (s *statusAccumulator) toReport() queue.StatusReport {
 // fields stay at zero, which is the correct semantic. Worker is the sole
 // writer of these fields on the success / cancelled / failed paths, so
 // overwriting any caller-set value is intentional.
+//
+// Known limitation: cancellation mid-stream may lose a final "result" event
+// because the runner's OnEvent forwarder takes the ctx.Done() drain path
+// without invoking the callback (worker/agent/runner.go:325-329). When that
+// happens the accumulator never sees the totals and cancelled JobResults
+// carry zero. Tracked separately in #253.
 func (s *statusAccumulator) applyTotalsTo(result *queue.JobResult) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/worker/pool/status_test.go
+++ b/worker/pool/status_test.go
@@ -1,0 +1,87 @@
+package pool
+
+import (
+	"testing"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+func TestStatusAccumulator_ApplyTotalsTo(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(*statusAccumulator)
+		initialResult  queue.JobResult
+		wantCost       float64
+		wantInTokens   int
+		wantOutTokens  int
+	}{
+		{
+			name: "completed with totals",
+			setup: func(s *statusAccumulator) {
+				s.costUSD = 0.05
+				s.inputTokens = 100
+				s.outputTokens = 50
+			},
+			initialResult: queue.JobResult{Status: "completed"},
+			wantCost:      0.05,
+			wantInTokens:  100,
+			wantOutTokens: 50,
+		},
+		{
+			name: "partial on failure",
+			setup: func(s *statusAccumulator) {
+				s.costUSD = 0.02
+				s.inputTokens = 40
+				s.outputTokens = 0
+			},
+			initialResult: queue.JobResult{Status: "failed", Error: "boom"},
+			wantCost:      0.02,
+			wantInTokens:  40,
+			wantOutTokens: 0,
+		},
+		{
+			name:          "never saw result event",
+			setup:         func(s *statusAccumulator) {},
+			initialResult: queue.JobResult{Status: "cancelled"},
+			wantCost:      0,
+			wantInTokens:  0,
+			wantOutTokens: 0,
+		},
+		{
+			name: "overwrites caller-set values",
+			setup: func(s *statusAccumulator) {
+				s.costUSD = 0.10
+				s.inputTokens = 200
+				s.outputTokens = 100
+			},
+			initialResult: queue.JobResult{
+				Status:       "completed",
+				CostUSD:      99.99,
+				InputTokens:  9999,
+				OutputTokens: 9999,
+			},
+			wantCost:      0.10,
+			wantInTokens:  200,
+			wantOutTokens: 100,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &statusAccumulator{}
+			tc.setup(s)
+			r := tc.initialResult
+
+			s.applyTotalsTo(&r)
+
+			if r.CostUSD != tc.wantCost {
+				t.Errorf("CostUSD = %v, want %v", r.CostUSD, tc.wantCost)
+			}
+			if r.InputTokens != tc.wantInTokens {
+				t.Errorf("InputTokens = %d, want %d", r.InputTokens, tc.wantInTokens)
+			}
+			if r.OutputTokens != tc.wantOutTokens {
+				t.Errorf("OutputTokens = %d, want %d", r.OutputTokens, tc.wantOutTokens)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

bug fix (real defect — schema fields existed but were never written).

#### What this PR does / why we need it

`shared/queue/job.go:118-120` defines `CostUSD` / `InputTokens` / `OutputTokens` on `JobResult`, and `app/workflow` already knows how to render `result.CostUSD` into the Slack diagnostics line. The worker never filled them: `worker/pool/executor.go:233` (success), `:329` (cancelled), and `:339` (failed) all built `&queue.JobResult{…}` without touching the fields, so the schema was dead on the wire even though the data existed upstream.

Concretely, `statusAccumulator.recordEvent` (`worker/pool/status.go:39-61`) already captures cost/tokens from `StreamEvent{Type:"result"}` events emitted by `ReadStreamJSONClaude` / `ReadStreamJSONOpencode`. The accumulator publishes them on the `StatusReport` bus via `toReport()`. The terminal `JobResult` simply wasn't stamped.

Fix: add `applyTotalsTo(*queue.JobResult)` to `statusAccumulator` (mirrors `toReport`'s mutex pattern), then call it from `handleJob` immediately after `executeJob` returns. Single call site, single line, all three return paths (success / cancelled / failed) inherit the stamp because the caller-side stamp happens regardless of `result.Status`. `executor.go` is intentionally untouched — putting the stamp inside would mean either touching three constructors or wrapping the return, both more invasive than the caller-side line.

Once this lands together with #251, the Slack diagnostics line on issue / ask / pr_review success posts will show `$cost` whenever the agent reports a non-zero cost. The line already shows `elapsed` and `worker: label` today; the `$cost` slot has been silently empty because of this propagation gap.

#### Known limitation (tracked in #253)

For the **completed** path, this PR fully satisfies the issue acceptance criteria. For the **cancelled** path, partial cost may still be dropped because `worker/agent/runner.go:325-329` takes the `ctx.Done()` drain branch and silently discards buffered events without invoking the `onEvent` callback — so the accumulator never sees a "result" event that arrived just before cancel. The bug is broader than cost (it also drops `lastTool` / `filesRead` / counters on cancellation) and is filed as #253 for an independent runner-side fix. The `applyTotalsTo` doc comment notes this limitation inline.

#### Which issue(s) this PR fixes:

Fixes #250

#### Special notes for your reviewer:

3 commits, each independently buildable and tested:

- `7b72e51` feat: add `applyTotalsTo` method on `statusAccumulator` + 4-subtest unit table (completed-with-totals, partial-on-failure, never-saw-result-event, overwrites-caller-set-values)
- `14658c6` fix: wire `status.applyTotalsTo(result)` into `handleJob` + extend `mockRunner` with `events` field + integration test `TestHandleJob_PublishesCostAndTokensInJobResult`
- `<doc>` docs: note cancellation-drop limitation on `applyTotalsTo` (references #253)

5 files changed, 184 insertions, 0 deletions. Production deltas: `status.go +20` (new method + doc + limitation note), `pool.go +1` (the wiring line). The rest is test code.

Race analysis: by the time `handleJob` calls `applyTotalsTo`, `executeJob` has returned. That path goes through `worker/agent/runner.go:303-348` → `readOutput` blocks on its `wg.Wait()` AFTER `close(eventCh)`, which only happens after the OnEvent forwarder goroutine has drained. So `recordEvent` calls into the accumulator have all completed before the stamp reads. `applyTotalsTo` also acquires `s.mu`, so even if `reportStatus` (the periodic publisher goroutine) is still running, the lock serializes them.

Verification (run from repo root):

- `(cd worker && go test ./...)` → 158 passed
- `(cd app && go test ./...)` → 568 passed
- `(cd shared && go test ./...)` → 292 passed
- `(cd worker && go vet ./...)` → clean
- Commit messages pass `commitlint --extends @commitlint/config-conventional`.

Reviewer hint: the helper (`Task 1` / `7b72e51`) and the wiring (`Task 2` / `14658c6`) are both small and isolated. Read them in commit order.

#### Does this PR introduce a user-facing change?

```release-note
JobResult now carries the agent's reported cost (USD) and token counts for completed jobs. Combined with the diagnostics line shipped in #251, Slack messages on completed issue / ask / pr_review jobs will start showing `$cost` alongside elapsed time and worker label. Cancelled jobs may still report zero cost until #253 lands.
```

#### Additional documentation e.g., ADRs, README, design docs, etc.:

```docs
Design spec at docs/superpowers/specs/2026-05-11-issue-250-cost-token-propagation-design.md and implementation plan at docs/superpowers/plans/2026-05-12-issue-250-cost-token-propagation.md (both untracked per workflow rule — request via thread if needed).
```

---
Generated via superpowers workflow