### PR TITLE
feat(worker): opencode-server-mode Stage 2 — server-mode happy path (Tasks 3.2-4..3.2-7)

### DIFF
--- a/worker/agent/opencode_dispatch_test.go
+++ b/worker/agent/opencode_dispatch_test.go
@@ -53,12 +53,16 @@ func TestDispatchTarget_Matrix(t *testing.T) {
 	}
 }
 
-// TestRunOne_ServerStub_ReturnsExplicitError walks the dispatcher and the
-// stub end-to-end: when opencode+server is configured, runOne must call
-// runOneServer, which (in Stage 1) returns an error mentioning the
-// not-implemented state. This proves the dispatcher actually reaches the
-// stub rather than silently falling through to spawn.
-func TestRunOne_ServerStub_ReturnsExplicitError(t *testing.T) {
+// TestRunOne_Server_NilSupervisor_ReturnsExplicitError walks the
+// dispatcher and the nil-supervisor guard end-to-end: when opencode+
+// server is configured but the Runner has no Supervisor (e.g. Runner
+// constructed via NewRunner directly, or boot failed to attach one),
+// runOne must call runOneServer, which then surfaces an explicit
+// "supervisor not initialized" error rather than panicking on nil
+// dereference. This proves the dispatcher actually reaches
+// runOneServer and that the Stage 2 implementation's defensive guard
+// fires correctly.
+func TestRunOne_Server_NilSupervisor_ReturnsExplicitError(t *testing.T) {
 	r := &Runner{
 		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
 	}
@@ -71,10 +75,10 @@ func TestRunOne_ServerStub_ReturnsExplicitError(t *testing.T) {
 		RunOptions{},
 	)
 	if err == nil {
-		t.Fatal("expected stub error, got nil")
+		t.Fatal("expected nil-supervisor error, got nil")
 	}
-	if !strings.Contains(err.Error(), "server mode not implemented") {
-		t.Errorf("error %q does not mention 'server mode not implemented'", err.Error())
+	if !strings.Contains(err.Error(), "supervisor not initialized") {
+		t.Errorf("error %q does not mention 'supervisor not initialized'", err.Error())
 	}
 }
 

--- a/worker/agent/opencode_events.go
+++ b/worker/agent/opencode_events.go
@@ -38,12 +38,21 @@ type opencodeBusEventEnvelope struct {
 // `text` (final assistant answer), `tool` (tool_use events), and
 // `step-finish` (token counters + cost). `reasoning` and `step-start`
 // are recognized but produce no event.
+//
+// State.Status is required to gate `tool` part emission: opencode
+// upstream emits `message.part.updated` for `pending` → `running` →
+// `completed` (or `error`) transitions of the same tool call. We
+// follow opencode/src/cli/cmd/run.ts:623's gate and only emit a
+// downstream `tool_use` event on the terminal `completed`/`error`
+// status, so Slack counters reflect one event per tool call instead
+// of three.
 type opencodeAssistantPart struct {
-	Type   string `json:"type"`
-	Text   string `json:"text,omitempty"`
-	Tool   string `json:"tool,omitempty"`
-	State  *struct {
-		Input map[string]any `json:"input"`
+	Type  string `json:"type"`
+	Text  string `json:"text,omitempty"`
+	Tool  string `json:"tool,omitempty"`
+	State *struct {
+		Status string         `json:"status,omitempty"`
+		Input  map[string]any `json:"input,omitempty"`
 	} `json:"state,omitempty"`
 	Tokens *struct {
 		Input  int `json:"input"`
@@ -67,26 +76,33 @@ type opencodeMessagePartUpdated struct {
 // decodeOpencodeBusEvent translates one raw BusEvent JSON line into a
 // `queue.StreamEvent`. Returns (ev, true, nil) when the event maps to a
 // downstream-visible signal; (zero, false, nil) when the event is a
-// no-op (heartbeats, recognized-but-irrelevant types); error only on
-// JSON-shape failures.
+// no-op (heartbeats, intermediate tool states, recognized-but-irrelevant
+// types); error only on JSON-shape failures.
 //
 // Mapping mirrors `ReadStreamJSONOpencode`'s taxonomy so consumers can
 // stay parser-agnostic:
 //
 //   - server.connected, server.heartbeat, message.updated,
-//     session.status, session.error → no-op for Stage 2 happy path.
+//     session.status, message.part.delta → no-op.
+//   - session.error → emit `error` event so Stage 3 Task 3.2-9 / 3.2-11
+//     can read it for retry / failure classification without re-touching
+//     the decoder. Stage 2 happy path treats `error` as informational
+//     (POST response is still the authoritative completion signal).
 //   - message.part.updated + part.type=text → message_delta (TextBytes
 //     = len(text)). Mirrors the per-delta event ReadStreamJSONOpencode
 //     emits for each `text` NDJSON line.
-//   - message.part.updated + part.type=tool → tool_use, with ToolName
-//     pulled from part.tool and ToolInputFirstArg from part.state.input
-//     using the same priority order as extractFirstArg in
-//     shared/queue/stream.go.
+//   - message.part.updated + part.type=tool → tool_use, **only when
+//     part.state.status ∈ {completed, error}**. Intermediate pending /
+//     running updates are dropped so a single tool call yields exactly
+//     one downstream tool_use (matching opencode run.ts:623). Without
+//     this gate, Slack's status display inflates `toolCalls` /
+//     `filesRead` ~3x per tool call.
 //   - message.part.updated + part.type=step-finish → result, carrying
-//     part.tokens and part.cost. (ReadStreamJSONOpencode synthesizes a
-//     terminal result event after the scanner closes; the BusEvent
-//     stream emits one per step. Both shapes downstream-equivalent
-//     for Slack render's cost / token totals.)
+//     part.tokens and part.cost. Server emits one of these per step;
+//     the SSE consumer in opencode_http.go accumulates them and emits
+//     ONE terminal `result` event at stream end so downstream
+//     `worker/pool/status.go` (which OVERWRITES on `result`) records
+//     cumulative tokens, not just the last step's.
 //
 // Bug A detection (Task 3.2-11) will examine `finish=other` +
 // `tokens.output=0` on the POST /session/{id}/message response, not on
@@ -98,9 +114,16 @@ func decodeOpencodeBusEvent(raw []byte) (queue.StreamEvent, bool, error) {
 	}
 	switch env.Type {
 	case "server.connected", "server.heartbeat",
-		"message.updated", "session.status", "session.error",
+		"message.updated", "session.status",
 		"message.part.delta":
 		return queue.StreamEvent{}, false, nil
+	case "session.error":
+		// Surface upstream errors as a typed event so Stage 3's
+		// retry / Bug A classifier can see them. Stage 2 happy path
+		// doesn't act on this beyond letting it ride to downstream
+		// consumers (which currently ignore unknown event types,
+		// matching spawn-mode's behavior on the same upstream noise).
+		return queue.StreamEvent{Type: "error"}, true, nil
 	case "message.part.updated":
 		var updated opencodeMessagePartUpdated
 		if err := json.Unmarshal(env.Properties, &updated); err != nil {
@@ -121,14 +144,19 @@ func mapOpencodePart(part opencodeAssistantPart) (queue.StreamEvent, bool) {
 			TextBytes: len(part.Text),
 		}, true
 	case "tool":
-		var input map[string]any
-		if part.State != nil {
-			input = part.State.Input
+		// Gate on terminal status only (opencode run.ts:623). Pending /
+		// running intermediates yield empty input + would inflate
+		// downstream counters 3x.
+		if part.State == nil {
+			return queue.StreamEvent{}, false
+		}
+		if part.State.Status != "completed" && part.State.Status != "error" {
+			return queue.StreamEvent{}, false
 		}
 		return queue.StreamEvent{
 			Type:              "tool_use",
 			ToolName:          titleCaseFirstASCII(part.Tool),
-			ToolInputFirstArg: firstArgFromInput(input),
+			ToolInputFirstArg: firstArgFromInput(part.State.Input),
 		}, true
 	case "step-finish":
 		event := queue.StreamEvent{

--- a/worker/agent/opencode_events.go
+++ b/worker/agent/opencode_events.go
@@ -1,0 +1,181 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// SSE event decoder for `opencode serve`'s `/event` endpoint.
+//
+// Spec line 88 / plan Task 3.2-6 say "feeds inner JSON to
+// shared/queue/stream.go ReadStreamJSONOpencode". That description is
+// schema-blind: `opencode run --format json` emits NDJSON with
+// `{"type":"text","part":{...}}` at root, but `opencode serve`'s SSE
+// emits BusEvent envelopes — `{"id":..., "type":"message.part.updated",
+// "properties":{"part":{...}}}`. The POC (refs/heads/poc/opencode-server-
+// mode cmd/dev/poc-opencode-server/events.go) already discovered this
+// and wrote a dedicated decoder. Stage 2 follows the POC's approach
+// rather than the plan's literal wording — see Stage 2 manifest §3.5
+// for the cross-source reconciliation note.
+//
+// Output is `shared/queue.StreamEvent` so downstream consumers (Slack
+// render, status accumulator) stay unchanged; only the input parser
+// differs between spawn mode (run --format json NDJSON) and server
+// mode (BusEvent SSE).
+
+// opencodeBusEventEnvelope is the outer SSE payload from `/event`. We
+// only care about `type` and `properties` for Stage 2 happy path; the
+// `id` field is ignored.
+type opencodeBusEventEnvelope struct {
+	Type       string          `json:"type"`
+	Properties json.RawMessage `json:"properties"`
+}
+
+// opencodeAssistantPart mirrors the per-part shape inside
+// `message.part.updated` events. opencode emits `tool` / `text` /
+// `step-start` / `step-finish` part types; Stage 2 only acts on
+// `text` (final assistant answer), `tool` (tool_use events), and
+// `step-finish` (token counters + cost). `reasoning` and `step-start`
+// are recognized but produce no event.
+type opencodeAssistantPart struct {
+	Type   string `json:"type"`
+	Text   string `json:"text,omitempty"`
+	Tool   string `json:"tool,omitempty"`
+	State  *struct {
+		Input map[string]any `json:"input"`
+	} `json:"state,omitempty"`
+	Tokens *struct {
+		Input  int `json:"input"`
+		Output int `json:"output"`
+	} `json:"tokens,omitempty"`
+	Cost float64 `json:"cost"`
+	Time *struct {
+		End *int64 `json:"end,omitempty"`
+	} `json:"time,omitempty"`
+}
+
+// opencodeMessagePartUpdated is the body shape of the
+// `message.part.updated` BusEvent. SessionID may be absent in some
+// shapes; caller is responsible for cross-checking sessionID externally
+// if filtering is needed (Stage 2 happy path runs one session per
+// runOneServer call, so cross-talk isn't a concern yet).
+type opencodeMessagePartUpdated struct {
+	Part opencodeAssistantPart `json:"part"`
+}
+
+// decodeOpencodeBusEvent translates one raw BusEvent JSON line into a
+// `queue.StreamEvent`. Returns (ev, true, nil) when the event maps to a
+// downstream-visible signal; (zero, false, nil) when the event is a
+// no-op (heartbeats, recognized-but-irrelevant types); error only on
+// JSON-shape failures.
+//
+// Mapping mirrors `ReadStreamJSONOpencode`'s taxonomy so consumers can
+// stay parser-agnostic:
+//
+//   - server.connected, server.heartbeat, message.updated,
+//     session.status, session.error → no-op for Stage 2 happy path.
+//   - message.part.updated + part.type=text → message_delta (TextBytes
+//     = len(text)). Mirrors the per-delta event ReadStreamJSONOpencode
+//     emits for each `text` NDJSON line.
+//   - message.part.updated + part.type=tool → tool_use, with ToolName
+//     pulled from part.tool and ToolInputFirstArg from part.state.input
+//     using the same priority order as extractFirstArg in
+//     shared/queue/stream.go.
+//   - message.part.updated + part.type=step-finish → result, carrying
+//     part.tokens and part.cost. (ReadStreamJSONOpencode synthesizes a
+//     terminal result event after the scanner closes; the BusEvent
+//     stream emits one per step. Both shapes downstream-equivalent
+//     for Slack render's cost / token totals.)
+//
+// Bug A detection (Task 3.2-11) will examine `finish=other` +
+// `tokens.output=0` on the POST /session/{id}/message response, not on
+// SSE events, so it doesn't live here.
+func decodeOpencodeBusEvent(raw []byte) (queue.StreamEvent, bool, error) {
+	var env opencodeBusEventEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return queue.StreamEvent{}, false, err
+	}
+	switch env.Type {
+	case "server.connected", "server.heartbeat",
+		"message.updated", "session.status", "session.error",
+		"message.part.delta":
+		return queue.StreamEvent{}, false, nil
+	case "message.part.updated":
+		var updated opencodeMessagePartUpdated
+		if err := json.Unmarshal(env.Properties, &updated); err != nil {
+			return queue.StreamEvent{}, false, err
+		}
+		event, ok := mapOpencodePart(updated.Part)
+		return event, ok, nil
+	default:
+		return queue.StreamEvent{}, false, nil
+	}
+}
+
+func mapOpencodePart(part opencodeAssistantPart) (queue.StreamEvent, bool) {
+	switch part.Type {
+	case "text":
+		return queue.StreamEvent{
+			Type:      "message_delta",
+			TextBytes: len(part.Text),
+		}, true
+	case "tool":
+		var input map[string]any
+		if part.State != nil {
+			input = part.State.Input
+		}
+		return queue.StreamEvent{
+			Type:              "tool_use",
+			ToolName:          titleCaseFirstASCII(part.Tool),
+			ToolInputFirstArg: firstArgFromInput(input),
+		}, true
+	case "step-finish":
+		event := queue.StreamEvent{
+			Type:    "result",
+			CostUSD: part.Cost,
+		}
+		if part.Tokens != nil {
+			event.InputTokens = part.Tokens.Input
+			event.OutputTokens = part.Tokens.Output
+		}
+		return event, true
+	}
+	return queue.StreamEvent{}, false
+}
+
+// titleCaseFirstASCII normalizes lowercase tool names (opencode
+// convention) to PascalCase so the worker-side Slack render's
+// hardcoded "Read" / "Bash" / "Grep" filters match. Same logic as
+// shared/queue/stream.go's titleCaseTool; duplicated here to keep the
+// worker/agent package free of any private-to-shared/queue helper.
+func titleCaseFirstASCII(name string) string {
+	if name == "" || name[0] < 'a' || name[0] > 'z' {
+		return name
+	}
+	return string(name[0]-'a'+'A') + name[1:]
+}
+
+// firstArgFromInput picks the first non-empty string from a tool input
+// map using the same priority order as shared/queue/stream.go's
+// extractFirstArg (file_path/filePath/command/pattern/path/url),
+// truncated to 100 runes.
+func firstArgFromInput(input map[string]any) string {
+	if input == nil {
+		return ""
+	}
+	for _, k := range []string{"file_path", "filePath", "command", "pattern", "path", "url"} {
+		if v, ok := input[k].(string); ok && v != "" {
+			return truncateRunesShared(v, 100)
+		}
+	}
+	return ""
+}
+
+func truncateRunesShared(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/worker/agent/opencode_events_test.go
+++ b/worker/agent/opencode_events_test.go
@@ -1,0 +1,179 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeOpencodeBusEvent_NoOps(t *testing.T) {
+	cases := []string{
+		`{"type":"server.connected","properties":{}}`,
+		`{"type":"server.heartbeat","properties":{}}`,
+		`{"type":"message.updated","properties":{"info":{"id":"m1","role":"assistant"}}}`,
+		`{"type":"session.status","properties":{"sessionID":"s1","status":{"type":"idle"}}}`,
+		`{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"X"}}}`,
+		`{"type":"message.part.delta","properties":{"field":"text","delta":"abc"}}`,
+		`{"type":"unknown.future.event","properties":{}}`,
+	}
+	for _, in := range cases {
+		t.Run(in[:min(40, len(in))], func(t *testing.T) {
+			ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok {
+				t.Errorf("expected ok=false for %q, got ev=%+v", in, ev)
+			}
+		})
+	}
+}
+
+func TestDecodeOpencodeBusEvent_TextPartUpdate(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"text","text":"hello world"}}}`
+	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for text part update")
+	}
+	if ev.Type != "message_delta" {
+		t.Errorf("Type = %q, want message_delta", ev.Type)
+	}
+	if ev.TextBytes != len("hello world") {
+		t.Errorf("TextBytes = %d, want %d", ev.TextBytes, len("hello world"))
+	}
+}
+
+func TestDecodeOpencodeBusEvent_ToolPartUpdate(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hostname"}}}}}`
+	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for tool part update")
+	}
+	if ev.Type != "tool_use" {
+		t.Errorf("Type = %q, want tool_use", ev.Type)
+	}
+	if ev.ToolName != "Read" {
+		t.Errorf("ToolName = %q, want Read (Pascal-cased)", ev.ToolName)
+	}
+	if ev.ToolInputFirstArg != "/etc/hostname" {
+		t.Errorf("ToolInputFirstArg = %q, want /etc/hostname", ev.ToolInputFirstArg)
+	}
+}
+
+func TestDecodeOpencodeBusEvent_ToolWithoutState(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"bash"}}}`
+	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for tool part update without state")
+	}
+	if ev.Type != "tool_use" {
+		t.Errorf("Type = %q, want tool_use", ev.Type)
+	}
+	if ev.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want Bash", ev.ToolName)
+	}
+	if ev.ToolInputFirstArg != "" {
+		t.Errorf("ToolInputFirstArg = %q, want empty (no input)", ev.ToolInputFirstArg)
+	}
+}
+
+func TestDecodeOpencodeBusEvent_StepFinish(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":120,"output":80},"cost":0.0023}}}`
+	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for step-finish")
+	}
+	if ev.Type != "result" {
+		t.Errorf("Type = %q, want result", ev.Type)
+	}
+	if ev.InputTokens != 120 || ev.OutputTokens != 80 {
+		t.Errorf("tokens = (%d,%d), want (120,80)", ev.InputTokens, ev.OutputTokens)
+	}
+	if ev.CostUSD != 0.0023 {
+		t.Errorf("CostUSD = %v, want 0.0023", ev.CostUSD)
+	}
+}
+
+func TestDecodeOpencodeBusEvent_ReasoningAndStepStartIgnored(t *testing.T) {
+	cases := []string{
+		`{"type":"message.part.updated","properties":{"part":{"type":"reasoning","text":"thinking..."}}}`,
+		`{"type":"message.part.updated","properties":{"part":{"type":"step-start"}}}`,
+	}
+	for _, in := range cases {
+		t.Run(in[:min(60, len(in))], func(t *testing.T) {
+			_, ok, err := decodeOpencodeBusEvent([]byte(in))
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if ok {
+				t.Errorf("expected ok=false for unsupported part type")
+			}
+		})
+	}
+}
+
+func TestDecodeOpencodeBusEvent_InvalidJSON(t *testing.T) {
+	_, _, err := decodeOpencodeBusEvent([]byte(`{not-json}`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFirstArgFromInput_PriorityAndTruncation(t *testing.T) {
+	t.Run("priority-order-file-path", func(t *testing.T) {
+		got := firstArgFromInput(map[string]any{"command": "ls", "file_path": "/a/b"})
+		if got != "/a/b" {
+			t.Errorf("got %q, want /a/b (file_path beats command)", got)
+		}
+	})
+	t.Run("filePath-camel-case", func(t *testing.T) {
+		got := firstArgFromInput(map[string]any{"filePath": "/c/d"})
+		if got != "/c/d" {
+			t.Errorf("got %q, want /c/d", got)
+		}
+	})
+	t.Run("nil-input-empty", func(t *testing.T) {
+		if firstArgFromInput(nil) != "" {
+			t.Error("nil input should return empty string")
+		}
+	})
+	t.Run("truncation-to-100-runes", func(t *testing.T) {
+		long := strings.Repeat("a", 200)
+		got := firstArgFromInput(map[string]any{"path": long})
+		runes := []rune(got)
+		if len(runes) != 100 {
+			t.Errorf("got %d runes, want 100", len(runes))
+		}
+		if runes[99] != '…' {
+			t.Errorf("expected last rune '…', got %q", string(runes[99]))
+		}
+	})
+}
+
+func TestTitleCaseFirstASCII(t *testing.T) {
+	cases := map[string]string{
+		"":      "",
+		"read":  "Read",
+		"bash":  "Bash",
+		"Read":  "Read", // already cap; unchanged
+		"123":   "123",
+		"αlpha": "αlpha", // non-ASCII first byte; unchanged
+	}
+	for in, want := range cases {
+		if got := titleCaseFirstASCII(in); got != want {
+			t.Errorf("titleCaseFirstASCII(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+

--- a/worker/agent/opencode_events_test.go
+++ b/worker/agent/opencode_events_test.go
@@ -11,7 +11,6 @@ func TestDecodeOpencodeBusEvent_NoOps(t *testing.T) {
 		`{"type":"server.heartbeat","properties":{}}`,
 		`{"type":"message.updated","properties":{"info":{"id":"m1","role":"assistant"}}}`,
 		`{"type":"session.status","properties":{"sessionID":"s1","status":{"type":"idle"}}}`,
-		`{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"X"}}}`,
 		`{"type":"message.part.delta","properties":{"field":"text","delta":"abc"}}`,
 		`{"type":"unknown.future.event","properties":{}}`,
 	}
@@ -25,6 +24,20 @@ func TestDecodeOpencodeBusEvent_NoOps(t *testing.T) {
 				t.Errorf("expected ok=false for %q, got ev=%+v", in, ev)
 			}
 		})
+	}
+}
+
+func TestDecodeOpencodeBusEvent_SessionError_EmitsErrorEvent(t *testing.T) {
+	in := `{"type":"session.error","properties":{"sessionID":"s1","error":{"name":"RateLimitExceeded","data":{"isRetryable":true}}}}`
+	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true so Stage 3 retry classifier can hook in")
+	}
+	if ev.Type != "error" {
+		t.Errorf("Type = %q, want error", ev.Type)
 	}
 }
 
@@ -45,14 +58,14 @@ func TestDecodeOpencodeBusEvent_TextPartUpdate(t *testing.T) {
 	}
 }
 
-func TestDecodeOpencodeBusEvent_ToolPartUpdate(t *testing.T) {
-	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hostname"}}}}}`
+func TestDecodeOpencodeBusEvent_ToolCompleted_EmitsToolUse(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"completed","input":{"file_path":"/etc/hostname"}}}}}`
 	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if !ok {
-		t.Fatal("expected ok=true for tool part update")
+		t.Fatal("expected ok=true for tool part update with completed status")
 	}
 	if ev.Type != "tool_use" {
 		t.Errorf("Type = %q, want tool_use", ev.Type)
@@ -65,14 +78,14 @@ func TestDecodeOpencodeBusEvent_ToolPartUpdate(t *testing.T) {
 	}
 }
 
-func TestDecodeOpencodeBusEvent_ToolWithoutState(t *testing.T) {
-	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"bash"}}}`
+func TestDecodeOpencodeBusEvent_ToolError_EmitsToolUse(t *testing.T) {
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"bash","state":{"status":"error","input":{"command":"false"}}}}}`
 	ev, ok, err := decodeOpencodeBusEvent([]byte(in))
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if !ok {
-		t.Fatal("expected ok=true for tool part update without state")
+		t.Fatal("expected ok=true for tool part with error status (tool ran, errored — still one call)")
 	}
 	if ev.Type != "tool_use" {
 		t.Errorf("Type = %q, want tool_use", ev.Type)
@@ -80,8 +93,37 @@ func TestDecodeOpencodeBusEvent_ToolWithoutState(t *testing.T) {
 	if ev.ToolName != "Bash" {
 		t.Errorf("ToolName = %q, want Bash", ev.ToolName)
 	}
-	if ev.ToolInputFirstArg != "" {
-		t.Errorf("ToolInputFirstArg = %q, want empty (no input)", ev.ToolInputFirstArg)
+}
+
+func TestDecodeOpencodeBusEvent_ToolIntermediateStates_Skipped(t *testing.T) {
+	cases := map[string]string{
+		"pending": `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"pending"}}}}`,
+		"running": `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"running","input":{"file_path":"/x"}}}}}`,
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ok, err := decodeOpencodeBusEvent([]byte(in))
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if ok {
+				t.Errorf("expected ok=false (intermediate tool state must NOT emit, would inflate Slack counters 3x)")
+			}
+		})
+	}
+}
+
+func TestDecodeOpencodeBusEvent_ToolWithoutState_Skipped(t *testing.T) {
+	// Schema-incomplete event with no state at all. Spec parity says
+	// gate on state.status, so absent state defaults to "not terminal"
+	// → skip. Caller would have to send a status to indicate completion.
+	in := `{"type":"message.part.updated","properties":{"part":{"type":"tool","tool":"bash"}}}`
+	_, ok, err := decodeOpencodeBusEvent([]byte(in))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false (no state == not terminal)")
 	}
 }
 

--- a/worker/agent/opencode_http.go
+++ b/worker/agent/opencode_http.go
@@ -1,0 +1,350 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+// HTTP/SSE client for `opencode serve`. Wraps an http.Client with
+// (a) CreateSession, which POSTs /session and returns the new sessionID,
+// and (b) SendPrompt, which opens /event SSE in parallel with
+// POST /session/{id}/message and exposes both event stream and final
+// assistant text via PromptRun.
+//
+// Plan Task 3.2-6 acceptance writes the signature as
+// `SendPrompt → (<-chan queue.StreamEvent, error)`. We deviate slightly:
+// SendPrompt returns `*PromptRun`, with `Events <-chan queue.StreamEvent`
+// as a struct field plus `Wait()` for the final assembled text. The
+// channel-only signature would force runOneServer to either (a) ditch
+// the final text from the POST response (lossy — POST body carries the
+// authoritative answer and Bug A diagnostics for Task 3.2-11), or (b)
+// accumulate text from SSE deltas (lossy too — server emits the final
+// text part once via `time.end`, not via incremental deltas). Wrapping
+// channel + Wait() preserves both. See Stage 2 manifest §3.5 +
+// PR description for the spec/plan drift note.
+
+// Session-create + prompt JSON bodies. Field names match opencode 1.14.41
+// server schema (`SessionRoutes.create` and `SessionRoutes.prompt`); see
+// docs/specs/opencode-server-mode-poc-report.md P8 for breaking-change
+// verdict.
+
+const (
+	clientAgentName         = "build"
+	clientSessionTitle      = "agentdock-worker"
+	clientDirectoryHeader   = "X-Opencode-Directory"
+	clientSSEDataLinePrefix = "data: "
+	clientEventChannelSize  = 256
+)
+
+// Client wraps an *http.Client with the supervisor's BaseURL and the
+// random OPENCODE_SERVER_PASSWORD. One Client per worker process is
+// sufficient: opencode serve loads per-Instance state on demand via the
+// `x-opencode-directory` header, so per-job workDir isolation happens
+// at request time, not Client-construction time.
+type Client struct {
+	baseURL    string
+	password   string
+	httpClient *http.Client
+}
+
+// NewClient constructs a Client. Pass the supervisor's BaseURL (e.g.
+// `http://127.0.0.1:50000`) and Password.
+//
+// `httpClient` may be nil; default is a no-timeout http.Client because
+// the SSE GET /event is long-lived (context cancellation drives
+// teardown, not Client.Timeout — a non-zero Timeout would slam the SSE
+// stream after the elapsed period regardless of progress).
+func NewClient(baseURL, password string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		password:   password,
+		httpClient: httpClient,
+	}
+}
+
+// CreateSession POSTs /session with `{"title":"agentdock-worker"}` and
+// the `x-opencode-directory: directory` header. Returns the new session
+// ID. Used by runOneServer once per ask job; the returned sessionID is
+// then passed to SendPrompt for that same job.
+func (c *Client) CreateSession(ctx context.Context, directory string) (string, error) {
+	body := bytes.NewBufferString(fmt.Sprintf(`{"title":%q}`, clientSessionTitle))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/session", body)
+	if err != nil {
+		return "", fmt.Errorf("build create-session request: %w", err)
+	}
+	req.SetBasicAuth(supervisorAuthUsername, c.password)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(clientDirectoryHeader, directory)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("create-session request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		tail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", fmt.Errorf("create-session status %d: %s", resp.StatusCode, strings.TrimSpace(string(tail)))
+	}
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode create-session response: %w", err)
+	}
+	if out.ID == "" {
+		return "", errors.New("create-session response missing id")
+	}
+	return out.ID, nil
+}
+
+// PromptRun is the handle returned by SendPrompt. It owns two
+// goroutines: an SSE reader that translates BusEvent payloads into
+// queue.StreamEvent via decodeOpencodeBusEvent, and a POST worker that
+// blocks until the server returns the final AssistantMessage. Caller
+// must call Wait or Close before discarding the run.
+type PromptRun struct {
+	Events <-chan queue.StreamEvent
+
+	cancel       context.CancelFunc
+	sseErrCh     <-chan error
+	responseCh   <-chan promptResponse
+	closeOnce    sync.Once
+	closedSignal chan struct{}
+}
+
+type promptResponse struct {
+	finalText string
+	finish    string
+	tokensOut int
+	err       error
+}
+
+// Wait blocks until the POST /session/{id}/message request completes,
+// returning the assembled final assistant text on success. If the SSE
+// stream errors first (e.g. transport close, /event 4xx) Wait surfaces
+// that error instead. Wait always cancels both goroutines on return —
+// callers do not need to defer Close after a successful Wait.
+//
+// Bug A detection (Task 3.2-11) will read `finish` and `tokensOut` on
+// the same response; Stage 2 only exposes `finalText` + transport
+// errors here. promptResponse keeps those fields populated so 3.2-11
+// can lift the discriminator in without expanding this signature.
+func (r *PromptRun) Wait() (string, error) {
+	defer r.Close()
+	select {
+	case resp, ok := <-r.responseCh:
+		if !ok {
+			return "", errors.New("opencode prompt response channel closed before sending")
+		}
+		if resp.err != nil {
+			return "", resp.err
+		}
+		return resp.finalText, nil
+	case sseErr := <-r.sseErrCh:
+		return "", fmt.Errorf("opencode /event SSE: %w", sseErr)
+	}
+}
+
+// Close cancels both goroutines and waits for them to exit. Idempotent.
+func (r *PromptRun) Close() {
+	r.cancel()
+	r.cleanup()
+}
+
+func (r *PromptRun) cleanup() {
+	r.closeOnce.Do(func() { close(r.closedSignal) })
+}
+
+// SendPrompt subscribes to /event SSE first, then POSTs
+// /session/{id}/message with `agent: build` + text prompt. Returns a
+// PromptRun whose Events channel emits queue.StreamEvent translated
+// from server BusEvents, and whose Wait method blocks for the final
+// assistant text.
+//
+// `directory` populates the `x-opencode-directory` header on both
+// GET /event and POST /session/{id}/message so per-job workDir
+// isolation reaches the server consistently.
+func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt string) (*PromptRun, error) {
+	if sessionID == "" {
+		return nil, errors.New("SendPrompt: empty sessionID")
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	events := make(chan queue.StreamEvent, clientEventChannelSize)
+	sseErrCh := make(chan error, 1)
+	if err := c.subscribeEvents(runCtx, directory, events, sseErrCh); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	responseCh := make(chan promptResponse, 1)
+	closedSignal := make(chan struct{})
+	go func() {
+		defer close(responseCh)
+		resp := c.postPromptMessage(runCtx, sessionID, directory, prompt)
+		select {
+		case responseCh <- resp:
+		case <-closedSignal:
+		}
+	}()
+
+	return &PromptRun{
+		Events:       events,
+		cancel:       cancel,
+		sseErrCh:     sseErrCh,
+		responseCh:   responseCh,
+		closedSignal: closedSignal,
+	}, nil
+}
+
+// subscribeEvents fires GET /event, drains SSE lines on a goroutine,
+// strips the `data: ` prefix and pushes decoded events to `events`.
+// Recoverable signals (heartbeats, unmapped event types) silently
+// dropped. Errors surface via sseErrCh.
+func (c *Client) subscribeEvents(ctx context.Context, directory string, events chan<- queue.StreamEvent, sseErrCh chan<- error) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/event", nil)
+	if err != nil {
+		return fmt.Errorf("build event request: %w", err)
+	}
+	req.SetBasicAuth(supervisorAuthUsername, c.password)
+	req.Header.Set(clientDirectoryHeader, directory)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("event request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		tail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("event status %d: %s", resp.StatusCode, strings.TrimSpace(string(tail)))
+	}
+
+	go func() {
+		defer close(events)
+		defer resp.Body.Close()
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, clientSSEDataLinePrefix) {
+				continue
+			}
+			raw := []byte(strings.TrimPrefix(line, clientSSEDataLinePrefix))
+			ev, ok, decErr := decodeOpencodeBusEvent(raw)
+			if decErr != nil {
+				trySendErr(sseErrCh, fmt.Errorf("decode SSE event: %w", decErr))
+				return
+			}
+			if !ok {
+				continue
+			}
+			select {
+			case events <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			trySendErr(sseErrCh, fmt.Errorf("scan SSE stream: %w", err))
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		trySendErr(sseErrCh, errors.New("SSE stream closed unexpectedly"))
+	}()
+	return nil
+}
+
+// postPromptMessage POSTs `/session/{id}/message` with the prompt
+// payload and decodes the AssistantMessage response. The response body
+// carries the final assistant parts; we join all `type=text` parts as
+// the final text (matching POC AssistantMessage.Text()), and surface
+// finish + output token count for Task 3.2-11 Bug A detection.
+func (c *Client) postPromptMessage(ctx context.Context, sessionID, directory, prompt string) promptResponse {
+	payload := map[string]any{
+		"agent": clientAgentName,
+		"parts": []map[string]any{
+			{"type": "text", "text": prompt},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return promptResponse{err: fmt.Errorf("marshal prompt payload: %w", err)}
+	}
+
+	url := fmt.Sprintf("%s/session/%s/message", c.baseURL, sessionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return promptResponse{err: fmt.Errorf("build prompt request: %w", err)}
+	}
+	req.SetBasicAuth(supervisorAuthUsername, c.password)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(clientDirectoryHeader, directory)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return promptResponse{err: fmt.Errorf("prompt request: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		tail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return promptResponse{err: fmt.Errorf("prompt status %d: %s", resp.StatusCode, strings.TrimSpace(string(tail)))}
+	}
+
+	var body struct {
+		Info struct {
+			Finish string `json:"finish"`
+			Tokens *struct {
+				Input  int `json:"input"`
+				Output int `json:"output"`
+			} `json:"tokens,omitempty"`
+		} `json:"info"`
+		Parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
+		} `json:"parts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return promptResponse{err: fmt.Errorf("decode prompt response: %w", err)}
+	}
+
+	var b strings.Builder
+	for _, p := range body.Parts {
+		if p.Type == "text" {
+			b.WriteString(p.Text)
+		}
+	}
+	out := promptResponse{
+		finalText: b.String(),
+		finish:    body.Info.Finish,
+	}
+	if body.Info.Tokens != nil {
+		out.tokensOut = body.Info.Tokens.Output
+	}
+	return out
+}
+
+func trySendErr(ch chan<- error, err error) {
+	select {
+	case ch <- err:
+	default:
+	}
+}

--- a/worker/agent/opencode_http.go
+++ b/worker/agent/opencode_http.go
@@ -117,11 +117,19 @@ func (c *Client) CreateSession(ctx context.Context, directory string) (string, e
 // queue.StreamEvent via decodeOpencodeBusEvent, and a POST worker that
 // blocks until the server returns the final AssistantMessage. Caller
 // must call Wait or Close before discarding the run.
+//
+// SSEErrors carries non-fatal SSE-side errors (transport disconnects,
+// scanner failures). Wait does NOT short-circuit on these — POST is
+// the authoritative completion signal per spec line 92. Callers
+// (runOneServer) should drain SSEErrors at warn level so operators
+// can correlate SSE disruption with downstream issues without aborting
+// otherwise-successful POST requests. (Cross-review M1 fix: SSE close
+// alone must not fail a job whose POST is still computing.)
 type PromptRun struct {
-	Events <-chan queue.StreamEvent
+	Events    <-chan queue.StreamEvent
+	SSEErrors <-chan error
 
 	cancel       context.CancelFunc
-	sseErrCh     <-chan error
 	responseCh   <-chan promptResponse
 	closeOnce    sync.Once
 	closedSignal chan struct{}
@@ -135,10 +143,11 @@ type promptResponse struct {
 }
 
 // Wait blocks until the POST /session/{id}/message request completes,
-// returning the assembled final assistant text on success. If the SSE
-// stream errors first (e.g. transport close, /event 4xx) Wait surfaces
-// that error instead. Wait always cancels both goroutines on return —
-// callers do not need to defer Close after a successful Wait.
+// returning the assembled final assistant text on success. POST is
+// authoritative; SSE-side errors do not abort Wait — they surface via
+// PromptRun.SSEErrors so the caller can log them without failing the
+// request. Wait always cancels both goroutines on return; callers do
+// not need to defer Close after a successful Wait.
 //
 // Bug A detection (Task 3.2-11) will read `finish` and `tokensOut` on
 // the same response; Stage 2 only exposes `finalText` + transport
@@ -146,21 +155,20 @@ type promptResponse struct {
 // can lift the discriminator in without expanding this signature.
 func (r *PromptRun) Wait() (string, error) {
 	defer r.Close()
-	select {
-	case resp, ok := <-r.responseCh:
-		if !ok {
-			return "", errors.New("opencode prompt response channel closed before sending")
-		}
-		if resp.err != nil {
-			return "", resp.err
-		}
-		return resp.finalText, nil
-	case sseErr := <-r.sseErrCh:
-		return "", fmt.Errorf("opencode /event SSE: %w", sseErr)
+	resp, ok := <-r.responseCh
+	if !ok {
+		return "", errors.New("opencode prompt response channel closed before sending")
 	}
+	if resp.err != nil {
+		return "", resp.err
+	}
+	return resp.finalText, nil
 }
 
-// Close cancels both goroutines and waits for them to exit. Idempotent.
+// Close cancels both goroutines but does NOT block waiting for their
+// exit. Callers that need synchronous teardown should call Wait first,
+// which drains responseCh and the deferred Close runs after.
+// Idempotent — safe to call multiple times.
 func (r *PromptRun) Close() {
 	r.cancel()
 	r.cleanup()
@@ -205,8 +213,8 @@ func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt st
 
 	return &PromptRun{
 		Events:       events,
+		SSEErrors:    sseErrCh,
 		cancel:       cancel,
-		sseErrCh:     sseErrCh,
 		responseCh:   responseCh,
 		closedSignal: closedSignal,
 	}, nil
@@ -214,8 +222,19 @@ func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt st
 
 // subscribeEvents fires GET /event, drains SSE lines on a goroutine,
 // strips the `data: ` prefix and pushes decoded events to `events`.
-// Recoverable signals (heartbeats, unmapped event types) silently
-// dropped. Errors surface via sseErrCh.
+// Recoverable signals (heartbeats, intermediate tool states) silently
+// dropped. Per-step `result` events are accumulated internally and
+// surfaced as ONE cumulative terminal `result` event on goroutine
+// exit, so worker/pool/status.go's overwrite-on-result semantics
+// record full-job tokens / cost instead of just the last step
+// (cross-review M3 fix).
+//
+// SSE-side errors (scanner failures, decode errors, premature stream
+// close) are reported through sseErrCh as informational — POST is the
+// authoritative completion signal and PromptRun.Wait does not short-
+// circuit on these (cross-review M1 fix). Callers (runOneServer)
+// should log them at warn level so an operator can correlate SSE
+// disruption with downstream behavior.
 func (c *Client) subscribeEvents(ctx context.Context, directory string, events chan<- queue.StreamEvent, sseErrCh chan<- error) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/event", nil)
 	if err != nil {
@@ -236,8 +255,39 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 	}
 
 	go func() {
+		var (
+			cumInputTokens  int
+			cumOutputTokens int
+			cumCostUSD      float64
+			hasStepFinish   bool
+			sentTerminal    bool
+		)
+		emitTerminal := func() {
+			if sentTerminal || !hasStepFinish {
+				return
+			}
+			sentTerminal = true
+			select {
+			case events <- queue.StreamEvent{
+				Type:         "result",
+				InputTokens:  cumInputTokens,
+				OutputTokens: cumOutputTokens,
+				CostUSD:      cumCostUSD,
+			}:
+			default:
+				// events buffer (clientEventChannelSize=256) is sized
+				// well above realistic per-job event counts; default
+				// case is paranoia for the impossible-in-practice case
+				// where drainer has stopped reading but channel isn't
+				// closed yet. Drop is acceptable — POST response also
+				// carries `tokens.output`, so cost data isn't unique
+				// to this event.
+			}
+		}
 		defer close(events)
 		defer resp.Body.Close()
+		defer emitTerminal()
+
 		scanner := bufio.NewScanner(resp.Body)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 		for scanner.Scan() {
@@ -254,6 +304,13 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 			if !ok {
 				continue
 			}
+			if ev.Type == "result" {
+				cumInputTokens += ev.InputTokens
+				cumOutputTokens += ev.OutputTokens
+				cumCostUSD += ev.CostUSD
+				hasStepFinish = true
+				continue
+			}
 			select {
 			case events <- ev:
 			case <-ctx.Done():
@@ -264,10 +321,17 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 			trySendErr(sseErrCh, fmt.Errorf("scan SSE stream: %w", err))
 			return
 		}
-		if ctx.Err() != nil {
-			return
+		// SSE close without ctx cancellation: surface as informational
+		// SSE error. Wait() does NOT abort on these; runOneServer logs
+		// them at warn level. Floor-version (1.14.41) keeps SSE open
+		// for the duration of the prompt, so seeing this in practice
+		// indicates either a proxy/middlebox disconnect, a worker
+		// upgrading past floor and hitting the 1.14.42+ SSE-close
+		// regression documented in POC report § Historical bisect, or
+		// something else worth flagging.
+		if ctx.Err() == nil {
+			trySendErr(sseErrCh, errors.New("SSE stream closed before request completion (POST is authoritative)"))
 		}
-		trySendErr(sseErrCh, errors.New("SSE stream closed unexpectedly"))
 	}()
 	return nil
 }

--- a/worker/agent/opencode_http_test.go
+++ b/worker/agent/opencode_http_test.go
@@ -86,7 +86,9 @@ func TestClient_SendPrompt_HappyPath(t *testing.T) {
 			writeSSELines(w, r, []string{
 				`{"id":"e1","type":"server.connected","properties":{}}`,
 				`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"text","text":"Hi there"}}}`,
-				`{"id":"e3","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hostname"}}}}}`,
+				`{"id":"e3a","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"pending"}}}}`,
+				`{"id":"e3b","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"running","input":{"file_path":"/etc/hostname"}}}}}`,
+				`{"id":"e3c","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"completed","input":{"file_path":"/etc/hostname"}}}}}`,
 				`{"id":"e4","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":5,"output":3},"cost":0.0011}}}`,
 				`{"id":"e5","type":"server.heartbeat","properties":{}}`,
 			})
