### PR TITLE
fix(image): bump opencode 1.14.29→1.14.41

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -17,7 +17,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @openai/code
 # "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
 # version downloaded a platform ripgrep binary at startup and failed to
 # extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
-ARG OPENCODE_VERSION=1.14.29
+ARG OPENCODE_VERSION=1.14.41
 RUN curl -sL https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-musl.tar.gz | \
     tar xzf - -C /usr/local/bin opencode
 


### PR DESCRIPTION
## Summary

- Bumps the worker image's pinned opencode from `1.14.29` → `1.14.41`.
- `1.14.41` is the **newest opencode version** that still behaves correctly under server-mode `/event` SSE — `1.14.42` onwards introduces an upstream regression where the SSE stream closes ~12ms after subscription, before any session events fire.
- Current production runs spawn-mode (process-per-job), so the SSE regression doesn't bite today. The bump is "stay current without crossing the future-blocker boundary" — keeps the Phase 3.2 server-mode swap viable on this image.
- Local dev binary at `~/.opencode/bin/opencode` updated to `1.14.41` in the same session via `opencode upgrade 1.14.41`.

## Bisect evidence (POC P3, harbor-4images fixture)

| Version | Result | Notes |
| --- | --- | --- |
| 1.14.29 | ✅ | Current pin / baseline |
| 1.14.38 | ✅ | 5/5 success |
| 1.14.41 | ✅ | 5/5 success on 120s run timeout |
| 1.14.42 | ❌ | 3/3 `server_mode_regression`, `/event` closes at ≤12ms |
| 1.14.43 | ❌ | Same close-at-12ms |
| 1.14.48 | ❌ | Same close-at-12ms (the original POC red) |

The SSE-close regression at 1.14.42 is upstream (no relation to anything in this repo). It only affects long-running `opencode serve` consumers, not `opencode run` per-job invocations.

## Test plan

- [ ] CI build of the image succeeds (Dockerfile change only).
- [ ] Goreleaser pipeline produces an image whose `opencode --version` reports `1.14.41`.
- [ ] When you cut a new release tag and update `deploy/worker-opencode.yaml` to that tag, the worker pod boots and processes an ask end-to-end (spawn mode).

POC code and the Phase 3.2 server-mode work stay on `poc/opencode-server-mode`; nothing in this PR touches that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)