### PR TITLE
feat(worker): opencode-server-mode Stage 1 — foundation (config + dispatcher stub)

### DIFF
--- a/worker/agent/opencode_dispatch_test.go
+++ b/worker/agent/opencode_dispatch_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Ivantseng123/agentdock/worker/config"
+)
+
+// TestDispatchTarget_Matrix covers the 4 agents × 3 mode states = 12
+// dispatch decisions: only opencode×server routes to the server-mode
+// runner. Every other combination falls through to spawn. The empty
+// mode (zero value, e.g. Runner constructed via NewRunner without a
+// follow-up NewRunnerFromConfig) also routes to spawn, so a partially
+// constructed Runner doesn't silently end up in server mode.
+func TestDispatchTarget_Matrix(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		mode    string
+		want    string
+	}{
+		{"claude/spawn", "claude", config.OpencodeModeSpawn, "spawn"},
+		{"claude/server", "claude", config.OpencodeModeServer, "spawn"},
+		{"claude/zero", "claude", "", "spawn"},
+		{"codex/spawn", "codex", config.OpencodeModeSpawn, "spawn"},
+		{"codex/server", "codex", config.OpencodeModeServer, "spawn"},
+		{"codex/zero", "codex", "", "spawn"},
+		{"opencode/spawn", "opencode", config.OpencodeModeSpawn, "spawn"},
+		{"opencode/server", "opencode", config.OpencodeModeServer, "server"},
+		{"opencode/zero", "opencode", "", "spawn"},
+		{"gemini/spawn", "gemini", config.OpencodeModeSpawn, "spawn"},
+		{"gemini/server", "gemini", config.OpencodeModeServer, "spawn"},
+		{"gemini/zero", "gemini", "", "spawn"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Runner{
+				opencodeCfg: config.OpencodeConfig{Mode: tc.mode},
+			}
+			got := r.dispatchTarget(config.AgentConfig{Command: tc.command})
+			if got != tc.want {
+				t.Errorf("dispatchTarget(%q, mode=%q) = %q, want %q", tc.command, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunOne_ServerStub_ReturnsExplicitError walks the dispatcher and the
+// stub end-to-end: when opencode+server is configured, runOne must call
+// runOneServer, which (in Stage 1) returns an error mentioning the
+// not-implemented state. This proves the dispatcher actually reaches the
+// stub rather than silently falling through to spawn.
+func TestRunOne_ServerStub_ReturnsExplicitError(t *testing.T) {
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+	}
+	_, err := r.runOne(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp",
+		"unused prompt",
+		RunOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected stub error, got nil")
+	}
+	if !strings.Contains(err.Error(), "server mode not implemented") {
+		t.Errorf("error %q does not mention 'server mode not implemented'", err.Error())
+	}
+}
+
+// TestNewRunnerFromConfig_PopulatesOpencodeCfg verifies the dispatcher
+// field is wired through the Config constructor — without this, a worker
+// loaded via NewRunnerFromConfig with `opencode.mode: server` in yaml
+// would still route to spawn, hiding the configuration error.
+func TestNewRunnerFromConfig_PopulatesOpencodeCfg(t *testing.T) {
+	cfg := &config.Config{
+		Providers: []string{"opencode"},
+		Agents: map[string]config.AgentConfig{
+			"opencode": {Command: "opencode"},
+		},
+		Opencode: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+	}
+	runner := NewRunnerFromConfig(cfg)
+	if runner.opencodeCfg.Mode != config.OpencodeModeServer {
+		t.Errorf("opencodeCfg.Mode = %q, want %q", runner.opencodeCfg.Mode, config.OpencodeModeServer)
+	}
+}

--- a/worker/agent/opencode_dispatch_test.go
+++ b/worker/agent/opencode_dispatch_test.go
@@ -15,6 +15,11 @@ import (
 // mode (zero value, e.g. Runner constructed via NewRunner without a
 // follow-up NewRunnerFromConfig) also routes to spawn, so a partially
 // constructed Runner doesn't silently end up in server mode.
+//
+// `gemini` is included even though there is no built-in gemini agent
+// today (see worker/config/builtin_agents.go) — the dispatcher should
+// route any future agent name through the spawn path by default, and
+// this is forward-defensive coverage for when one is added.
 func TestDispatchTarget_Matrix(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -61,7 +66,7 @@ func TestRunOne_ServerStub_ReturnsExplicitError(t *testing.T) {
 		context.Background(),
 		slog.Default(),
 		config.AgentConfig{Command: "opencode"},
-		"/tmp",
+		t.TempDir(),
 		"unused prompt",
 		RunOptions{},
 	)

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/Ivantseng123/agentdock/worker/config"
+)
+
+// runOneServer is the entry point for opencode's server-mode run path
+// (long-running `opencode serve` subprocess shared by the worker pool over
+// HTTP/SSE). Stage 1 ships this as a stub so operators who flip
+// `opencode.mode: server` before the Phase 3.2 supervisor lands receive a
+// loud, explicit error from the existing agent-chain failure path rather
+// than a silent degradation.
+//
+// Implementation lands in Stage 2:
+//   - Task 3.2-5 wires the supervisor (Start/Stop/BaseURL/Password).
+//   - Task 3.2-6 wires the HTTP/SSE client (CreateSession, SendPrompt).
+//   - Task 3.2-7 fills this function with the supervisor + client glue.
+//
+// Until those land, `Run`'s agent-chain fallback at runner.go's Run()
+// catches the error, logs the failure, and tries the next provider — so
+// the worker stays alive and ask jobs degrade visibly rather than wedge.
+func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (string, error) {
+	logger.Error(
+		"opencode server-mode 尚未實作 (Stage 2+)",
+		"phase", "失敗",
+		"command", agent.Command,
+		"mode", r.opencodeCfg.Mode,
+		"hint", "Stage 1 PR only ships the dispatcher; flip opencode.mode back to spawn until Stage 2 (Task 3.2-5..3.2-7) lands.",
+	)
+	return "", errors.New("opencode server mode not implemented yet (Stage 2+; flip opencode.mode to spawn or wait for Tasks 3.2-5..3.2-7)")
+}

--- a/worker/agent/opencode_spawn.go
+++ b/worker/agent/opencode_spawn.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+	"github.com/Ivantseng123/agentdock/shared/tracing"
+	"github.com/Ivantseng123/agentdock/worker/config"
+)
+
+// runOneSpawn executes a single agent in the legacy per-job spawn mode:
+// each call exec's a fresh CLI process (e.g. `opencode run`, `claude --print`),
+// pipes prompt via args or stdin, reads stream output, and waits for exit.
+// This is the historical default path and remains in use for:
+//
+//   - All non-opencode agents (claude / codex / gemini) regardless of
+//     `cfg.Opencode.Mode`.
+//   - The opencode agent when `cfg.Opencode.Mode == "spawn"` (the worker
+//     default).
+//
+// The dispatcher in runner.go decides between this and runOneServer.
+// Helpers used here (readOutput, expandExtraArgs, detectBlockedArgs,
+// filterClaudeCodeEnv, tailStderr, blockedArgs, claudeCodeEnvWhitelist,
+// stderrTailLen) live in runner.go so they remain available to the
+// dispatcher path and any future runOne* variant.
+func (r *Runner) runOneSpawn(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (output string, err error) {
+	ctx, span := tracer.Start(ctx, tracing.SpanAgentExecute,
+		trace.WithAttributes(
+			attribute.String("agent_type", filepath.Base(agent.Command)),
+		),
+	)
+	start := time.Now()
+	var stderrLen int
+	exitCode := -1 // -1 = not run / not waited
+	// Closure captures `output`, `err` (named returns), `stderrLen`, and
+	// `exitCode` so span attrs AND status reflect whatever values the
+	// function ends up returning, regardless of which exit branch fires.
+	// Single status-setting site here keeps the cmd.Start / cmd.Wait /
+	// blocked-args / output-file paths consistent — Jaeger filters by
+	// `error=true` would otherwise miss exit-non-zero (the most common
+	// failure mode), since `span.End` alone leaves status Unset.
+	defer func() {
+		attrs := []attribute.KeyValue{
+			attribute.Int64("duration_ms", time.Since(start).Milliseconds()),
+			attribute.Int("stdout_len", len(output)),
+			attribute.Int("stderr_len", stderrLen),
+		}
+		if exitCode >= 0 {
+			attrs = append(attrs, attribute.Int("exit_code", exitCode))
+		}
+		span.SetAttributes(attrs...)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "agent run failed")
+		} else if exitCode > 0 {
+			span.SetStatus(codes.Error, fmt.Sprintf("agent exited %d", exitCode))
+		}
+		if opts.OnExit != nil {
+			opts.OnExit(exitCode)
+		}
+		span.End()
+	}()
+
+	timeout := agent.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	const maxArgLen = 32 * 1024 // 32KB safe limit for command args
+
+	hasPromptPlaceholder := false
+	hasOutputFilePlaceholder := false
+	for _, a := range agent.Args {
+		if strings.Contains(a, "{prompt}") {
+			hasPromptPlaceholder = true
+		}
+		if strings.Contains(a, "{output_file}") {
+			hasOutputFilePlaceholder = true
+		}
+	}
+
+	// Some CLIs (e.g. `codex exec -o <file>`) write their final message to a
+	// path instead of stdout. Allocate a temp file and let the caller read from
+	// it after the process exits; the {output_file} placeholder opts into this.
+	var outputFile string
+	if hasOutputFilePlaceholder {
+		f, err := os.CreateTemp("", "agentdock-output-*.txt")
+		if err != nil {
+			return "", fmt.Errorf("create output file: %w", err)
+		}
+		outputFile = f.Name()
+		_ = f.Close()
+		defer os.Remove(outputFile)
+	}
+
+	useStdin := !hasPromptPlaceholder || len(prompt) >= maxArgLen
+
+	// Single splice site for {extra_args}. Both branches below operate on the
+	// already-expanded slice, so future placeholders / bug fixes only need to
+	// touch one place.
+	expanded := expandExtraArgs(agent.Args, agent.ExtraArgs)
+
+	if blocked := detectBlockedArgs(expanded); len(blocked) > 0 {
+		return "", fmt.Errorf("blocked args rejected: %s", strings.Join(blocked, ", "))
+	}
+
+	var args []string
+	if useStdin && hasPromptPlaceholder {
+		// Prompt too large for args — drop the prompt arg, use stdin instead.
+		// {output_file} still substitutes in place; {prompt}-bearing args are
+		// skipped entirely. {extra_args} is already gone (expandExtraArgs ran
+		// above), so this loop only handles the remaining string-valued slots.
+		for _, a := range expanded {
+			if strings.Contains(a, "{prompt}") {
+				continue
+			}
+			args = append(args, strings.ReplaceAll(a, "{output_file}", outputFile))
+		}
+		logger.Info("Prompt 過大，改用 stdin", "phase", "處理中", "prompt_len", len(prompt))
+	} else {
+		args = substituteStringPlaceholders(expanded, map[string]string{
+			"{prompt}":      prompt,
+			"{output_file}": outputFile,
+		})
+	}
+
+	cmd := exec.CommandContext(ctx, agent.Command, args...)
+	cmd.Dir = workDir
+
+	// Graceful termination: SIGTERM first, then force-kill after 10s.
+	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.WaitDelay = 10 * time.Second
+
+	// Inject secrets as environment variables. Filter inherited env to drop
+	// residual CLAUDE_CODE_* vars from the worker host that could pollute
+	// agent behavior across deployments.
+	env := filterClaudeCodeEnv(os.Environ())
+	if len(opts.Secrets) > 0 {
+		for k, v := range opts.Secrets {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	} else if r.githubToken != "" {
+		env = append(env, fmt.Sprintf("GH_TOKEN=%s", r.githubToken))
+	}
+	cmd.Env = env
+
+	if useStdin {
+		cmd.Stdin = strings.NewReader(prompt)
+	}
+
+	// Use StdoutPipe for streaming reads.
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	if startErr := cmd.Start(); startErr != nil {
+		// Process couldn't even launch (e.g. binary missing) — not a
+		// business failure but a worker-environment problem. Defer above
+		// records this on the span via the named-return `err` capture.
+		return "", startErr
+	}
+
+	// Notify listener of PID.
+	if opts.OnStarted != nil {
+		opts.OnStarted(cmd.Process.Pid, agent.Command)
+	}
+	logger.Info("Agent process 已啟動", "phase", "處理中", "command", agent.Command, "pid", cmd.Process.Pid)
+
+	// Inactivity timer fires SIGTERM when no stream event arrives within
+	// agent.InactivityTimeout. Streaming agents only — non-stream CLIs emit
+	// no events and would be killed prematurely. Disabled when timeout <= 0.
+	var inactivityKilled atomic.Bool
+	eventCallback := opts.OnEvent
+	if agent.InactivityTimeout > 0 && agent.StreamFormat != "" {
+		inactivityTimer := time.AfterFunc(agent.InactivityTimeout, func() {
+			inactivityKilled.Store(true)
+			logger.Warn("Inactivity timeout 觸發，發送 SIGTERM",
+				"phase", "失敗",
+				"command", agent.Command,
+				"timeout", agent.InactivityTimeout)
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		})
+		defer inactivityTimer.Stop()
+		eventCallback = func(evt queue.StreamEvent) {
+			inactivityTimer.Reset(agent.InactivityTimeout)
+			if opts.OnEvent != nil {
+				opts.OnEvent(evt)
+			}
+		}
+	}
+
+	// Read stdout in a goroutine; wait for it before cmd.Wait().
+	// `output` is the named return value; goroutine writes through closure.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		output = readOutput(ctx, stdoutPipe, agent.StreamFormat, eventCallback)
+	}()
+	wg.Wait()
+
+	err = cmd.Wait()
+	stderrLen = stderr.Len()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	} else if err == nil {
+		exitCode = 0
+	}
+	if err != nil {
+		if inactivityKilled.Load() {
+			return "", fmt.Errorf("inactivity timeout after %s (no stream events)", agent.InactivityTimeout)
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout after %s", timeout)
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("exit %d: %s", exitErr.ExitCode(), tailStderr(stderr.String()))
+		}
+		return "", err
+	}
+	if outputFile != "" {
+		data, readErr := os.ReadFile(outputFile)
+		if readErr != nil {
+			return "", fmt.Errorf("read output file: %w", readErr)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	// Exit 0 + empty stdout is silent failure (e.g. opencode run auto-rejecting
+	// a permission ask and cascade-collapsing the session). Surface stderr tail
+	// so the next time this happens, log alone is enough to diagnose without
+	// kubectl exec'ing into the worker.
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		logger.Warn("Agent exit 0 但 stdout 空", "phase", "失敗", "command", agent.Command, "stderr_tail", tailStderr(stderr.String()))
+	}
+	return trimmed, nil
+}

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -5,22 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"syscall"
-	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/Ivantseng123/agentdock/shared/queue"
-	"github.com/Ivantseng123/agentdock/shared/tracing"
 	"github.com/Ivantseng123/agentdock/worker/config"
 )
 
@@ -84,223 +74,15 @@ func (r *Runner) Run(ctx context.Context, logger *slog.Logger, workDir, prompt s
 	return "", fmt.Errorf("all agents failed: %s", strings.Join(errs, "; "))
 }
 
+// runOne dispatches an agent invocation to the right per-mode runner.
+// Today every agent goes through runOneSpawn (the legacy per-job CLI
+// process path). Task 3.2-3 will turn this into a mode-aware dispatcher:
+// when the agent is opencode AND `cfg.Opencode.Mode == "server"`, it
+// routes to runOneServer (long-running `opencode serve` over HTTP/SSE);
+// otherwise it falls through to runOneSpawn. Until then this is a thin
+// indirection — behaviorally identical to the pre-3.2-2 inline path.
 func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (output string, err error) {
-	ctx, span := tracer.Start(ctx, tracing.SpanAgentExecute,
-		trace.WithAttributes(
-			attribute.String("agent_type", filepath.Base(agent.Command)),
-		),
-	)
-	start := time.Now()
-	var stderrLen int
-	exitCode := -1 // -1 = not run / not waited
-	// Closure captures `output`, `err` (named returns), `stderrLen`, and
-	// `exitCode` so span attrs AND status reflect whatever values the
-	// function ends up returning, regardless of which exit branch fires.
-	// Single status-setting site here keeps the cmd.Start / cmd.Wait /
-	// blocked-args / output-file paths consistent — Jaeger filters by
-	// `error=true` would otherwise miss exit-non-zero (the most common
-	// failure mode), since `span.End` alone leaves status Unset.
-	defer func() {
-		attrs := []attribute.KeyValue{
-			attribute.Int64("duration_ms", time.Since(start).Milliseconds()),
-			attribute.Int("stdout_len", len(output)),
-			attribute.Int("stderr_len", stderrLen),
-		}
-		if exitCode >= 0 {
-			attrs = append(attrs, attribute.Int("exit_code", exitCode))
-		}
-		span.SetAttributes(attrs...)
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "agent run failed")
-		} else if exitCode > 0 {
-			span.SetStatus(codes.Error, fmt.Sprintf("agent exited %d", exitCode))
-		}
-		if opts.OnExit != nil {
-			opts.OnExit(exitCode)
-		}
-		span.End()
-	}()
-
-	timeout := agent.Timeout
-	if timeout <= 0 {
-		timeout = 5 * time.Minute
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	const maxArgLen = 32 * 1024 // 32KB safe limit for command args
-
-	hasPromptPlaceholder := false
-	hasOutputFilePlaceholder := false
-	for _, a := range agent.Args {
-		if strings.Contains(a, "{prompt}") {
-			hasPromptPlaceholder = true
-		}
-		if strings.Contains(a, "{output_file}") {
-			hasOutputFilePlaceholder = true
-		}
-	}
-
-	// Some CLIs (e.g. `codex exec -o <file>`) write their final message to a
-	// path instead of stdout. Allocate a temp file and let the caller read from
-	// it after the process exits; the {output_file} placeholder opts into this.
-	var outputFile string
-	if hasOutputFilePlaceholder {
-		f, err := os.CreateTemp("", "agentdock-output-*.txt")
-		if err != nil {
-			return "", fmt.Errorf("create output file: %w", err)
-		}
-		outputFile = f.Name()
-		_ = f.Close()
-		defer os.Remove(outputFile)
-	}
-
-	useStdin := !hasPromptPlaceholder || len(prompt) >= maxArgLen
-
-	// Single splice site for {extra_args}. Both branches below operate on the
-	// already-expanded slice, so future placeholders / bug fixes only need to
-	// touch one place.
-	expanded := expandExtraArgs(agent.Args, agent.ExtraArgs)
-
-	if blocked := detectBlockedArgs(expanded); len(blocked) > 0 {
-		return "", fmt.Errorf("blocked args rejected: %s", strings.Join(blocked, ", "))
-	}
-
-	var args []string
-	if useStdin && hasPromptPlaceholder {
-		// Prompt too large for args — drop the prompt arg, use stdin instead.
-		// {output_file} still substitutes in place; {prompt}-bearing args are
-		// skipped entirely. {extra_args} is already gone (expandExtraArgs ran
-		// above), so this loop only handles the remaining string-valued slots.
-		for _, a := range expanded {
-			if strings.Contains(a, "{prompt}") {
-				continue
-			}
-			args = append(args, strings.ReplaceAll(a, "{output_file}", outputFile))
-		}
-		logger.Info("Prompt 過大，改用 stdin", "phase", "處理中", "prompt_len", len(prompt))
-	} else {
-		args = substituteStringPlaceholders(expanded, map[string]string{
-			"{prompt}":      prompt,
-			"{output_file}": outputFile,
-		})
-	}
-
-	cmd := exec.CommandContext(ctx, agent.Command, args...)
-	cmd.Dir = workDir
-
-	// Graceful termination: SIGTERM first, then force-kill after 10s.
-	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
-	cmd.WaitDelay = 10 * time.Second
-
-	// Inject secrets as environment variables. Filter inherited env to drop
-	// residual CLAUDE_CODE_* vars from the worker host that could pollute
-	// agent behavior across deployments.
-	env := filterClaudeCodeEnv(os.Environ())
-	if len(opts.Secrets) > 0 {
-		for k, v := range opts.Secrets {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-	} else if r.githubToken != "" {
-		env = append(env, fmt.Sprintf("GH_TOKEN=%s", r.githubToken))
-	}
-	cmd.Env = env
-
-	if useStdin {
-		cmd.Stdin = strings.NewReader(prompt)
-	}
-
-	// Use StdoutPipe for streaming reads.
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", fmt.Errorf("stdout pipe: %w", err)
-	}
-
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-
-	if startErr := cmd.Start(); startErr != nil {
-		// Process couldn't even launch (e.g. binary missing) — not a
-		// business failure but a worker-environment problem. Defer above
-		// records this on the span via the named-return `err` capture.
-		return "", startErr
-	}
-
-	// Notify listener of PID.
-	if opts.OnStarted != nil {
-		opts.OnStarted(cmd.Process.Pid, agent.Command)
-	}
-	logger.Info("Agent process 已啟動", "phase", "處理中", "command", agent.Command, "pid", cmd.Process.Pid)
-
-	// Inactivity timer fires SIGTERM when no stream event arrives within
-	// agent.InactivityTimeout. Streaming agents only — non-stream CLIs emit
-	// no events and would be killed prematurely. Disabled when timeout <= 0.
-	var inactivityKilled atomic.Bool
-	eventCallback := opts.OnEvent
-	if agent.InactivityTimeout > 0 && agent.StreamFormat != "" {
-		inactivityTimer := time.AfterFunc(agent.InactivityTimeout, func() {
-			inactivityKilled.Store(true)
-			logger.Warn("Inactivity timeout 觸發，發送 SIGTERM",
-				"phase", "失敗",
-				"command", agent.Command,
-				"timeout", agent.InactivityTimeout)
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-		})
-		defer inactivityTimer.Stop()
-		eventCallback = func(evt queue.StreamEvent) {
-			inactivityTimer.Reset(agent.InactivityTimeout)
-			if opts.OnEvent != nil {
-				opts.OnEvent(evt)
-			}
-		}
-	}
-
-	// Read stdout in a goroutine; wait for it before cmd.Wait().
-	// `output` is the named return value; goroutine writes through closure.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		output = readOutput(ctx, stdoutPipe, agent.StreamFormat, eventCallback)
-	}()
-	wg.Wait()
-
-	err = cmd.Wait()
-	stderrLen = stderr.Len()
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		exitCode = exitErr.ExitCode()
-	} else if err == nil {
-		exitCode = 0
-	}
-	if err != nil {
-		if inactivityKilled.Load() {
-			return "", fmt.Errorf("inactivity timeout after %s (no stream events)", agent.InactivityTimeout)
-		}
-		if ctx.Err() == context.DeadlineExceeded {
-			return "", fmt.Errorf("timeout after %s", timeout)
-		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("exit %d: %s", exitErr.ExitCode(), tailStderr(stderr.String()))
-		}
-		return "", err
-	}
-	if outputFile != "" {
-		data, readErr := os.ReadFile(outputFile)
-		if readErr != nil {
-			return "", fmt.Errorf("read output file: %w", readErr)
-		}
-		return strings.TrimSpace(string(data)), nil
-	}
-	// Exit 0 + empty stdout is silent failure (e.g. opencode run auto-rejecting
-	// a permission ask and cascade-collapsing the session). Surface stderr tail
-	// so the next time this happens, log alone is enough to diagnose without
-	// kubectl exec'ing into the worker.
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
-		logger.Warn("Agent exit 0 但 stdout 空", "phase", "失敗", "command", agent.Command, "stderr_tail", tailStderr(stderr.String()))
-	}
-	return trimmed, nil
+	return r.runOneSpawn(ctx, logger, agent, workDir, prompt, opts)
 }
 
 // readOutput routes stdout through the appropriate reader based on the

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -31,8 +31,9 @@ type RunOptions struct {
 }
 
 type Runner struct {
-	agents      []config.AgentConfig
-	githubToken string
+	agents       []config.AgentConfig
+	githubToken  string
+	opencodeCfg  config.OpencodeConfig
 }
 
 func NewRunner(agents []config.AgentConfig) *Runner {
@@ -50,6 +51,7 @@ func NewRunnerFromConfig(cfg *config.Config) *Runner {
 	}
 	runner := NewRunner(chain)
 	runner.githubToken = cfg.GitHub.Token
+	runner.opencodeCfg = cfg.Opencode
 	return runner
 }
 