@@ -198,7 +200,9 @@ func TestClient_SendPrompt_SSEErrorPropagates(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/event":
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
-			// hang forever — SSE error should preempt
+			// hang forever — SSE setup error should fail the call
+			// outright (we never finished subscribing, so there's no
+			// SSE side to fall back on).
 			<-r.Context().Done()
 		default:
 			http.NotFound(w, r)
@@ -209,7 +213,145 @@ func TestClient_SendPrompt_SSEErrorPropagates(t *testing.T) {
 	c := NewClient(srv.URL, "secret", nil)
 	_, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
 	if err == nil {
-		t.Fatal("expected error when /event returns non-200")
+		t.Fatal("expected error when /event returns non-200 at subscription time")
+	}
+}
+
+// TestClient_SendPrompt_CumulativeResultEmittedOnce verifies the M3
+// fix: per-step `result` events from `step-finish` SSE updates are
+// accumulated inside the SSE consumer and surfaced as exactly ONE
+// terminal `result` event at stream end with summed tokens / cost.
+// Without this, worker/pool/status.go's overwrite-on-result records
+// only the last step's metrics.
+func TestClient_SendPrompt_CumulativeResultEmittedOnce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{
+				`{"id":"e1","type":"server.connected","properties":{}}`,
+				`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":5,"output":3},"cost":0.001}}}`,
+				`{"id":"e3","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":7,"output":4},"cost":0.002}}}`,
+				`{"id":"e4","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":2,"output":1},"cost":0.0005}}}`,
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"input":14,"output":8}},"parts":[{"type":"text","text":"answer"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	var results []queue.StreamEvent
+	collectDone := make(chan struct{})
+	go func() {
+		for ev := range run.Events {
+			if ev.Type == "result" {
+				results = append(results, ev)
+			}
+		}
+		close(collectDone)
+	}()
+
+	_, err = run.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	<-collectDone
+
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 cumulative result event, got %d: %+v", len(results), results)
+	}
+	got := results[0]
+	if got.InputTokens != 14 {
+		t.Errorf("cumulative InputTokens = %d, want 14 (5+7+2)", got.InputTokens)
+	}
+	if got.OutputTokens != 8 {
+		t.Errorf("cumulative OutputTokens = %d, want 8 (3+4+1)", got.OutputTokens)
+	}
+	if got.CostUSD < 0.00349 || got.CostUSD > 0.00351 {
+		t.Errorf("cumulative CostUSD = %f, want ~0.0035", got.CostUSD)
+	}
+}
+
+// TestClient_SendPrompt_SSECloseEarly_POSTAuthoritative verifies the
+// M1 fix: SSE stream closing before POST returns is informational
+// (logged via SSEErrors), not fatal. Wait() blocks on the POST
+// response and returns the final text.
+func TestClient_SendPrompt_SSECloseEarly_POSTAuthoritative(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			// Write one event then return immediately, closing SSE
+			// stream before POST finishes (simulates floor+1
+			// regression or proxy disconnect).
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"id":"e1","type":"server.connected","properties":{}}`)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			// return → stream ends
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			// Simulate server taking time to compute final answer
+			// AFTER SSE has already closed.
+			select {
+			case <-time.After(200 * time.Millisecond):
+			case <-r.Context().Done():
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"output":2}},"parts":[{"type":"text","text":"late answer"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	// drain events + collect SSE errors
+	var sseErrs []error
+	collectDone := make(chan struct{})
+	go func() {
+		defer close(collectDone)
+		for {
+			select {
+			case _, ok := <-run.Events:
+				if !ok {
+					return
+				}
+			case err, ok := <-run.SSEErrors:
+				if !ok {
+					continue
+				}
+				sseErrs = append(sseErrs, err)
+			}
+		}
+	}()
+
+	text, err := run.Wait()
+	if err != nil {
+		t.Fatalf("Wait should succeed despite SSE close: %v", err)
+	}
+	if text != "late answer" {
+		t.Errorf("text = %q, want %q (POST is authoritative)", text, "late answer")
+	}
+	<-collectDone
+	if len(sseErrs) == 0 {
+		t.Log("SSE error not surfaced; acceptable if scanner saw clean EOF")
 	}
 }
 

--- a/worker/agent/opencode_http_test.go
+++ b/worker/agent/opencode_http_test.go
@@ -1,0 +1,271 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+)
+
+func TestClient_CreateSession_HappyPath(t *testing.T) {
+	var seenDir, seenAuth atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/session" {
+			if r.Header.Get(clientDirectoryHeader) == "/tmp/work" {
+				seenDir.Store(true)
+			}
+			u, p, ok := r.BasicAuth()
+			if ok && u == supervisorAuthUsername && p == "secret" {
+				seenAuth.Store(true)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"ses_test_001"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	sid, err := c.CreateSession(context.Background(), "/tmp/work")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if sid != "ses_test_001" {
+		t.Errorf("sid = %q, want ses_test_001", sid)
+	}
+	if !seenDir.Load() {
+		t.Error("server never saw x-opencode-directory header")
+	}
+	if !seenAuth.Load() {
+		t.Error("server never saw Basic auth with opencode + secret")
+	}
+}
+
+func TestClient_CreateSession_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"directory not found"}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	_, err := c.CreateSession(context.Background(), "/nonexistent")
+	if err == nil {
+		t.Fatal("expected error on non-200")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error %q does not surface status code", err.Error())
+	}
+}
+
+func TestClient_CreateSession_MissingID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	_, err := c.CreateSession(context.Background(), "/tmp/work")
+	if err == nil {
+		t.Fatal("expected error on missing id")
+	}
+}
+
+func TestClient_SendPrompt_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{
+				`{"id":"e1","type":"server.connected","properties":{}}`,
+				`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"text","text":"Hi there"}}}`,
+				`{"id":"e3","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hostname"}}}}}`,
+				`{"id":"e4","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":5,"output":3},"cost":0.0011}}}`,
+				`{"id":"e5","type":"server.heartbeat","properties":{}}`,
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"input":5,"output":3}},"parts":[{"type":"text","text":"final answer"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_test_001", "/tmp/work", "ask me")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	var collected []queue.StreamEvent
+	collectDone := make(chan struct{})
+	go func() {
+		for ev := range run.Events {
+			collected = append(collected, ev)
+		}
+		close(collectDone)
+	}()
+
+	text, err := run.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if text != "final answer" {
+		t.Errorf("final text = %q, want %q", text, "final answer")
+	}
+	<-collectDone
+
+	seenDelta, seenTool, seenResult := false, false, false
+	for _, e := range collected {
+		switch e.Type {
+		case "message_delta":
+			seenDelta = true
+			if e.TextBytes != len("Hi there") {
+				t.Errorf("message_delta TextBytes = %d, want %d", e.TextBytes, len("Hi there"))
+			}
+		case "tool_use":
+			seenTool = true
+			if e.ToolName != "Read" || e.ToolInputFirstArg != "/etc/hostname" {
+				t.Errorf("tool_use = %+v, want Read/etc/hostname", e)
+			}
+		case "result":
+			seenResult = true
+			if e.InputTokens != 5 || e.OutputTokens != 3 {
+				t.Errorf("result tokens = (%d,%d), want (5,3)", e.InputTokens, e.OutputTokens)
+			}
+			if e.CostUSD != 0.0011 {
+				t.Errorf("result CostUSD = %v, want 0.0011", e.CostUSD)
+			}
+		}
+	}
+	if !seenDelta {
+		t.Error("missing message_delta event")
+	}
+	if !seenTool {
+		t.Error("missing tool_use event")
+	}
+	if !seenResult {
+		t.Error("missing result event")
+	}
+}
+
+func TestClient_SendPrompt_POSTError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{`{"id":"e1","type":"server.connected","properties":{}}`})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			http.Error(w, `{"error":"backend"}`, http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	defer run.Close()
+	// drain events so SSE goroutine doesn't block
+	go func() {
+		for range run.Events {
+		}
+	}()
+
+	_, err = run.Wait()
+	if err == nil {
+		t.Fatal("expected error from POST /session/{id}/message")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %q does not surface 500 status", err.Error())
+	}
+}
+
+func TestClient_SendPrompt_SSEErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			// hang forever — SSE error should preempt
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	_, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
+	if err == nil {
+		t.Fatal("expected error when /event returns non-200")
+	}
+}
+
+func TestClient_SendPrompt_CloseIdempotent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{`{"id":"e1","type":"server.connected","properties":{}}`})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "x")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	go func() {
+		for range run.Events {
+		}
+	}()
+	run.Close()
+	run.Close()
+	run.Close()
+}
+
+func TestClient_SendPrompt_EmptySessionID(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", "secret", nil)
+	_, err := c.SendPrompt(context.Background(), "", "/tmp/work", "x")
+	if err == nil {
+		t.Fatal("expected error on empty sessionID")
+	}
+}
+
+// writeSSELines emits lines as `data: <line>\n\n` and holds the
+// connection open until the request context is canceled (matches real
+// SSE handler shape).
+func writeSSELines(w http.ResponseWriter, r *http.Request, lines []string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	for _, line := range lines {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", line)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	select {
+	case <-r.Context().Done():
+	case <-time.After(5 * time.Second):
+		// safety belt so the test can never wedge if a client
+		// forgets to cancel.
+	}
+}

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -3,33 +3,141 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/Ivantseng123/agentdock/shared/tracing"
 	"github.com/Ivantseng123/agentdock/worker/config"
 )
 
-// runOneServer is the entry point for opencode's server-mode run path
-// (long-running `opencode serve` subprocess shared by the worker pool over
-// HTTP/SSE). Stage 1 ships this as a stub so operators who flip
-// `opencode.mode: server` before the Phase 3.2 supervisor lands receive a
-// loud, explicit error from the existing agent-chain failure path rather
-// than a silent degradation.
+// runOneServer is the server-mode counterpart to runOneSpawn. It drives
+// one ask job through the worker-process-scoped Supervisor (long-running
+// `opencode serve` child) plus a per-job HTTP/SSE Client. See plan Task
+// 3.2-7 for the acceptance contract.
 //
-// Implementation lands in Stage 2:
-//   - Task 3.2-5 wires the supervisor (Start/Stop/BaseURL/Password).
-//   - Task 3.2-6 wires the HTTP/SSE client (CreateSession, SendPrompt).
-//   - Task 3.2-7 fills this function with the supervisor + client glue.
+// Contract parity with runOneSpawn (Stage 1 cross-review pre-mortems
+// 6.1 + 6.3):
 //
-// Until those land, `Run`'s agent-chain fallback at runner.go's Run()
-// catches the error, logs the failure, and tries the next provider — so
-// the worker stays alive and ask jobs degrade visibly rather than wedge.
-func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (string, error) {
-	logger.Error(
-		"opencode server-mode 尚未實作 (Stage 2+)",
-		"phase", "失敗",
-		"command", agent.Command,
-		"mode", r.opencodeCfg.Mode,
-		"hint", "Stage 1 PR only ships the dispatcher; flip opencode.mode back to spawn until Stage 2 (Task 3.2-5..3.2-7) lands.",
+//   - OnStarted fires with supervisor.ChildPID() and agent.Command so
+//     the pool's status registry has a valid PID to track. Server mode
+//     has no per-job exec'd process — the supervisor's child is the
+//     only OS process running the work, so reusing its PID across
+//     every job is the honest signal.
+//   - OnEvent fires for every queue.StreamEvent the BusEvent decoder
+//     produces (message_delta / tool_use / result), same taxonomy as
+//     ReadStreamJSONOpencode populates in spawn mode.
+//   - OnExit fires in a deferred closure with a synthetic exit code:
+//     0 on a clean answer, -1 when transport / request errors surface
+//     before Wait returns successfully. Bug A discrimination
+//     (finish=other + tokens.output=0) is plan Task 3.2-11 (Stage 3);
+//     promptResponse already carries those fields so the discriminator
+//     can lift in without altering this function's signature.
+//   - OTel span attributes mirror runOneSpawn's set (agent_type,
+//     duration_ms, stdout_len, exit_code) so Jaeger filters by
+//     `error=true` keep working across modes.
+//
+// Supervisor is owned by the worker's Runner; calling runOneServer
+// with r.supervisor == nil is a programming error (the dispatcher only
+// routes here when Mode == server, which is mutually exclusive with a
+// nil supervisor in production boot). A defensive guard surfaces an
+// explicit error rather than panicking on dereference.
+func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent config.AgentConfig, workDir, prompt string, opts RunOptions) (output string, err error) {
+	if r.supervisor == nil {
+		return "", errors.New("opencode supervisor not initialized (runOneServer reached with nil supervisor — Runner construction bug)")
+	}
+
+	ctx, span := tracer.Start(ctx, tracing.SpanAgentExecute,
+		trace.WithAttributes(
+			attribute.String("agent_type", filepath.Base(agent.Command)),
+		),
 	)
-	return "", errors.New("opencode server mode not implemented yet (Stage 2+; flip opencode.mode to spawn or wait for Tasks 3.2-5..3.2-7)")
+	start := time.Now()
+	exitCode := -1
+	defer func() {
+		attrs := []attribute.KeyValue{
+			attribute.Int64("duration_ms", time.Since(start).Milliseconds()),
+			attribute.Int("stdout_len", len(output)),
+		}
+		if exitCode >= 0 {
+			attrs = append(attrs, attribute.Int("exit_code", exitCode))
+		}
+		span.SetAttributes(attrs...)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "agent run failed")
+		}
+		if opts.OnExit != nil {
+			opts.OnExit(exitCode)
+		}
+		span.End()
+	}()
+
+	timeout := agent.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	sup := r.supervisor
+	client := NewClient(sup.BaseURL(), sup.Password(), nil)
+
+	if opts.OnStarted != nil {
+		opts.OnStarted(sup.ChildPID(), agent.Command)
+	}
+	logger.Info("opencode server-mode session 啟動",
+		"phase", "處理中",
+		"command", agent.Command,
+		"supervisor_pid", sup.ChildPID(),
+		"base_url", sup.BaseURL(),
+	)
+
+	sessionID, err := client.CreateSession(ctx, workDir)
+	if err != nil {
+		return "", fmt.Errorf("create opencode session: %w", err)
+	}
+	logger.Info("opencode session 已建立",
+		"phase", "處理中",
+		"command", agent.Command,
+		"session_id", sessionID,
+	)
+
+	run, err := client.SendPrompt(ctx, sessionID, workDir, prompt)
+	if err != nil {
+		return "", fmt.Errorf("send opencode prompt: %w", err)
+	}
+
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for ev := range run.Events {
+			if opts.OnEvent != nil {
+				opts.OnEvent(ev)
+			}
+		}
+	}()
+
+	output, err = run.Wait()
+	<-drainDone
+
+	if err != nil {
+		return "", err
+	}
+	exitCode = 0
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		logger.Warn("opencode 答案為空",
+			"phase", "失敗",
+			"command", agent.Command,
+			"session_id", sessionID,
+		)
+	}
+	return trimmed, nil
 }

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -69,9 +69,17 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 			attrs = append(attrs, attribute.Int("exit_code", exitCode))
 		}
 		span.SetAttributes(attrs...)
+		// Span status parity with runOneSpawn (cross-review M4): mark
+		// span as Error not only on Go err but also when exitCode > 0
+		// with nil err. Stage 2 only emits exitCode ∈ {-1, 0}, so the
+		// second branch is currently unreachable; Stage 3 Task 3.2-11's
+		// Bug A detector will emit positive exit codes, and Jaeger
+		// filters by `error=true` need this branch to keep working.
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "agent run failed")
+		} else if exitCode > 0 {
+			span.SetStatus(codes.Error, fmt.Sprintf("agent exited %d", exitCode))
 		}
 		if opts.OnExit != nil {
 			opts.OnExit(exitCode)
@@ -117,9 +125,30 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		for ev := range run.Events {
-			if opts.OnEvent != nil {
-				opts.OnEvent(ev)
+		for {
+			select {
+			case ev, ok := <-run.Events:
+				if !ok {
+					return
+				}
+				if opts.OnEvent != nil {
+					opts.OnEvent(ev)
+				}
+			case sseErr, ok := <-run.SSEErrors:
+				if !ok {
+					continue
+				}
+				// SSE is telemetry only — POST is authoritative. Warn
+				// the operator so an SSE disruption (proxy disconnect,
+				// floor+1 upstream regression, etc.) is correlatable
+				// with downstream behavior, but never abort the job
+				// (cross-review M1 fix).
+				logger.Warn("opencode SSE 中斷",
+					"phase", "處理中",
+					"command", agent.Command,
+					"session_id", sessionID,
+					"error", sseErr,
+				)
 			}
 		}
 	}()

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -57,7 +57,9 @@ func TestRunOneServer_HappyPath_FiresAllCallbacks(t *testing.T) {
 		sseEvents: []string{
 			`{"id":"e1","type":"server.connected","properties":{}}`,
 			`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"text","text":"hi"}}}`,
-			`{"id":"e3","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hosts"}}}}}`,
+			`{"id":"e3a","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"pending"}}}}`,
+			`{"id":"e3b","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"running","input":{"file_path":"/etc/hosts"}}}}}`,
+			`{"id":"e3c","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"status":"completed","input":{"file_path":"/etc/hosts"}}}}}`,
 			`{"id":"e4","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":2,"output":3},"cost":0.0005}}}`,
 		},
 	})