@@ -74,14 +76,38 @@ func (r *Runner) Run(ctx context.Context, logger *slog.Logger, workDir, prompt s
 	return "", fmt.Errorf("all agents failed: %s", strings.Join(errs, "; "))
 }
 
-// runOne dispatches an agent invocation to the right per-mode runner.
-// Today every agent goes through runOneSpawn (the legacy per-job CLI
-// process path). Task 3.2-3 will turn this into a mode-aware dispatcher:
-// when the agent is opencode AND `cfg.Opencode.Mode == "server"`, it
-// routes to runOneServer (long-running `opencode serve` over HTTP/SSE);
-// otherwise it falls through to runOneSpawn. Until then this is a thin
-// indirection — behaviorally identical to the pre-3.2-2 inline path.
+// dispatchTarget returns the name of the per-mode runner this agent call
+// should route to. Pure decision function — no side effects, no exec —
+// so the dispatch matrix can be unit-tested without depending on a real
+// opencode/claude/codex/gemini binary on PATH.
+//
+// Routing rule: opencode + Mode=server → "server". Every other
+// combination → "spawn". This includes any non-opencode agent regardless
+// of mode, opencode with Mode unset (zero value), and opencode with
+// Mode=="spawn".
+//
+// The Command == "opencode" check matches the built-in agent definition
+// at worker/config/builtin_agents.go. Operator overrides that rename
+// `command:` to a wrapper script will skip the server-mode dispatch and
+// fall through to spawn — acceptable for Stage 1 per the manifest's
+// §1.3 trade-off; revisit if an operator actually hits this.
+func (r *Runner) dispatchTarget(agent config.AgentConfig) string {
+	if agent.Command == "opencode" && r.opencodeCfg.Mode == config.OpencodeModeServer {
+		return "server"
+	}
+	return "spawn"
+}
+
+// runOne dispatches an agent invocation based on dispatchTarget. Stage 1
+// ships runOneServer as a stub that errors out, so even when the
+// dispatcher picks "server" the worker stays alive via Run's
+// agent-chain failure path (the stub error surfaces, next provider in
+// the chain takes over). Stage 2's lazy supervisor lands without
+// further plumbing changes here.
 func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (output string, err error) {
+	if r.dispatchTarget(agent) == "server" {
+		return r.runOneServer(ctx, logger, agent, workDir, prompt, opts)
+	}
 	return r.runOneSpawn(ctx, logger, agent, workDir, prompt, opts)
 }
 

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -31,9 +31,9 @@ type RunOptions struct {
 }
 
 type Runner struct {
-	agents       []config.AgentConfig
-	githubToken  string
-	opencodeCfg  config.OpencodeConfig
+	agents      []config.AgentConfig
+	githubToken string
+	opencodeCfg config.OpencodeConfig
 }
 
 func NewRunner(agents []config.AgentConfig) *Runner {
@@ -102,8 +102,10 @@ func (r *Runner) dispatchTarget(agent config.AgentConfig) string {
 // ships runOneServer as a stub that errors out, so even when the
 // dispatcher picks "server" the worker stays alive via Run's
 // agent-chain failure path (the stub error surfaces, next provider in
-// the chain takes over). Stage 2's lazy supervisor lands without
-// further plumbing changes here.
+// the chain takes over). The dispatcher's signature won't need to
+// change for Stage 2 — but Stage 2 will add new Runner fields (e.g. a
+// `*Supervisor`) and populate them inside `NewRunnerFromConfig`, so
+// Runner construction *will* evolve when the real server-mode lands.
 func (r *Runner) runOne(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (output string, err error) {
 	if r.dispatchTarget(agent) == "server" {
 		return r.runOneServer(ctx, logger, agent, workDir, prompt, opts)

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Queue        QueueConfig            `yaml:"queue"`
 	Tracing      TracingConfig          `yaml:"tracing"`
 	Redis        RedisConfig            `yaml:"redis"`
+	Opencode     OpencodeConfig         `yaml:"opencode"`
 	SecretKey    string                 `yaml:"secret_key"`
 	Secrets      map[string]string      `yaml:"secrets"`
 }
@@ -114,4 +115,28 @@ type RedisConfig struct {
 	Password string `yaml:"password"`
 	DB       int    `yaml:"db"`
 	TLS      bool   `yaml:"tls"`
+}
+
+// Opencode runtime mode. Server is opt-in (Phase 3.2 work); Spawn is the
+// historical default and remains the worker's behavior when no `opencode:`
+// block is present in worker.yaml.
+const (
+	OpencodeModeSpawn  = "spawn"
+	OpencodeModeServer = "server"
+)
+
+// OpencodeConfig is the top-level worker-scope block that influences how the
+// opencode agent is invoked. Only meaningful when "opencode" appears in
+// Providers; other agents (claude / codex / gemini) ignore this block.
+//
+// Mode picks between the legacy `opencode run` per-job process (spawn) and
+// the Phase 3.2 long-running `opencode serve` subprocess shared by the
+// worker pool (server). IdleTimeout governs the lazy supervisor's auto-stop
+// window in server mode. StorageDir is the isolated `XDG_DATA_HOME` for the
+// supervisor's child opencode; empty means "resolve at runtime" — Stage 2
+// supervisor owns the resolution.
+type OpencodeConfig struct {
+	Mode        string        `yaml:"mode"`
+	IdleTimeout time.Duration `yaml:"idle_timeout"`
+	StorageDir  string        `yaml:"storage_dir"`
 }

--- a/worker/config/defaults.go
+++ b/worker/config/defaults.go
@@ -69,6 +69,14 @@ func ApplyDefaults(cfg *Config) {
 	if cfg.RepoCache.MaxAge <= 0 {
 		cfg.RepoCache.MaxAge = 10 * time.Minute
 	}
+	if cfg.Opencode.Mode == "" {
+		cfg.Opencode.Mode = OpencodeModeSpawn
+	}
+	if cfg.Opencode.IdleTimeout <= 0 {
+		cfg.Opencode.IdleTimeout = 5 * time.Minute
+	}
+	// StorageDir defaults to empty as a sentinel for "resolve at runtime";
+	// the Stage 2 supervisor will choose a XDG_DATA_HOME path when it spawns.
 	resolveSecrets(cfg)
 }
 

--- a/worker/config/opencode_config_test.go
+++ b/worker/config/opencode_config_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpencodeConfig_Defaults_WhenBlockAbsent(t *testing.T) {
+	cfg := loadFromString(t, `
+count: 1
+agents:
+  opencode:
+    command: opencode
+`)
+	if cfg.Opencode.Mode != OpencodeModeSpawn {
+		t.Errorf("Mode default = %q, want %q", cfg.Opencode.Mode, OpencodeModeSpawn)
+	}
+	if cfg.Opencode.IdleTimeout != 5*time.Minute {
+		t.Errorf("IdleTimeout default = %s, want 5m0s", cfg.Opencode.IdleTimeout)
+	}
+	if cfg.Opencode.StorageDir != "" {
+		t.Errorf("StorageDir default = %q, want empty (runtime-resolved)", cfg.Opencode.StorageDir)
+	}
+}
+
+func TestOpencodeConfig_CustomValuesFromYAML(t *testing.T) {
+	cfg := loadFromString(t, `
+count: 1
+opencode:
+  mode: server
+  idle_timeout: 90s
+  storage_dir: /var/lib/agentdock/opencode
+agents:
+  opencode:
+    command: opencode
+`)
+	if cfg.Opencode.Mode != OpencodeModeServer {
+		t.Errorf("Mode = %q, want %q", cfg.Opencode.Mode, OpencodeModeServer)
+	}
+	if cfg.Opencode.IdleTimeout != 90*time.Second {
+		t.Errorf("IdleTimeout = %s, want 1m30s", cfg.Opencode.IdleTimeout)
+	}
+	if cfg.Opencode.StorageDir != "/var/lib/agentdock/opencode" {
+		t.Errorf("StorageDir = %q, want /var/lib/agentdock/opencode", cfg.Opencode.StorageDir)
+	}
+}
+
+func TestValidate_OpencodeMode_InvalidRejected(t *testing.T) {
+	cfg := baseValidCfg()
+	cfg.Opencode.Mode = "garbage"
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatalf("expected validation error for mode=garbage, got nil")
+	}
+	if !strings.Contains(err.Error(), "opencode.mode") {
+		t.Errorf("error did not mention opencode.mode: %v", err)
+	}
+}
+
+func TestValidate_OpencodeMode_SpawnAndServerAccepted(t *testing.T) {
+	for _, mode := range []string{OpencodeModeSpawn, OpencodeModeServer} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := baseValidCfg()
+			cfg.Opencode.Mode = mode
+			if err := Validate(cfg); err != nil {
+				t.Errorf("mode=%q should be valid; got %v", mode, err)
+			}
+		})
+	}
+}
+
+func TestValidate_OpencodeIdleTimeout_NonPositiveRejected(t *testing.T) {
+	cfg := baseValidCfg()
+	cfg.Opencode.IdleTimeout = 0
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatalf("expected validation error for idle_timeout=0, got nil")
+	}
+	if !strings.Contains(err.Error(), "opencode.idle_timeout") {
+		t.Errorf("error did not mention opencode.idle_timeout: %v", err)
+	}
+}