@@ -206,6 +208,69 @@ func TestRunOneServer_POSTMessageError_OnExitMinusOne(t *testing.T) {
 	}
 	if exitCode.Load() != -1 {
 		t.Errorf("OnExit code = %d, want -1", exitCode.Load())
+	}
+}
+
+// TestRunOneServer_SSECloseEarly_POSTAuthoritative verifies the M1
+// fix at the runOneServer layer: SSE close before POST completes
+// must NOT abort the job — runOneServer logs the SSE error at warn
+// level and lets POST be authoritative. End user gets their answer.
+func TestRunOneServer_SSECloseEarly_POSTAuthoritative(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"ses_sse_drops"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			// Send connect event then close immediately
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"id":"e1","type":"server.connected","properties":{}}`)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			// handler returns → stream closes
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message"):
+			// POST returns successfully even though SSE has closed
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"output":2}},"parts":[{"type":"text","text":"survives SSE close"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 33333)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+	var exitCode atomic.Int64
+	exitCode.Store(-99)
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{
+			OnExit: func(code int) { exitCode.Store(int64(code)) },
+		},
+	)
+	if err != nil {
+		t.Fatalf("runOneServer should succeed despite SSE close: %v", err)
+	}
+	if output != "survives SSE close" {
+		t.Errorf("output = %q, want %q (POST is authoritative)", output, "survives SSE close")
+	}
+	if exitCode.Load() != 0 {
+		t.Errorf("OnExit code = %d, want 0", exitCode.Load())
 	}
 }
 

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -1,0 +1,262 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Ivantseng123/agentdock/shared/queue"
+	"github.com/Ivantseng123/agentdock/worker/config"
+)
+
+// primedSupervisor builds a Supervisor in the "started" state pointed
+// at a test HTTP server. Bypasses the real `opencode serve` spawn so
+// runOneServer can be exercised end-to-end against httptest fakes
+// without a real opencode binary. Test-only — production boot uses
+// NewSupervisor + Start.
+func primedSupervisor(baseURL, password string, pid int) *Supervisor {
+	return &Supervisor{
+		baseURL:  baseURL,
+		password: password,
+		pid:      pid,
+		started:  true,
+	}
+}
+
+func TestRunOneServer_NilSupervisorGuard(t *testing.T) {
+	r := &Runner{opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer}}
+	_, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		t.TempDir(),
+		"prompt",
+		RunOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected nil-supervisor error")
+	}
+	if !strings.Contains(err.Error(), "supervisor not initialized") {
+		t.Errorf("error %q missing nil-supervisor marker", err.Error())
+	}
+}
+
+func TestRunOneServer_HappyPath_FiresAllCallbacks(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:    "ses_runOne_test",
+		finalText:    "final answer",
+		finishReason: "stop",
+		outputTokens: 3,
+		sseEvents: []string{
+			`{"id":"e1","type":"server.connected","properties":{}}`,
+			`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"text","text":"hi"}}}`,
+			`{"id":"e3","type":"message.part.updated","properties":{"part":{"type":"tool","tool":"read","state":{"input":{"file_path":"/etc/hosts"}}}}}`,
+			`{"id":"e4","type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":2,"output":3},"cost":0.0005}}}`,
+		},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 54321)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	var (
+		startedPID atomic.Int64
+		startedCmd atomic.Value
+		exitCode   atomic.Int64
+		eventCount atomic.Int64
+		eventsMu   sync.Mutex
+		events     []queue.StreamEvent
+	)
+	startedCmd.Store("")
+	exitCode.Store(-99)
+
+	opts := RunOptions{
+		OnStarted: func(pid int, command string) {
+			startedPID.Store(int64(pid))
+			startedCmd.Store(command)
+		},
+		OnEvent: func(ev queue.StreamEvent) {
+			eventsMu.Lock()
+			events = append(events, ev)
+			eventsMu.Unlock()
+			eventCount.Add(1)
+		},
+		OnExit: func(code int) {
+			exitCode.Store(int64(code))
+		},
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/workdir",
+		"please answer",
+		opts,
+	)
+	if err != nil {
+		t.Fatalf("runOneServer: %v", err)
+	}
+	if output != "final answer" {
+		t.Errorf("output = %q, want %q", output, "final answer")
+	}
+	if startedPID.Load() != 54321 {
+		t.Errorf("OnStarted PID = %d, want 54321", startedPID.Load())
+	}
+	if startedCmd.Load().(string) != "opencode" {
+		t.Errorf("OnStarted command = %q, want opencode", startedCmd.Load().(string))
+	}
+	if exitCode.Load() != 0 {
+		t.Errorf("OnExit code = %d, want 0", exitCode.Load())
+	}
+	if eventCount.Load() < 3 {
+		t.Errorf("event count = %d, want ≥ 3 (delta + tool + result)", eventCount.Load())
+	}
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	seenDelta, seenTool, seenResult := false, false, false
+	for _, ev := range events {
+		switch ev.Type {
+		case "message_delta":
+			seenDelta = true
+		case "tool_use":
+			seenTool = true
+			if ev.ToolName != "Read" {
+				t.Errorf("tool_use ToolName = %q, want Read", ev.ToolName)
+			}
+		case "result":
+			seenResult = true
+		}
+	}
+	if !seenDelta || !seenTool || !seenResult {
+		t.Errorf("missing event types: delta=%v tool=%v result=%v", seenDelta, seenTool, seenResult)
+	}
+}
+
+func TestRunOneServer_CreateSessionError_OnExitMinusOne(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"directory missing"}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 11111)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+	var exitCode atomic.Int64
+	exitCode.Store(-99)
+	_, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/nonexistent",
+		"prompt",
+		RunOptions{
+			OnExit: func(code int) { exitCode.Store(int64(code)) },
+		},
+	)
+	if err == nil {
+		t.Fatal("expected CreateSession error")
+	}
+	if exitCode.Load() != -1 {
+		t.Errorf("OnExit code = %d, want -1 (transport-layer error)", exitCode.Load())
+	}
+}
+
+func TestRunOneServer_POSTMessageError_OnExitMinusOne(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:        "ses_post_err",
+		failPostMessage:  true,
+		failPostStatus:   500,
+		failPostBody:     `{"error":"backend exploded"}`,
+		sseEvents:        []string{`{"id":"e1","type":"server.connected","properties":{}}`},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 22222)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+	var exitCode atomic.Int64
+	exitCode.Store(-99)
+	_, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{
+			OnExit: func(code int) { exitCode.Store(int64(code)) },
+		},
+	)
+	if err == nil {
+		t.Fatal("expected POST /session/{id}/message error")
+	}
+	if exitCode.Load() != -1 {
+		t.Errorf("OnExit code = %d, want -1", exitCode.Load())
+	}
+}
+
+// fakeOpencodeBehavior parameterizes the fake opencode HTTP API for
+// runOneServer tests. Zero values are happy-path defaults; flip
+// failPostMessage to exercise the POST /session/{id}/message error
+// path.
+type fakeOpencodeBehavior struct {
+	sessionID    string
+	finalText    string
+	finishReason string
+	outputTokens int
+	sseEvents    []string
+
+	failPostMessage bool
+	failPostStatus  int
+	failPostBody    string
+}
+
+func newFakeOpencodeServer(t *testing.T, b fakeOpencodeBehavior) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"id":%q}`, b.sessionID)
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, b.sseEvents)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message"):
+			if b.failPostMessage {
+				status := b.failPostStatus
+				if status == 0 {
+					status = http.StatusInternalServerError
+				}
+				http.Error(w, b.failPostBody, status)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			body := fmt.Sprintf(
+				`{"info":{"finish":%q,"tokens":{"input":2,"output":%d}},"parts":[{"type":"text","text":%q}]}`,
+				b.finishReason, b.outputTokens, b.finalText,
+			)
+			_, _ = io.WriteString(w, body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/worker/agent/opencode_version.go
+++ b/worker/agent/opencode_version.go
@@ -1,0 +1,100 @@
+// Package agent — opencode_version.go is the opencode-server-mode
+// capability check. It has a deliberately different policy from
+// version.go's LogVersions:
+//
+//   - LogVersions is warn-and-continue for every agent at boot. Some
+//     CLIs predate the --version convention, so a probe failure must
+//     NOT crash the worker (see version.go doc comment).
+//
+//   - CheckOpencodeVersion is blocking, opencode-only, server-mode-only.
+//     Below floor or probe failure → caller exits non-zero. Server mode
+//     wires HTTP/SSE contracts whose semantics depend on the
+//     POC-validated baseline (1.14.41); running on an older binary
+//     would silently degrade ask answers.
+//
+// The parser handles opencode's bare-semver `--version` output
+// (e.g. `1.14.41\n`) which differs from claude / codex which print a
+// `<name> <version>` banner. version.go's detectVersion returns the
+// trimmed first line, so for opencode that line is itself the version.
+// Three-segment numeric compare; no `golang.org/x/mod/semver` (spec N4).
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// MinimumOpencodeVersion is the lower-bound floor for opencode in
+// `cfg.Opencode.Mode == "server"`. Backed by the POC report on main
+// (docs/specs/opencode-server-mode-poc-report.md, PR #258). Bumping
+// requires re-running POC `-all -replay-count=100` against the
+// candidate build and publishing a refreshed report; see spec
+// § Bumping the floor.
+const MinimumOpencodeVersion = "1.14.41"
+
+// CheckOpencodeVersion probes `binaryPath --version` (via the same
+// detectVersion used by LogVersions) and compares the result against
+// MinimumOpencodeVersion. Returns the detected version on success.
+//
+// In server mode, callers must treat any error as a boot-blocker. Probe
+// failure (binary missing / non-zero exit / malformed output) AND
+// below-floor mismatch are both surfaced as errors here — stricter than
+// LogVersions's warn-only policy by design. Spawn mode must not call
+// this; LogVersions's warn-and-continue path is sufficient there.
+func CheckOpencodeVersion(ctx context.Context, binaryPath string) (string, error) {
+	detected, err := detectVersion(ctx, binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("probe %s --version: %w", binaryPath, err)
+	}
+	if err := compareToMinimumOpencodeVersion(detected); err != nil {
+		return detected, err
+	}
+	return detected, nil
+}
+
+func compareToMinimumOpencodeVersion(detected string) error {
+	d, err := parseOpencodeSemver(detected)
+	if err != nil {
+		return fmt.Errorf("opencode 版本格式無法解析 (detected=%q, required=%q, 見 docs/specs/opencode-server-mode-poc-report.md): %w",
+			detected, MinimumOpencodeVersion, err)
+	}
+	m, err := parseOpencodeSemver(MinimumOpencodeVersion)
+	if err != nil {
+		// Unreachable in production — the constant is checked at parse
+		// time in TestMinimumOpencodeVersionParses. Surface as a plain
+		// error so a future typo in the constant fails the unit test.
+		return fmt.Errorf("MinimumOpencodeVersion 常數格式錯誤: %w", err)
+	}
+	for i := 0; i < 3; i++ {
+		if d[i] > m[i] {
+			return nil
+		}
+		if d[i] < m[i] {
+			return fmt.Errorf("opencode %s 低於 server-mode 最低版本 %s (見 docs/specs/opencode-server-mode-poc-report.md)",
+				detected, MinimumOpencodeVersion)
+		}
+	}
+	return nil
+}
+
+func parseOpencodeSemver(s string) ([3]int, error) {
+	var out [3]int
+	s = strings.TrimSpace(s)
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return out, fmt.Errorf("expected MAJOR.MINOR.PATCH, got %q", s)
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return out, fmt.Errorf("non-numeric segment %q in %q", p, s)
+		}
+		if n < 0 {
+			return out, fmt.Errorf("negative segment %d in %q", n, s)
+		}
+		out[i] = n
+	}
+	return out, nil
+}