--- a/worker/config/validate.go
+++ b/worker/config/validate.go
@@ -42,6 +42,16 @@ func Validate(cfg *Config) error {
 		errs = append(errs, "repo_cache.max_age must be > 0")
 	}
 
+	switch cfg.Opencode.Mode {
+	case OpencodeModeSpawn, OpencodeModeServer:
+		// ok
+	default:
+		errs = append(errs, fmt.Sprintf("opencode.mode must be %q or %q, got %q", OpencodeModeSpawn, OpencodeModeServer, cfg.Opencode.Mode))
+	}
+	if cfg.Opencode.IdleTimeout <= 0 {
+		errs = append(errs, "opencode.idle_timeout must be > 0")
+	}
+
 	// NicknamePool: trim-normalise in place, then check length.
 	for i, raw := range cfg.NicknamePool {
 		trimmed := strings.TrimSpace(raw)


### PR DESCRIPTION
## Summary

Stage 1 of 4 for Phase 3.2 (plan: \`docs/specs/opencode-server-mode-plan.md\`). **No behavior change in default \`mode: spawn\`.** Three logical units, one per commit:

- **Task 3.2-1 \`feat(worker/config)\` \`095f8a1\`** — Top-level \`opencode:\` block (\`mode\` enum, \`idle_timeout\` 5m default, \`storage_dir\` runtime-resolved). Defaults + enum validation + 5 new test cases.
- **Task 3.2-2 \`refactor(worker/agent)\` \`0733d83\`** — Move \`runOne\` body to \`worker/agent/opencode_spawn.go\` as \`runOneSpawn\`. Behavior-preserving (verified byte-identical body diff). Helpers stay in \`runner.go\` because they're not opencode-specific.
- **Task 3.2-3 \`feat(worker/agent)\` \`9607f79\`** — \`runOne\` becomes mode-aware dispatcher via new \`dispatchTarget(agent)\` function. \`runOneServer\` ships as a stub returning \`errors.New(\"opencode server mode not implemented yet ...\")\`. \`Runner.opencodeCfg\` populated by \`NewRunnerFromConfig\`. New 12-case dispatch matrix test.
- **Cross-review nits \`refactor(worker/agent)\` \`73791a8\`** — Addresses the two 🟡 Major (gofmt + doc-comment softening) and two 🟢 Minor (\`t.TempDir\`, gemini-coverage comment) from \`cross-review pr\`. Zero 🔴 Critical findings.

## Verification

- \`go -C worker build ./...\` — clean
- \`go -C worker test ./...\` — all packages green (\`worker/agent\`, \`worker/config\`, \`worker/integration\`, \`worker/pool\`, \`worker/prompt\`)
- \`go test ./test/...\` (import_direction_test.go) — green
- \`commitlint --last\` on each of the four commits — exit 0
- \`gofmt -d worker/agent/\` clean on my touched files (note: pre-existing \`worker/config/env.go\` gofmt drift on main, out of scope)

## Stage 1 design contracts

- **Default \`mode: spawn\` byte-identical to pre-PR behavior.** No \`worker.yaml\` migration needed. Operator's existing config (no \`opencode:\` block) gets defaults \`{mode: \"spawn\", idle_timeout: 5m, storage_dir: \"\"}\` from \`ApplyDefaults\`.
- **\`mode: server\` opt-in returns an explicit, actionable error today.** The stub error names Stage 2 task IDs (3.2-5..3.2-7) and tells the operator how to recover (\"flip opencode.mode to spawn\"). Surfaces through \`Run\`'s agent-chain failure path — worker stays alive, doesn't wedge.
- **Dispatcher is a pure function (\`dispatchTarget\`).** Lets the 12-case matrix test cover \`{claude, codex, opencode, gemini} × {spawn, server, \"\"}\` without depending on any binary being on PATH at test time.
- **Forward-defensive zero-value coverage.** Empty \`Mode\` (zero value, e.g. \`NewRunner\` direct construction) routes to spawn — a partially constructed \`Runner\` cannot silently end up in server mode.

## Cross-review

\`cross-review pr\` ran against the active manifest at \`.claude/manifest/opencode-server-mode-stage-1.md\`:
- 🔴 Critical: **0**
- 🟡 Major: 2 (gofmt alignment, doc-comment overstatement) — **both fixed in commit \`73791a8\`**
- 🟢 Minor: 4 — two fixed (TempDir, gemini-coverage comment); two deferred (plan body \"8 cases\" → \"12 cases\" cosmetic update is out-of-scope for this PR; \`opencode_spawn.go\` filename rename can wait until Stage 2+ if no other opencode-specific spawn logic appears).

## What's NOT in this PR (deferred to later Stages)

- Production server supervisor — Task 3.2-4 (version capability check) + 3.2-5..3.2-7 land in Stage 2.
- Lazy lifecycle / crash recovery / SIGTERM teardown — Stage 3.
- Performance benchmark + init-template docs — Stage 4.

## Test plan

- [ ] CI green (test job, commitlint)
- [ ] Manual: \`agentdock worker\` with current \`worker.yaml\` (no \`opencode:\` block) runs identically to pre-PR — \`mode\` resolves to \`spawn\`, opencode jobs go through \`runOneSpawn\`.
- [ ] Manual: \`agentdock worker\` with \`worker.yaml\` containing \`opencode:\n  mode: server\` errors out per-job with the stub message; worker stays alive; chain fallback kicks in if other providers configured.
- [ ] Confirm \`grep -rn 'opencode' worker/config/builtin_agents.go\` still wires the agent correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)