--- a/worker/agent/opencode_version_test.go
+++ b/worker/agent/opencode_version_test.go
@@ -1,0 +1,160 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMinimumOpencodeVersionParses(t *testing.T) {
+	if _, err := parseOpencodeSemver(MinimumOpencodeVersion); err != nil {
+		t.Fatalf("MinimumOpencodeVersion %q failed to parse: %v", MinimumOpencodeVersion, err)
+	}
+}
+
+func TestParseOpencodeSemver(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    [3]int
+		wantErr bool
+	}{
+		{"floor", "1.14.41", [3]int{1, 14, 41}, false},
+		{"zeros", "0.0.0", [3]int{0, 0, 0}, false},
+		{"two-digit-major", "10.20.30", [3]int{10, 20, 30}, false},
+		{"trim-whitespace", "  1.14.41\n", [3]int{1, 14, 41}, false},
+		{"two-segments", "1.14", [3]int{}, true},
+		{"four-segments", "1.14.41.0", [3]int{}, true},
+		{"non-numeric", "1.14.x", [3]int{}, true},
+		{"empty", "", [3]int{}, true},
+		{"banner", "claude 1.14.41", [3]int{}, true},
+		{"rc-suffix", "1.14.41-rc.1", [3]int{}, true},
+		{"build-suffix", "1.14.41+build.7", [3]int{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseOpencodeSemver(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseOpencodeSemver(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOpencodeSemver(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseOpencodeSemver(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareToMinimumOpencodeVersion(t *testing.T) {
+	cases := []struct {
+		name     string
+		detected string
+		wantErr  bool
+	}{
+		{"equal-to-floor", MinimumOpencodeVersion, false},
+		{"patch-above", "1.14.42", false},
+		{"minor-above", "1.15.0", false},
+		{"major-above", "2.0.0", false},
+		{"patch-below", "1.14.40", true},
+		{"minor-below", "1.13.99", true},
+		{"major-below", "0.99.99", true},
+		{"malformed", "not-a-version", true},
+		{"two-segments", "1.14", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compareToMinimumOpencodeVersion(tc.detected)
+			if tc.wantErr && err == nil {
+				t.Errorf("compareToMinimumOpencodeVersion(%q) = nil, want error", tc.detected)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("compareToMinimumOpencodeVersion(%q) = %v, want nil", tc.detected, err)
+			}
+		})
+	}
+}
+
+func TestCompareToMinimumOpencodeVersion_BelowFloorErrorMessage(t *testing.T) {
+	err := compareToMinimumOpencodeVersion("1.14.40")
+	if err == nil {
+		t.Fatal("expected error for below-floor version")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "1.14.40") {
+		t.Errorf("error %q missing detected version", msg)
+	}
+	if !strings.Contains(msg, MinimumOpencodeVersion) {
+		t.Errorf("error %q missing required version", msg)
+	}
+	if !strings.Contains(msg, "opencode-server-mode-poc-report.md") {
+		t.Errorf("error %q missing pointer to POC report", msg)
+	}
+}
+
+func TestCheckOpencodeVersion_BinaryMissing(t *testing.T) {
+	_, err := CheckOpencodeVersion(context.Background(), "/nonexistent/binary/path/opencode-does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for missing binary, got nil")
+	}
+	if !strings.Contains(err.Error(), "probe") {
+		t.Errorf("error %q does not look like a probe failure: missing 'probe' marker", err.Error())
+	}
+}
+
+func TestCheckOpencodeVersion_FakeBinaryHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "opencode")
+	script := "#!/bin/sh\necho " + MinimumOpencodeVersion + "\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	detected, err := CheckOpencodeVersion(context.Background(), binPath)
+	if err != nil {
+		t.Fatalf("CheckOpencodeVersion(floor) unexpected error: %v", err)
+	}
+	if detected != MinimumOpencodeVersion {
+		t.Errorf("detected = %q, want %q", detected, MinimumOpencodeVersion)
+	}
+}
+
+func TestCheckOpencodeVersion_FakeBinaryBelowFloor(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "opencode")
+	script := "#!/bin/sh\necho 1.14.40\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	detected, err := CheckOpencodeVersion(context.Background(), binPath)
+	if err == nil {
+		t.Fatalf("expected below-floor error, got nil (detected=%q)", detected)
+	}
+	if detected != "1.14.40" {
+		t.Errorf("detected = %q, want %q", detected, "1.14.40")
+	}
+	if !strings.Contains(err.Error(), "低於 server-mode 最低版本") {
+		t.Errorf("error %q missing Chinese below-floor marker", err.Error())
+	}
+}
+
+func TestCheckOpencodeVersion_FakeBinaryMalformed(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "opencode")
+	script := "#!/bin/sh\necho not-a-semver\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	_, err := CheckOpencodeVersion(context.Background(), binPath)
+	if err == nil {
+		t.Fatal("expected malformed-output error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opencode 版本格式無法解析") {
+		t.Errorf("error %q does not surface Chinese parse-failure message", err.Error())
+	}
+}

--- a/worker/agent/runner.go
+++ b/worker/agent/runner.go
@@ -34,6 +34,13 @@ type Runner struct {
 	agents      []config.AgentConfig
 	githubToken string
 	opencodeCfg config.OpencodeConfig
+	// supervisor is the long-running `opencode serve` child shared by
+	// the worker pool when cfg.Opencode.Mode == "server". Populated by
+	// worker boot via SetOpencodeSupervisor after the version check
+	// passes and Supervisor.Start succeeds. nil under Mode = "spawn"
+	// or when constructed via NewRunner (no Config). runOneServer
+	// guards against the nil case.
+	supervisor *Supervisor
 }
 
 func NewRunner(agents []config.AgentConfig) *Runner {
@@ -53,6 +60,14 @@ func NewRunnerFromConfig(cfg *config.Config) *Runner {
 	runner.githubToken = cfg.GitHub.Token
 	runner.opencodeCfg = cfg.Opencode
 	return runner
+}
+
+// SetOpencodeSupervisor wires the long-running opencode serve handle
+// into the Runner so runOneServer can dispatch per-job HTTP/SSE work
+// through it. Called by worker boot only when cfg.Opencode.Mode ==
+// "server", after Supervisor.Start succeeds.
+func (r *Runner) SetOpencodeSupervisor(s *Supervisor) {
+	r.supervisor = s
 }
 
 func (r *Runner) Run(ctx context.Context, logger *slog.Logger, workDir, prompt string, opts RunOptions) (string, error) {

--- a/worker/agent/server_supervisor.go
+++ b/worker/agent/server_supervisor.go
@@ -1,0 +1,364 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Server supervisor for `opencode serve`. Stage 2 is always-on: Start is
+// called at worker boot, Stop on worker shutdown. Lazy lifecycle (spawn on
+// first job, idle-stop, sync.Once boot lock) is deferred to plan Task
+// 3.2-8 / Stage 3.
+
+const (
+	supervisorStartTimeout   = 10 * time.Second
+	supervisorStopGrace      = 5 * time.Second
+	supervisorHealthInterval = 200 * time.Millisecond
+	supervisorHealthRequest  = 2 * time.Second
+	supervisorAuthUsername   = "opencode"
+)
+
+// supervisorListenLine matches opencode serve's startup line printed
+// after `Server.listen` resolves. The trailing newline is stripped by the
+// scanner. We capture the full URL — hostname + kernel-assigned port —
+// so the supervisor never has to pre-pick a port (avoids the well-known
+// pickFreePort → exec.Start race window).
+var supervisorListenLine = regexp.MustCompile(`opencode server listening on (https?://\S+)`)
+
+// SupervisorConfig is the supervisor's constructor input.
+type SupervisorConfig struct {
+	BinaryPath string
+	StorageDir string
+	Logger     *slog.Logger
+}
+
+// Supervisor holds the long-running `opencode serve` child process for a
+// worker. One Supervisor per worker process; the pool's N goroutines share
+// the same BaseURL/Password via per-request `x-opencode-directory` header
+// isolation (see spec § Code Style and § Boundaries Always: server-pool
+// mapping = 1:N).
+type Supervisor struct {
+	cfg SupervisorConfig
+
+	mu       sync.Mutex
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	baseURL  string
+	password string
+	pid      int
+	started  bool
+	waitErr  chan error
+}
+
+// NewSupervisor constructs a Supervisor; call Start to spawn the child.
+func NewSupervisor(cfg SupervisorConfig) *Supervisor {
+	return &Supervisor{cfg: cfg}
+}
+
+// Start spawns `opencode serve --port 0 --hostname 127.0.0.1` with an
+// isolated XDG_DATA_HOME (spec § Boundaries Always: storage isolation) and
+// a random OPENCODE_SERVER_PASSWORD. Blocks until the child prints its
+// listen URL AND GET /health returns 200, both within
+// supervisorStartTimeout. Returns an error if the binary is missing,
+// crashes before becoming ready, or never reports healthy in time.
+func (s *Supervisor) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("supervisor already started")
+	}
+	s.mu.Unlock()
+
+	password, err := generateSupervisorPassword()
+	if err != nil {
+		return fmt.Errorf("generate password: %w", err)
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(runCtx, s.cfg.BinaryPath, "serve",
+		"--port", "0",
+		"--hostname", "127.0.0.1",
+	)
+	cmd.Env = buildSupervisorEnv(password, s.cfg.StorageDir)
+	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.WaitDelay = supervisorStopGrace
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancelRun()
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	cmd.Stderr = newSupervisorLogWriter(s.cfg.Logger, "stderr")
+
+	if err := cmd.Start(); err != nil {
+		cancelRun()
+		return fmt.Errorf("start opencode serve: %w", err)
+	}
+
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
+
+	startCtx, cancelStart := context.WithTimeout(ctx, supervisorStartTimeout)
+	defer cancelStart()
+
+	baseURL, err := awaitSupervisorListenURL(startCtx, stdout, waitErr, s.cfg.Logger)
+	if err != nil {
+		cancelRun()
+		return err
+	}
+
+	if err := pollSupervisorHealth(startCtx, baseURL, password); err != nil {
+		cancelRun()
+		return fmt.Errorf("opencode serve /health 探測失敗: %w", err)
+	}
+
+	s.mu.Lock()
+	s.cmd = cmd
+	s.cancel = cancelRun
+	s.baseURL = baseURL
+	s.password = password
+	s.pid = cmd.Process.Pid
+	s.started = true
+	s.waitErr = waitErr
+	s.mu.Unlock()
+
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("opencode serve 啟動",
+			"phase", "完成",
+			"base_url", baseURL,
+			"pid", cmd.Process.Pid,
+		)
+	}
+	return nil
+}
+
+// Stop signals SIGTERM to the child process and waits up to
+// supervisorStopGrace + 1s for it to exit. Cancellation of runCtx triggers
+// cmd.Cancel (SIGTERM); cmd.WaitDelay escalates to SIGKILL after the
+// grace window if the child is still alive. Idempotent: calling Stop on
+// a never-started or already-stopped supervisor is a no-op.
+func (s *Supervisor) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	s.started = false
+	cancelRun := s.cancel
+	waitErr := s.waitErr
+	pid := s.pid
+	s.mu.Unlock()
+
+	cancelRun()
+
+	select {
+	case err := <-waitErr:
+		if s.cfg.Logger != nil {
+			s.cfg.Logger.Info("opencode serve 已停止",
+				"phase", "完成",
+				"pid", pid,
+				"wait_err", errString(err),
+			)
+		}
+		if isExpectedExitOnSignal(err) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("stop opencode serve: %w", ctx.Err())
+	case <-time.After(supervisorStopGrace + 2*time.Second):
+		return errors.New("opencode serve did not exit within grace window")
+	}
+}
+
+// BaseURL returns the listen URL the child reported on startup, e.g.
+// "http://127.0.0.1:50000". Empty before Start succeeds.
+func (s *Supervisor) BaseURL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.baseURL
+}
+
+// Password returns the random OPENCODE_SERVER_PASSWORD passed to the
+// child via env. Empty before Start succeeds.
+func (s *Supervisor) Password() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.password
+}
+
+// ChildPID returns the OS process ID of the spawned `opencode serve`.
+// Zero before Start succeeds or after Stop completes.
+func (s *Supervisor) ChildPID() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pid
+}
+
+func generateSupervisorPassword() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func buildSupervisorEnv(password, storageDir string) []string {
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("OPENCODE_SERVER_PASSWORD=%s", password))
+	if storageDir != "" {
+		env = append(env, fmt.Sprintf("XDG_DATA_HOME=%s", storageDir))
+	}
+	return env
+}
+
+func awaitSupervisorListenURL(ctx context.Context, stdout io.ReadCloser, waitErr <-chan error, logger *slog.Logger) (string, error) {
+	urlCh := make(chan string, 1)
+	scanDone := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		sent := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !sent {
+				if m := supervisorListenLine.FindStringSubmatch(line); m != nil {
+					urlCh <- m[1]
+					sent = true
+				}
+			}
+			if logger != nil {
+				logger.Debug("opencode stdout",
+					"phase", "處理中",
+					"line", line,
+				)
+			}
+		}
+		scanDone <- scanner.Err()
+	}()
+
+	select {
+	case u := <-urlCh:
+		return u, nil
+	case err := <-scanDone:
+		if err != nil {
+			return "", fmt.Errorf("opencode serve stdout 讀取失敗: %w", err)
+		}
+		return "", errors.New("opencode serve stdout 結束但未印出 listen URL")
+	case err := <-waitErr:
+		return "", fmt.Errorf("opencode serve 啟動失敗 (process exited): %w", err)
+	case <-ctx.Done():
+		return "", fmt.Errorf("opencode serve 啟動逾時 (%s): %w", supervisorStartTimeout, ctx.Err())
+	}
+}
+
+func pollSupervisorHealth(ctx context.Context, baseURL, password string) error {
+	client := &http.Client{Timeout: supervisorHealthRequest}
+	healthURL := strings.TrimRight(baseURL, "/") + "/health"
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(supervisorAuthUsername, password)
+		resp, err := client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(supervisorHealthInterval):
+		}
+	}
+}
+
+func isExpectedExitOnSignal(err error) bool {
+	if err == nil {
+		return true
+	}
+	// runCtx cancellation by Stop is an expected termination path; Go's
+	// exec.Cmd surfaces the cause as context.Canceled in some shells.
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		if status.Signaled() {
+			sig := status.Signal()
+			return sig == syscall.SIGTERM || sig == syscall.SIGKILL || sig == syscall.SIGINT
+		}
+	}
+	return false
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// supervisorLogWriter forwards each line from the child's stderr to the
+// supervisor's slog logger at DEBUG. Uses an internal buffer to coalesce
+// partial writes into whole lines — opencode's hono logger emits
+// multi-line records that arrive split across pipe writes.
+type supervisorLogWriter struct {
+	logger *slog.Logger
+	stream string
+	buf    strings.Builder
+}
+
+func newSupervisorLogWriter(logger *slog.Logger, stream string) io.Writer {
+	if logger == nil {
+		return io.Discard
+	}
+	return &supervisorLogWriter{logger: logger, stream: stream}
+}
+
+func (w *supervisorLogWriter) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+	current := w.buf.String()
+	for {
+		i := strings.IndexByte(current, '\n')
+		if i < 0 {
+			w.buf.Reset()
+			w.buf.WriteString(current)
+			return len(p), nil
+		}
+		line := current[:i]
+		current = current[i+1:]
+		if line != "" {
+			w.logger.Debug("opencode "+w.stream,
+				"phase", "處理中",
+				"line", line,
+			)
+		}
+	}
+}

--- a/worker/agent/server_supervisor.go
+++ b/worker/agent/server_supervisor.go
@@ -202,7 +202,10 @@ func (s *Supervisor) Password() string {
 }
 
 // ChildPID returns the OS process ID of the spawned `opencode serve`.
-// Zero before Start succeeds or after Stop completes.
+// Zero before Start succeeds. Returns the stale-but-dead PID after
+// Stop completes — Stop does not reset internal fields. Treat the
+// value as informational (registry display, span attrs); do not use
+// it to send signals or check liveness after Stop.
 func (s *Supervisor) ChildPID() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/worker/agent/server_supervisor_test.go
+++ b/worker/agent/server_supervisor_test.go
@@ -1,0 +1,340 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSupervisorListenLineMatches(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"loopback-port-0-result", "opencode server listening on http://127.0.0.1:50000", "http://127.0.0.1:50000"},
+		{"https-variant", "opencode server listening on https://127.0.0.1:443", "https://127.0.0.1:443"},
+		{"hostname-with-trailing-text", "opencode server listening on http://127.0.0.1:8080 (ready)", "http://127.0.0.1:8080"},
+		{"unrelated-line", "some other line", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := supervisorListenLine.FindStringSubmatch(tc.line)
+			var got string
+			if len(m) > 1 {
+				got = m[1]
+			}
+			if got != tc.want {
+				t.Errorf("FindStringSubmatch(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateSupervisorPassword_UniqueAndHex(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 32; i++ {
+		p, err := generateSupervisorPassword()
+		if err != nil {
+			t.Fatalf("generateSupervisorPassword: %v", err)
+		}
+		if len(p) != 48 {
+			t.Errorf("password length = %d, want 48", len(p))
+		}
+		if seen[p] {
+			t.Errorf("duplicate password generated: %q", p)
+		}
+		seen[p] = true
+		for _, r := range p {
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+				t.Errorf("password %q contains non-hex char %q", p, r)
+				break
+			}
+		}
+	}
+}
+
+func TestBuildSupervisorEnv(t *testing.T) {
+	t.Run("with-storage-dir", func(t *testing.T) {
+		env := buildSupervisorEnv("secret", "/tmp/xdg")
+		if !containsExact(env, "OPENCODE_SERVER_PASSWORD=secret") {
+			t.Error("env missing OPENCODE_SERVER_PASSWORD")
+		}
+		if !containsExact(env, "XDG_DATA_HOME=/tmp/xdg") {
+			t.Error("env missing XDG_DATA_HOME")
+		}
+	})
+	t.Run("empty-storage-dir-omits-xdg", func(t *testing.T) {
+		env := buildSupervisorEnv("secret", "")
+		if !containsExact(env, "OPENCODE_SERVER_PASSWORD=secret") {
+			t.Error("env missing OPENCODE_SERVER_PASSWORD")
+		}
+		for _, e := range env {
+			if strings.HasPrefix(e, "XDG_DATA_HOME=") && e == "XDG_DATA_HOME=" {
+				t.Error("empty StorageDir leaked into XDG_DATA_HOME=")
+			}
+		}
+	})
+}
+
+func TestPollSupervisorHealth_OkAfterRetries(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		u, p, ok := r.BasicAuth()
+		if !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"healthy":true,"version":"fake"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := pollSupervisorHealth(ctx, srv.URL, "secret"); err != nil {
+		t.Fatalf("pollSupervisorHealth: %v", err)
+	}
+	if hits.Load() < 3 {
+		t.Errorf("hits = %d, expected ≥ 3 to confirm retry", hits.Load())
+	}
+}
+
+func TestPollSupervisorHealth_NeverHealthyTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	err := pollSupervisorHealth(ctx, srv.URL, "secret")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error %v not a context.DeadlineExceeded", err)
+	}
+}
+
+func TestPollSupervisorHealth_BadCredentialsErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, ok := r.BasicAuth()
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	err := pollSupervisorHealth(ctx, srv.URL, "secret")
+	if err == nil {
+		t.Fatal("expected error on persistent 401, got nil")
+	}
+}
+
+func TestIsExpectedExitOnSignal(t *testing.T) {
+	if isExpectedExitOnSignal(nil) != true {
+		t.Error("nil should be treated as expected (clean exit)")
+	}
+	other := errors.New("non-exec error")
+	if isExpectedExitOnSignal(other) {
+		t.Error("non-exec error should not be expected")
+	}
+}
+
+func TestSupervisor_StartStop_HappyPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	if err := sup.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if got := sup.BaseURL(); got != srv.URL {
+		t.Errorf("BaseURL = %q, want %q", got, srv.URL)
+	}
+	if sup.Password() == "" {
+		t.Error("Password is empty after Start")
+	}
+	pid := sup.ChildPID()
+	if pid == 0 {
+		t.Error("ChildPID is 0 after Start")
+	}
+	if err := sup.Stop(context.Background()); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+	if alive, err := processAlive(pid); alive || err == nil {
+		t.Errorf("process %d still alive after Stop (err=%v)", pid, err)
+	}
+}
+
+func TestSupervisor_Start_BinaryMissing(t *testing.T) {
+	sup := NewSupervisor(SupervisorConfig{
+		BinaryPath: filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	err := sup.Start(context.Background())
+	if err == nil {
+		_ = sup.Stop(context.Background())
+		t.Fatal("Start succeeded with missing binary")
+	}
+}
+
+func TestSupervisor_Start_BinaryCrashesBeforeReady(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "opencode")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 7\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: bin})
+	err := sup.Start(context.Background())
+	if err == nil {
+		_ = sup.Stop(context.Background())
+		t.Fatal("Start succeeded with binary that exits before ready")
+	}
+}
+
+func TestSupervisor_Start_BinaryPrintsLineButNoHealth(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	// Point listen URL at a non-listening loopback port — health probe must
+	// surface ctx.Deadline rather than hang past supervisorStartTimeout.
+	binPath := writeFakeOpencodeServeBinary(t, "http://127.0.0.1:1", "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := sup.Start(ctx)
+	if err == nil {
+		_ = sup.Stop(context.Background())
+		t.Fatal("Start succeeded against non-listening URL")
+	}
+}
+
+func TestSupervisor_Stop_Idempotent(t *testing.T) {
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: "/never-started"})
+	if err := sup.Stop(context.Background()); err != nil {
+		t.Errorf("Stop on never-started supervisor: %v", err)
+	}
+}
+
+// newFakeHealthServer spins up an httptest server that responds 200 to
+// authenticated GET /health and 401 otherwise. The optional sessionsHandler
+// lets caller layer in additional routes for HTTP/SSE client tests.
+func newFakeHealthServer(t *testing.T, expectedPassword string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			u, p, ok := r.BasicAuth()
+			if !ok || u != supervisorAuthUsername {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if expectedPassword != "" && p != expectedPassword {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"healthy":true,"version":"fake"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+// writeFakeOpencodeServeBinary creates a sh script that prints the
+// expected listen line and either sleeps (mode=sleep, default for happy
+// path) or exits (mode=exit, for crash-before-ready coverage).
+func writeFakeOpencodeServeBinary(t *testing.T, fakeBaseURL, mode string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "opencode")
+	var body string
+	switch mode {
+	case "exit":
+		body = "exit 0"
+	default:
+		// exec sleep replaces the shell process image so SIGTERM is
+		// delivered straight to sleep, which terminates immediately.
+		// (Avoids the trap-while-sleep race on some POSIX shells.)
+		body = "exec sleep 600"
+	}
+	script := fmt.Sprintf("#!/bin/sh\necho \"opencode server listening on %s\"\n%s\n", fakeBaseURL, body)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return bin
+}
+
+func processAlive(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, errors.New("invalid pid")
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrProcessDone) {
+		return false, err
+	}
+	// macOS / linux: ESRCH from kill(2)
+	if isProcessNotFound(err) {
+		return false, err
+	}
+	return false, err
+}
+
+func isProcessNotFound(err error) bool {
+	var sysErr syscall.Errno
+	if errors.As(err, &sysErr) {
+		return sysErr == syscall.ESRCH
+	}
+	return false
+}
+
+func containsExact(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time sanity: ensure exec.ExitError is reachable for sad-path
+// assertions even when no test directly returns one.
+var _ = (*exec.ExitError)(nil)

--- a/worker/agent/version.go
+++ b/worker/agent/version.go
@@ -29,9 +29,12 @@ func (r *Runner) LogVersions(ctx context.Context, logger *slog.Logger) {
 }
 
 // detectVersion runs `command --version` with a per-agent timeout and
-// returns the trimmed first line. The first line is the convention for CLIs
-// that print a banner before the version (claude, codex, opencode all
-// conform). Caller decides how to surface failures.
+// returns the trimmed first line. The first line carries the
+// version-bearing string for the CLIs we wire today — claude / codex emit
+// a `<name> <version>` banner, opencode emits a bare semver (e.g.
+// `1.14.41`). Callers that need a parsed version (e.g.
+// CheckOpencodeVersion in opencode_version.go) interpret the returned
+// line per CLI. Caller decides how to surface failures.
 func detectVersion(ctx context.Context, command string) (string, error) {
 	versionCtx, cancel := context.WithTimeout(ctx, versionDetectTimeout)
 	defer cancel()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -116,6 +116,31 @@ func Run(cfg *config.Config) error {
 			"detected", detected,
 			"required", agent.MinimumOpencodeVersion,
 		)
+
+		// Spawn the long-running `opencode serve` child. Always-on at
+		// Stage 2 (lazy lifecycle stays Task 3.2-8 / Stage 3). Worker
+		// pool's N goroutines share the single supervisor via per-
+		// request `x-opencode-directory` header isolation.
+		serverLogger := logging.ComponentLogger(slog.Default(), "OpencodeServer")
+		supervisor := agent.NewSupervisor(agent.SupervisorConfig{
+			BinaryPath: opencodeAgent.Command,
+			StorageDir: cfg.Opencode.StorageDir,
+			Logger:     serverLogger,
+		})
+		if err := supervisor.Start(context.Background()); err != nil {
+			return fmt.Errorf("start opencode supervisor: %w", err)
+		}
+		agentRunner.SetOpencodeSupervisor(supervisor)
+		defer func() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer stopCancel()
+			if err := supervisor.Stop(stopCtx); err != nil {
+				appLogger.Warn("opencode supervisor stop 失敗",
+					"phase", "失敗",
+					"error", err,
+				)
+			}
+		}()
 	}
 
 	secretKey, err := crypto.DecodeSecretKey(cfg.SecretKey)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -83,6 +83,41 @@ func Run(cfg *config.Config) error {
 	agentRunner := agent.NewRunnerFromConfig(cfg)
 	agentRunner.LogVersions(context.Background(), appLogger)
 
+	if cfg.Opencode.Mode == config.OpencodeModeServer {
+		// Deliberately stricter than LogVersions's warn-and-continue: server
+		// mode wires HTTP/SSE contracts validated only against
+		// MinimumOpencodeVersion (see worker/agent/opencode_version.go and
+		// docs/specs/opencode-server-mode-poc-report.md). Booting below
+		// floor or with a broken binary would silently degrade ask answers,
+		// so this gate fails fast at the same phase as LogVersions.
+		versionLogger := logging.ComponentLogger(slog.Default(), "OpencodeVersion")
+		opencodeAgent, ok := cfg.Agents["opencode"]
+		if !ok {
+			versionLogger.Error("opencode.mode=server 但 worker.yaml agents.opencode 未定義",
+				"phase", "失敗",
+				"hint", "在 agents.opencode 加入定義，或將 opencode.mode 改回 spawn",
+			)
+			return fmt.Errorf("opencode provider not configured (worker.yaml agents.opencode missing while opencode.mode=server)")
+		}
+		detected, err := agent.CheckOpencodeVersion(context.Background(), opencodeAgent.Command)
+		if err != nil {
+			versionLogger.Error("opencode server-mode 版本檢查失敗",
+				"phase", "失敗",
+				"command", opencodeAgent.Command,
+				"detected", detected,
+				"required", agent.MinimumOpencodeVersion,
+				"error", err,
+			)
+			return fmt.Errorf("opencode server-mode version check failed: %w", err)
+		}
+		versionLogger.Info("opencode server-mode 版本通過門檻",
+			"phase", "完成",
+			"command", opencodeAgent.Command,
+			"detected", detected,
+			"required", agent.MinimumOpencodeVersion,
+		)
+	}
+
 	secretKey, err := crypto.DecodeSecretKey(cfg.SecretKey)
 	if err != nil {
 		return fmt.Errorf("invalid secret_key: %w", err)


### PR DESCRIPTION
## Summary

- 4 plan tasks: 3.2-4 version capability check · 3.2-5 always-on supervisor · 3.2-6 HTTP/SSE client · 3.2-7 wire runOneServer
- `cross-review pr` ran on the initial 4-commit branch; 1 Critical + 5 Major findings addressed in the 5th commit
- Default `opencode.mode: spawn` is unchanged — server mode stays opt-in; this PR lights up the runtime that backs the opt-in surface

## What's in this PR

### Task 3.2-4 — Opencode version capability check
- `MinimumOpencodeVersion = "1.14.41"` constant in `worker/agent/opencode_version.go`
- `CheckOpencodeVersion(ctx, binaryPath)` reuses `detectVersion` + three-segment numeric compare (no `x/mod/semver` dep — spec N4 stands)
- Worker boot calls it in `mode: server` right after `LogVersions`; below floor / probe failure → exit non-zero with Chinese error pointing to POC report. `mode: spawn` is completely unaffected.
- Stale comment in `worker/agent/version.go:33` corrected (opencode emits bare semver, not banner)

### Task 3.2-5 — Production server supervisor (always-on)
- `Supervisor.{Start, Stop, BaseURL, Password, ChildPID}` in `worker/agent/server_supervisor.go`
- Spawns `opencode serve --port 0 --hostname 127.0.0.1` with random `OPENCODE_SERVER_PASSWORD` (HTTP Basic) + `XDG_DATA_HOME = cfg.Opencode.StorageDir` for storage isolation (spec § Boundaries Always)
- Reads kernel-assigned port from `opencode server listening on http://...` stdout line — avoids the `pickFreePort` → `exec.Start` race window
- Polls `/health` for ready (10s budget); SIGTERM + 5s grace + SIGKILL teardown via `cmd.WaitDelay`
- Lazy lifecycle (`sync.Once` + idle-stop) explicitly stays Stage 3 Task 3.2-8 per plan

### Task 3.2-6 — HTTP/SSE client
- `Client.CreateSession(ctx, directory) → sessionID` (POST `/session` with `x-opencode-directory` header + Basic auth)
- `Client.SendPrompt(ctx, sessionID, directory, prompt) → (*PromptRun, error)`
- `PromptRun.{Events, SSEErrors, Wait, Close}` — channel + final-text resolver + non-fatal SSE error channel
- BusEvent envelope decoder in `worker/agent/opencode_events.go` produces `queue.StreamEvent{Type ∈ {message_delta, tool_use, result, error}}` — same taxonomy `ReadStreamJSONOpencode` populates, so downstream Slack render / status accumulator stay parser-agnostic

### Task 3.2-7 — Wire runOneServer happy path
- `Runner.supervisor *Supervisor` field + `SetOpencodeSupervisor` setter (extends Stage 1's plumbing pattern for new Runner fields)
- `runOneServer` replaces the Stage 1 stub: `OnStarted` / `OnEvent` / `OnExit` fire with parity to `runOneSpawn` (Stage 1 cross-review pre-mortem 6.1); OTel span attrs mirror `runOneSpawn` — `agent_type` / `duration_ms` / `stdout_len` / `exit_code` (pre-mortem 6.3)
- `worker/worker.go` wires `Supervisor.Start` before the pool starts and defers `Supervisor.Stop` on `Run()` exit
- Bug A discrimination (`finish=other` + `tokens.output=0`) explicitly deferred to Task 3.2-11 / Stage 3; `promptResponse` already carries those fields so the discriminator lifts in without altering this signature

### Cross-review fixes (commit 27aee02)

`cross-review pr` raised 1 Critical + 5 Major; all addressed in the final commit:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| C1 | 🔴 Critical | `tool_use` event 3x inflation (`pending` / `running` / `completed` part updates all emitted) | Gate on `state.status ∈ {completed, error}` per `opencode/src/cli/cmd/run.ts:623` |
| M1 | 🟡 Major | SSE close before POST aborted `Wait()` | POST is now authoritative; SSE errors via `PromptRun.SSEErrors`, `runOneServer` drains at warn |
| M2 | 🟡 Major | `session.error` SSE events silently dropped | Now emits `queue.StreamEvent{Type:"error"}` for Stage 3 retry / Bug A classifier |
| M3 | 🟡 Major | Per-step-finish `result` events overwrote tokens/cost in `worker/pool/status.go` | SSE consumer accumulates internally; emits ONE terminal `result` event on goroutine exit |
| M4 | 🟡 Major | `span.SetStatus(codes.Error)` parity gap for `exitCode > 0` with nil err | `runOneServer` deferred closure now matches `runOneSpawn`'s branch |
| M6 | 🟡 Major | `PromptRun.Close()` doc claimed it waited for goroutines; only cancels | Doc rewritten (fire-and-forget; `Wait` blocks for completion) |

## Drifts from spec / plan literal wording (intentional, documented)

1. **Plan Task 3.2-4 "fresh POC same PR" acceptance.** PR #258 already merged the POC report (`docs/specs/opencode-server-mode-poc-report.md`) to `main` with the 1.14.41 baseline, methodology blockquote, and historical bisect appendix. Spec § Bumping the floor expresses the institutional rule as "floor has POC backing"; this PR satisfies the gate via PR #258 rather than co-locating the report. Stage 2 manifest §1.1 + §3.1 records the reasoning.
2. **Spec line 88 / plan Task 3.2-6 "reuse ReadStreamJSONOpencode" wording.** Reading `opencode/packages/opencode/src/server/routes/instance/event.ts` confirmed the `/event` SSE emits BusEvent envelopes (`{"type":"message.part.updated","properties":{...}}`) — schema-incompatible with `ReadStreamJSONOpencode`'s NDJSON shape (`{"type":"text","part":{...}}`). The POC's `cmd/dev/poc-opencode-server/events.go` (on `refs/heads/poc/opencode-server-mode`) already shipped a dedicated decoder; Stage 2 follows POC. Output taxonomy preserved. Stage 2 manifest §3.5 records the reasoning; spec/plan body refresh is a docs follow-up outside Stage 2 scope.
3. **Plan Task 3.2-6 `SendPrompt` signature.** Plan acceptance writes `(<-chan queue.StreamEvent, error)`. This PR ships `(*PromptRun, error)` with the channel as a struct field plus `Wait/Close` methods. Channel-only would force `runOneServer` to either drop the POST response's authoritative final text (lossy — POST body is the answer source) or accumulate from SSE deltas (lossy — server emits the final text part once via `time.end`, not as a delta stream). Stage 2 manifest §1.7 records the reasoning.

## ⚠️ Do NOT flip `opencode.mode: server` in production yet

Bug A detection (`finish=other + tokens.output=0` discriminator) lands in **Stage 3 Task 3.2-11**, NOT in this PR. Without it, `runOneServer` will silently classify the empty-SSE Bug A pattern as a successful empty answer — the exact bug this whole spec was written to eliminate. Spec C1 keeps default `mode: spawn` precisely because of this; operators flipping to `mode: server` between this PR's ship and Stage 3 ship are exposed.

## Test plan
- [x] `go test ./worker/... ./shared/... ./test/...` — all green (count=1, CI default)
- [x] `go vet ./worker/...` — clean
- [x] commitlint validates every commit (5 commits, all conventional-conformant)
- [x] `cross-review pr` ran on the initial 4-commit branch; 1 Critical + 5 Major resolved in final commit
- [ ] Manual end-to-end test with a real `opencode 1.14.41` binary against a live Slack channel — gated on user-driven CI validation

## References
- Spec: `docs/specs/opencode-server-mode.md` — § Version Policy, § Boundaries, § Success Criteria F1–F8
- Plan: `docs/specs/opencode-server-mode-plan.md` — Stage 2 PR (Tasks 3.2-4..3.2-7), Checkpoint D
- ADR: `docs/adr/0005-opencode-server-mode.md`
- POC report: `docs/specs/opencode-server-mode-poc-report.md` — § P1–P10 results, § Historical bisect appendix proving 1.14.41 is the floor
- Stage 1 foundation: #259
- POC report ship: #258
- Manifest: `.claude/manifest/opencode-server-mode-stage-2.md` (not tracked; private session artifact)

## Known follow-ups (NOT in this PR)
- Spec / plan body refresh to acknowledge BusEvent decoder reality and `SendPrompt → *PromptRun` signature (docs-only PR)
- Stage 1 cross-review minor m1: plan body "4 agents × 2 modes = 8 cases" → "12 cases" (cosmetic docs cleanup)
- `Dockerfile.release:21` arm64 TARGETARCH bug (independent track)
- Pre-existing flake: `TestRunner_NonZeroExit_MarksSpanError` fails on `go test -count=2` (OTel tracer global state leak, predates Stage 2; CI uses count=1 so does not block)
- Cross-review Minor suggestions deferred to follow-ups: legacy `payload`-nested SSE envelope handling, shared `*http.Client` for TCP reuse, named const `supervisorStopTimeout`, additional dispatcher test for "Mode=server with missing agents.opencode entry"

🤖 Generated with [Claude Code](https://claude.com/claude-code)