### PR TITLE
feat(worker): opencode-server-mode Stage 3 — resilience (Tasks 3.2-8..3.2-12)

### DIFF
--- a/worker/agent/opencode_http.go
+++ b/worker/agent/opencode_http.go
@@ -330,9 +330,11 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 				// well above realistic per-job event counts; default
 				// case is paranoia for the impossible-in-practice case
 				// where drainer has stopped reading but channel isn't
-				// closed yet. Drop is acceptable — POST response also
-				// carries `tokens.output`, so cost data isn't unique
-				// to this event.
+				// closed yet. Token data is recoverable from the POST
+				// response; cost is uniquely emitted in this event and
+				// would be lost on the drop path. Acceptable trade-off:
+				// the drainer-stopped scenario implies the job is
+				// already failing somewhere else.
 			}
 		}
 		defer close(events)
@@ -362,10 +364,13 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 				hasStepFinish = true
 				continue
 			}
-			// Track that at least one text part landed via SSE; Stage 3
+			// Track that a non-empty text part landed via SSE; Stage 3
 			// Task 3.2-11's Bug A detector AND-gates on the absence of
-			// any text part as one of its three conditions.
-			if ev.Type == "message_delta" && sawText != nil {
+			// any *meaningful* text part. Empty-text deltas (TextBytes
+			// == 0) don't disqualify Bug A — opencode occasionally
+			// emits zero-byte text updates that carry no answer
+			// payload (cross-review pr finding).
+			if ev.Type == "message_delta" && ev.TextBytes > 0 && sawText != nil {
 				sawText.Store(true)
 			}
 			select {

--- a/worker/agent/opencode_http.go
+++ b/worker/agent/opencode_http.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Ivantseng123/agentdock/shared/queue"
 )
@@ -125,6 +126,13 @@ func (c *Client) CreateSession(ctx context.Context, directory string) (string, e
 // can correlate SSE disruption with downstream issues without aborting
 // otherwise-successful POST requests. (Cross-review M1 fix: SSE close
 // alone must not fail a job whose POST is still computing.)
+//
+// Finish / TokensOut / SawTextPart expose the three signals Stage 3
+// Task 3.2-11's Bug A detector AND-gates on. Finish and TokensOut are
+// cached from the POST response by Wait; SawTextPart is set by the
+// SSE consumer when any `message_delta` event is forwarded. Always
+// call Wait first, then the accessors — pre-Wait reads return zero
+// values.
 type PromptRun struct {
 	Events    <-chan queue.StreamEvent
 	SSEErrors <-chan error
@@ -133,6 +141,12 @@ type PromptRun struct {
 	responseCh   <-chan promptResponse
 	closeOnce    sync.Once
 	closedSignal chan struct{}
+
+	sawText *atomic.Bool
+
+	respMu        sync.Mutex
+	lastFinish    string
+	lastTokensOut int
 }
 
 type promptResponse struct {
@@ -149,20 +163,55 @@ type promptResponse struct {
 // request. Wait always cancels both goroutines on return; callers do
 // not need to defer Close after a successful Wait.
 //
-// Bug A detection (Task 3.2-11) will read `finish` and `tokensOut` on
-// the same response; Stage 2 only exposes `finalText` + transport
-// errors here. promptResponse keeps those fields populated so 3.2-11
-// can lift the discriminator in without expanding this signature.
+// Caches `finish` and `tokensOut` into PromptRun so the Bug A detector
+// in `runOneServer` can read them after Wait without expanding this
+// signature.
 func (r *PromptRun) Wait() (string, error) {
 	defer r.Close()
 	resp, ok := <-r.responseCh
 	if !ok {
 		return "", errors.New("opencode prompt response channel closed before sending")
 	}
+	r.respMu.Lock()
+	r.lastFinish = resp.finish
+	r.lastTokensOut = resp.tokensOut
+	r.respMu.Unlock()
 	if resp.err != nil {
 		return "", resp.err
 	}
 	return resp.finalText, nil
+}
+
+// Finish returns the POST response's `info.finish` reason, cached by
+// Wait. Returns "" before Wait completes or on a transport-error path
+// (no body decoded). Stage 3 Task 3.2-11 reads "other" here as one of
+// three Bug A conditions.
+func (r *PromptRun) Finish() string {
+	r.respMu.Lock()
+	defer r.respMu.Unlock()
+	return r.lastFinish
+}
+
+// TokensOut returns the POST response's `info.tokens.output`, cached
+// by Wait. Returns 0 before Wait completes or when the body omits the
+// tokens block. Stage 3 Task 3.2-11 reads 0 here as one of three Bug
+// A conditions.
+func (r *PromptRun) TokensOut() int {
+	r.respMu.Lock()
+	defer r.respMu.Unlock()
+	return r.lastTokensOut
+}
+
+// SawTextPart returns true when the SSE consumer forwarded at least
+// one `message_delta` event during this run. Used by Bug A detection
+// (Task 3.2-11) — when finish=other + tokens=0 + !SawTextPart all
+// hold, the run is the silent-drop signature and the job is failed
+// with the user-facing copy "LLM 回應為空，請稍後再試或改用 @bot issue".
+func (r *PromptRun) SawTextPart() bool {
+	if r.sawText == nil {
+		return false
+	}
+	return r.sawText.Load()
 }
 
 // Close cancels both goroutines but does NOT block waiting for their
@@ -195,7 +244,8 @@ func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt st
 	runCtx, cancel := context.WithCancel(ctx)
 	events := make(chan queue.StreamEvent, clientEventChannelSize)
 	sseErrCh := make(chan error, 1)
-	if err := c.subscribeEvents(runCtx, directory, events, sseErrCh); err != nil {
+	sawText := &atomic.Bool{}
+	if err := c.subscribeEvents(runCtx, directory, events, sseErrCh, sawText); err != nil {
 		cancel()
 		return nil, err
 	}
@@ -217,6 +267,7 @@ func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt st
 		cancel:       cancel,
 		responseCh:   responseCh,
 		closedSignal: closedSignal,
+		sawText:      sawText,
 	}, nil
 }
 
@@ -235,7 +286,7 @@ func (c *Client) SendPrompt(ctx context.Context, sessionID, directory, prompt st
 // circuit on these (cross-review M1 fix). Callers (runOneServer)
 // should log them at warn level so an operator can correlate SSE
 // disruption with downstream behavior.
-func (c *Client) subscribeEvents(ctx context.Context, directory string, events chan<- queue.StreamEvent, sseErrCh chan<- error) error {
+func (c *Client) subscribeEvents(ctx context.Context, directory string, events chan<- queue.StreamEvent, sseErrCh chan<- error, sawText *atomic.Bool) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/event", nil)
 	if err != nil {
 		return fmt.Errorf("build event request: %w", err)
@@ -310,6 +361,12 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 				cumCostUSD += ev.CostUSD
 				hasStepFinish = true
 				continue
+			}
+			// Track that at least one text part landed via SSE; Stage 3
+			// Task 3.2-11's Bug A detector AND-gates on the absence of
+			// any text part as one of its three conditions.
+			if ev.Type == "message_delta" && sawText != nil {
+				sawText.Store(true)
 			}
 			select {
 			case events <- ev:

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -52,6 +52,14 @@ import (
 // failure within retry surfaces as a hard error — no third attempt, no
 // fallback to spawn mode (spec C4).
 //
+// Stage 3 Task 3.2-11 Bug A: when the POST response carries `finish=
+// other` AND `tokens.output=0` AND the SSE consumer saw no text part,
+// the run hits the silent-drop signature and we mark the job failed
+// with the user-facing copy `LLM 回應為空，請稍後再試或改用 @bot issue`.
+// The three-condition AND-gate matches POC P7 (false-positive 0/100 on
+// the P2 success corpus). Bug A does not trigger retry — the silent
+// drop is an application-level outcome, not transport.
+//
 // Supervisor is owned by the worker's Runner; calling runOneServer
 // with r.supervisor == nil is a programming error (the dispatcher only
 // routes here when Mode == server, which is mutually exclusive with a
@@ -110,6 +118,14 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 		if attemptErr == nil {
 			exitCode = 0
 			return attemptOutput, nil
+		}
+		// Bug A: silent-drop signature. Mark span as application failure
+		// (exitCode=1, distinct from transport-layer -1) and surface
+		// immediately — retry can't fix a server that already returned
+		// `finish=other` + 0 output tokens.
+		if errors.Is(attemptErr, errOpencodeEmptyStream) {
+			exitCode = 1
+			return "", attemptErr
 		}
 		// Last attempt: surface error as-is (caller's runner.Run loops
 		// the agent chain). Don't double-wrap.
@@ -215,19 +231,52 @@ func (r *Runner) runOneServerAttempt(ctx context.Context, logger *slog.Logger, s
 	if err != nil {
 		return "", err
 	}
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
-		// Stage 2 placeholder. Stage 3 Task 3.2-11 promotes empty
-		// output (under the three-condition Bug A AND-gate) to an
-		// explicit failure.
-		logger.Warn("opencode 答案為空",
+
+	// Bug A AND-gate (Stage 3 Task 3.2-11): finish=other AND tokens.output=0
+	// AND no text part received via SSE. All three must hold — POC P7
+	// false-positive rate 0/100 on the P2 success corpus. Two-of-three
+	// is explicitly rejected by spec rationale.
+	if run.Finish() == "other" && run.TokensOut() == 0 && !run.SawTextPart() {
+		logger.Warn("Agent 執行失敗 (空 stream)",
 			"phase", "失敗",
 			"command", agent.Command,
 			"session_id", sessionID,
+			"finish", run.Finish(),
+			"tokens_output", run.TokensOut(),
+			"saw_text_part", run.SawTextPart(),
+		)
+		return "", errOpencodeEmptyStream
+	}
+
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		// Defensive: above gate is strict, but a trimmed-empty answer
+		// that didn't trip Bug A still warrants a warn so the operator
+		// can investigate. Job is not failed in this branch — the
+		// answer just happens to be whitespace.
+		logger.Warn("opencode 答案為空 (未命中 Bug A 三條件)",
+			"phase", "處理中",
+			"command", agent.Command,
+			"session_id", sessionID,
+			"finish", run.Finish(),
+			"tokens_output", run.TokensOut(),
+			"saw_text_part", run.SawTextPart(),
 		)
 	}
 	return trimmed, nil
 }
+
+// errOpencodeEmptyStream is the sentinel surfaced by Bug A detection.
+// Its message doubles as the Slack-visible failure copy spec mandates:
+// the worker error string flows verbatim into `r.Error` and is
+// rendered by app/workflow/ask.go's failed-path as
+// `:x: 思考失敗：<r.Error>`. The wrapping prefix from runner.go
+// ("all agents failed: opencode:") makes this less clean than a
+// direct app-side render special-case, but the spec § Boundaries
+// Ask first guard explicitly says do not widen scope to app/ without
+// approval. Stage 3 leaves the Slack copy slightly noisy; a follow-
+// up PR can clean it up by special-casing this sentinel in app/.
+var errOpencodeEmptyStream = errors.New("LLM 回應為空，請稍後再試或改用 @bot issue")
 
 // isRecoverableSupervisorCrash returns true when the error chain looks
 // like a transport-layer failure that retry-once can fix: either the

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +45,13 @@ import (
 //     duration_ms, stdout_len, exit_code) so Jaeger filters by
 //     `error=true` keep working across modes.
 //
+// Stage 3 Task 3.2-9 retry-once: when an attempt fails with a
+// recoverable transport-layer error (supervisor crashed, connection
+// refused, EOF mid-stream) the function transparently retries against a
+// fresh session and (after Acquire) a fresh server subprocess. A second
+// failure within retry surfaces as a hard error — no third attempt, no
+// fallback to spawn mode (spec C4).
+//
 // Supervisor is owned by the worker's Runner; calling runOneServer
 // with r.supervisor == nil is a programming error (the dispatcher only
 // routes here when Mode == server, which is mutually exclusive with a
@@ -71,10 +80,10 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 		span.SetAttributes(attrs...)
 		// Span status parity with runOneSpawn (cross-review M4): mark
 		// span as Error not only on Go err but also when exitCode > 0
-		// with nil err. Stage 2 only emits exitCode ∈ {-1, 0}, so the
-		// second branch is currently unreachable; Stage 3 Task 3.2-11's
-		// Bug A detector will emit positive exit codes, and Jaeger
-		// filters by `error=true` need this branch to keep working.
+		// with nil err. Stage 2 only emits exitCode ∈ {-1, 0}; Stage 3
+		// Task 3.2-11's Bug A detector will emit positive exit codes,
+		// and Jaeger filters by `error=true` need this branch to keep
+		// working.
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "agent run failed")
@@ -95,6 +104,41 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 	defer cancel()
 
 	sup := r.supervisor
+	const maxAttempts = 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		attemptOutput, attemptErr := r.runOneServerAttempt(ctx, logger, sup, agent, workDir, prompt, opts, attempt)
+		if attemptErr == nil {
+			exitCode = 0
+			return attemptOutput, nil
+		}
+		// Last attempt: surface error as-is (caller's runner.Run loops
+		// the agent chain). Don't double-wrap.
+		if attempt+1 >= maxAttempts {
+			return "", attemptErr
+		}
+		// Decide whether to retry. Only crashes / transport failures
+		// recover. 4xx, business-logic errors, and ctx cancellations
+		// surface immediately — retry can't fix them.
+		if !isRecoverableSupervisorCrash(attemptErr, sup) {
+			return "", attemptErr
+		}
+		logger.Warn("opencode server-mode retry-once 觸發",
+			"phase", "處理中",
+			"command", agent.Command,
+			"attempt", attempt+1,
+			"error", attemptErr,
+		)
+	}
+	// Loop above always returns explicitly; this is unreachable.
+	return "", errors.New("opencode server-mode retry-once exhausted (logic bug)")
+}
+
+// runOneServerAttempt is one Acquire/CreateSession/SendPrompt/Wait
+// cycle. Acquire is per-attempt so a crashed supervisor gets a fresh
+// spawn on retry (Stage 3 Task 3.2-9 spec line "fresh session against
+// the recovered server"). Returns the trimmed assistant text or a
+// transport / request error that the outer retry loop classifies.
+func (r *Runner) runOneServerAttempt(ctx context.Context, logger *slog.Logger, sup *Supervisor, agent config.AgentConfig, workDir, prompt string, opts RunOptions, attempt int) (string, error) {
 	if err := sup.Acquire(ctx); err != nil {
 		return "", fmt.Errorf("acquire opencode supervisor: %w", err)
 	}
@@ -102,7 +146,11 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 
 	client := NewClient(sup.BaseURL(), sup.Password(), nil)
 
-	if opts.OnStarted != nil {
+	// OnStarted fires only on attempt 0 — the pool status registry
+	// records one PID per job, and refiring on retry with the same
+	// supervisor PID would overwrite with identical data and noise
+	// the lifecycle log.
+	if opts.OnStarted != nil && attempt == 0 {
 		opts.OnStarted(sup.ChildPID(), agent.Command)
 	}
 	logger.Info("opencode server-mode session 啟動",
@@ -110,6 +158,7 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 		"command", agent.Command,
 		"supervisor_pid", sup.ChildPID(),
 		"base_url", sup.BaseURL(),
+		"attempt", attempt,
 	)
 
 	sessionID, err := client.CreateSession(ctx, workDir)
@@ -160,15 +209,17 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 		}
 	}()
 
-	output, err = run.Wait()
+	output, err := run.Wait()
 	<-drainDone
 
 	if err != nil {
 		return "", err
 	}
-	exitCode = 0
 	trimmed := strings.TrimSpace(output)
 	if trimmed == "" {
+		// Stage 2 placeholder. Stage 3 Task 3.2-11 promotes empty
+		// output (under the three-condition Bug A AND-gate) to an
+		// explicit failure.
 		logger.Warn("opencode 答案為空",
 			"phase", "失敗",
 			"command", agent.Command,
@@ -176,4 +227,48 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 		)
 	}
 	return trimmed, nil
+}
+
+// isRecoverableSupervisorCrash returns true when the error chain looks
+// like a transport-layer failure that retry-once can fix: either the
+// supervisor's state has already flipped to `crashed` (cmd.Wait
+// observed unexpected exit), or the error contains classic transport
+// signatures (connection refused / EOF / ErrUnexpectedEOF). Errors
+// that don't recover — 4xx from a healthy server, ctx cancellation,
+// Bug A (Stage 3 Task 3.2-11) — return false and surface immediately
+// without burning the retry budget.
+//
+// The state check covers the clean case where cmd.Wait already
+// observed the dead child by the time the HTTP request returned; the
+// error-signature fallback covers the race window where the child is
+// dead but the wait goroutine hasn't flipped state yet (TCP RST
+// arrives ahead of waitpid).
+func isRecoverableSupervisorCrash(err error, sup *Supervisor) bool {
+	if err == nil {
+		return false
+	}
+	if sup != nil && sup.State() == stateCrashed {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connection refused") {
+		return true
+	}
+	if strings.Contains(msg, "EOF") {
+		// Covers `EOF` and `unexpected EOF` from POSTs that lose the
+		// connection mid-stream (Go HTTP client wraps with "Post url:
+		// EOF"). Pairs with errors.Is checks above for the cases
+		// where the error chain preserves the typed sentinel.
+		return true
+	}
+	if strings.Contains(msg, "broken pipe") {
+		return true
+	}
+	return false
 }

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -112,9 +113,17 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 	defer cancel()
 
 	sup := r.supervisor
+	// onStartedFired tracks whether OnStarted has been delivered to
+	// the pool's status registry. Cross-review pr finding: the older
+	// `attempt == 0` gate skipped OnStarted when attempt 0 failed
+	// recoverably and attempt 1 succeeded, leaving status reporting /
+	// the kill registry without a PID for the job. Track the flip
+	// across attempts so the first SUCCESSFUL Acquire fires OnStarted,
+	// not the first ATTEMPT.
+	onStartedFired := &atomic.Bool{}
 	const maxAttempts = 2
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		attemptOutput, attemptErr := r.runOneServerAttempt(ctx, logger, sup, agent, workDir, prompt, opts, attempt)
+		attemptOutput, attemptErr := r.runOneServerAttempt(ctx, logger, sup, agent, workDir, prompt, opts, attempt, onStartedFired)
 		if attemptErr == nil {
 			exitCode = 0
 			return attemptOutput, nil
@@ -154,7 +163,7 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 // spawn on retry (Stage 3 Task 3.2-9 spec line "fresh session against
 // the recovered server"). Returns the trimmed assistant text or a
 // transport / request error that the outer retry loop classifies.
-func (r *Runner) runOneServerAttempt(ctx context.Context, logger *slog.Logger, sup *Supervisor, agent config.AgentConfig, workDir, prompt string, opts RunOptions, attempt int) (string, error) {
+func (r *Runner) runOneServerAttempt(ctx context.Context, logger *slog.Logger, sup *Supervisor, agent config.AgentConfig, workDir, prompt string, opts RunOptions, attempt int, onStartedFired *atomic.Bool) (string, error) {
 	if err := sup.Acquire(ctx); err != nil {
 		return "", fmt.Errorf("acquire opencode supervisor: %w", err)
 	}
@@ -162,11 +171,12 @@ func (r *Runner) runOneServerAttempt(ctx context.Context, logger *slog.Logger, s
 
 	client := NewClient(sup.BaseURL(), sup.Password(), nil)
 
-	// OnStarted fires only on attempt 0 — the pool status registry
-	// records one PID per job, and refiring on retry with the same
-	// supervisor PID would overwrite with identical data and noise
-	// the lifecycle log.
-	if opts.OnStarted != nil && attempt == 0 {
+	// OnStarted fires once per runOneServer call, at the first
+	// successful Acquire. CompareAndSwap so the second attempt's
+	// Acquire-after-retry still fires it if attempt 0's Acquire
+	// failed before this point (the pool's status registry needs
+	// a PID; missing one means /kill can't find the job).
+	if opts.OnStarted != nil && onStartedFired != nil && onStartedFired.CompareAndSwap(false, true) {
 		opts.OnStarted(sup.ChildPID(), agent.Command)
 	}
 	logger.Info("opencode server-mode session 啟動",
@@ -309,11 +319,12 @@ func isRecoverableSupervisorCrash(err error, sup *Supervisor) bool {
 	if strings.Contains(msg, "connection refused") {
 		return true
 	}
-	if strings.Contains(msg, "EOF") {
-		// Covers `EOF` and `unexpected EOF` from POSTs that lose the
-		// connection mid-stream (Go HTTP client wraps with "Post url:
-		// EOF"). Pairs with errors.Is checks above for the cases
-		// where the error chain preserves the typed sentinel.
+	if strings.Contains(msg, ": EOF") || strings.Contains(msg, "unexpected EOF") {
+		// Anchored matches: Go's HTTP client wraps post-EOF as
+		// `Post "url": EOF`, scanner errors as `... unexpected EOF`.
+		// The leading `: ` and `unexpected ` anchors avoid false
+		// positives like a future "session reached EOF state" message
+		// (cross-review pr finding).
 		return true
 	}
 	if strings.Contains(msg, "broken pipe") {

--- a/worker/agent/opencode_server.go
+++ b/worker/agent/opencode_server.go
@@ -95,6 +95,11 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 	defer cancel()
 
 	sup := r.supervisor
+	if err := sup.Acquire(ctx); err != nil {
+		return "", fmt.Errorf("acquire opencode supervisor: %w", err)
+	}
+	defer sup.Release()
+
 	client := NewClient(sup.BaseURL(), sup.Password(), nil)
 
 	if opts.OnStarted != nil {
@@ -111,6 +116,8 @@ func (r *Runner) runOneServer(ctx context.Context, logger *slog.Logger, agent co
 	if err != nil {
 		return "", fmt.Errorf("create opencode session: %w", err)
 	}
+	sup.SetActiveSession(sessionID)
+	defer sup.ClearActiveSession(sessionID)
 	logger.Info("opencode session 已建立",
 		"phase", "處理中",
 		"command", agent.Command,

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -16,17 +16,18 @@ import (
 	"github.com/Ivantseng123/agentdock/worker/config"
 )
 
-// primedSupervisor builds a Supervisor in the "started" state pointed
+// primedSupervisor builds a Supervisor in the running state pointed
 // at a test HTTP server. Bypasses the real `opencode serve` spawn so
 // runOneServer can be exercised end-to-end against httptest fakes
 // without a real opencode binary. Test-only — production boot uses
-// NewSupervisor + Start.
+// NewSupervisor + lazy Acquire.
 func primedSupervisor(baseURL, password string, pid int) *Supervisor {
 	return &Supervisor{
-		baseURL:  baseURL,
-		password: password,
-		pid:      pid,
-		started:  true,
+		baseURL:        baseURL,
+		password:       password,
+		pid:            pid,
+		state:          stateRunning,
+		activeSessions: make(map[string]struct{}),
 	}
 }
 

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -286,6 +286,83 @@ func TestRunOneServer_RetryOnce_RecoversFromTransportError(t *testing.T) {
 	}
 }
 
+// TestRunOneServer_OnStarted_FiresOnFirstSuccessfulAcquire verifies
+// the cross-review pr fix for OnStarted on retry-once. Older code
+// gated OnStarted on `attempt == 0`, which skipped firing when
+// attempt 0 failed recoverably and attempt 1 succeeded — leaving the
+// pool's status registry without a PID for the job. Fix: track the
+// fire flag across attempts; first SUCCESSFUL Acquire fires it.
+func TestRunOneServer_OnStarted_FiresOnFirstSuccessfulAcquire(t *testing.T) {
+	var (
+		sessionCalls atomic.Int32
+		onStartedHit atomic.Int32
+		gotPID       atomic.Int64
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			n := sessionCalls.Add(1)
+			if n == 1 {
+				// Attempt 0: hijack to simulate transport failure.
+				hj, _ := w.(http.Hijacker)
+				conn, _, _ := hj.Hijack()
+				_ = conn.Close()
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"ses_retry_onstart"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{
+				`{"id":"e1","type":"message.part.updated","properties":{"part":{"type":"text","text":"ok"}}}`,
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"input":1,"output":2}},"parts":[{"type":"text","text":"answer"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 12321)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{
+			OnStarted: func(pid int, command string) {
+				onStartedHit.Add(1)
+				gotPID.Store(int64(pid))
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("runOneServer (retry expected to succeed): %v", err)
+	}
+	if output != "answer" {
+		t.Errorf("output = %q, want %q", output, "answer")
+	}
+	if got := onStartedHit.Load(); got != 1 {
+		t.Errorf("OnStarted call count = %d, want exactly 1 (first successful Acquire)", got)
+	}
+	if got := gotPID.Load(); got != 12321 {
+		t.Errorf("OnStarted PID = %d, want 12321", got)
+	}
+}
+
 // TestRunOneServer_RetryOnce_SecondFailureSurfaces verifies the hard-
 // fail behavior: both attempts hit transport failures, retry-once does
 // NOT escalate to a third attempt, and the second attempt's error is

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -407,6 +407,163 @@ func TestIsRecoverableSupervisorCrash(t *testing.T) {
 	}
 }
 
+// TestRunOneServer_BugA_TriggersOnSilentDropSignature verifies the
+// Stage 3 Task 3.2-11 strict three-condition AND-gate: finish=other +
+// tokens.output=0 + no message_delta event over SSE → fail loud with
+// the user-facing copy. The error string matches the spec verbatim so
+// the existing failure render in app/workflow/ask.go HandleResult
+// shows it to the user without app-side changes.
+func TestRunOneServer_BugA_TriggersOnSilentDropSignature(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:    "ses_bug_a",
+		finalText:    "",
+		finishReason: "other",
+		outputTokens: 0,
+		sseEvents: []string{
+			`{"id":"e1","type":"server.connected","properties":{}}`,
+			// No `message.part.updated` text events — silent drop.
+		},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 65432)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected Bug A error, got nil")
+	}
+	if !errors.Is(err, errOpencodeEmptyStream) {
+		t.Errorf("error %v is not errOpencodeEmptyStream", err)
+	}
+	if got := err.Error(); got != "LLM 回應為空，請稍後再試或改用 @bot issue" {
+		t.Errorf("error message = %q, want spec copy verbatim", got)
+	}
+	if output != "" {
+		t.Errorf("output = %q, want empty on Bug A failure", output)
+	}
+}
+
+// TestRunOneServer_BugA_NotTriggered_WhenTextReceived verifies the
+// AND-gate's text-part clause: even if finish=other + tokens=0, a
+// single message_delta event over SSE is enough to disqualify the
+// Bug A signature. Runs return the (empty) text payload as-is.
+func TestRunOneServer_BugA_NotTriggered_WhenTextReceived(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:    "ses_no_bugA_text",
+		finalText:    "",
+		finishReason: "other",
+		outputTokens: 0,
+		sseEvents: []string{
+			`{"id":"e1","type":"message.part.updated","properties":{"part":{"type":"text","text":"partial"}}}`,
+		},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 65431)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error (saw text, should not be Bug A): %v", err)
+	}
+	if output != "" {
+		t.Errorf("output = %q, want empty (POST body had empty parts)", output)
+	}
+}
+
+// TestRunOneServer_BugA_NotTriggered_WhenTokensNonZero verifies the
+// AND-gate's tokens clause: finish=other + no text + tokens>0 is not
+// Bug A (the model produced something, even if no text emerged).
+func TestRunOneServer_BugA_NotTriggered_WhenTokensNonZero(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:    "ses_no_bugA_tokens",
+		finalText:    "",
+		finishReason: "other",
+		outputTokens: 5,
+		sseEvents: []string{
+			`{"id":"e1","type":"server.connected","properties":{}}`,
+		},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 65430)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error (tokens>0, not Bug A): %v", err)
+	}
+	_ = output
+}
+
+// TestRunOneServer_BugA_NotTriggered_WhenFinishStop verifies the
+// AND-gate's finish-reason clause: finish=stop is a normal termination
+// regardless of token count or text presence. Most no-op-style
+// answers ("say OK") would hit finish=stop + tokens>0 but this case
+// (finish=stop + tokens=0) still must not trip Bug A.
+func TestRunOneServer_BugA_NotTriggered_WhenFinishStop(t *testing.T) {
+	srv := newFakeOpencodeServer(t, fakeOpencodeBehavior{
+		sessionID:    "ses_no_bugA_finish",
+		finalText:    "",
+		finishReason: "stop",
+		outputTokens: 0,
+		sseEvents: []string{
+			`{"id":"e1","type":"server.connected","properties":{}}`,
+		},
+	})
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 65429)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error (finish=stop, not Bug A): %v", err)
+	}
+	_ = output
+}
+
 // TestRunOneServer_SSECloseEarly_POSTAuthoritative verifies the M1
 // fix at the runOneServer layer: SSE close before POST completes
 // must NOT abort the job — runOneServer logs the SSE error at warn

--- a/worker/agent/opencode_server_test.go
+++ b/worker/agent/opencode_server_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"github.com/Ivantseng123/agentdock/shared/queue"
@@ -209,6 +211,199 @@ func TestRunOneServer_POSTMessageError_OnExitMinusOne(t *testing.T) {
 	}
 	if exitCode.Load() != -1 {
 		t.Errorf("OnExit code = %d, want -1", exitCode.Load())
+	}
+}
+
+// TestRunOneServer_RetryOnce_RecoversFromTransportError verifies the
+// Stage 3 Task 3.2-9 retry-once contract: when the first attempt hits
+// a transport-layer failure (here, the server hijacks and closes the
+// /session POST mid-call, producing EOF on the client), runOneServer
+// transparently retries against the same supervisor and returns the
+// second attempt's answer. Tests EOF-string fallback in
+// isRecoverableSupervisorCrash, since primedSupervisor never flips
+// state to crashed (no real child process).
+func TestRunOneServer_RetryOnce_RecoversFromTransportError(t *testing.T) {
+	var sessionCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			n := sessionCalls.Add(1)
+			if n == 1 {
+				// Simulate transport-layer failure: hijack + close so
+				// client sees Post URL: EOF.
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					http.Error(w, "hijacker unavailable", http.StatusInternalServerError)
+					return
+				}
+				conn, _, _ := hj.Hijack()
+				_ = conn.Close()
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"ses_retry"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{
+				`{"id":"e1","type":"message.part.updated","properties":{"part":{"type":"text","text":"hello"}}}`,
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"input":1,"output":2}},"parts":[{"type":"text","text":"retried answer"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 99999)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	output, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err != nil {
+		t.Fatalf("runOneServer (retry expected to succeed): %v", err)
+	}
+	if output != "retried answer" {
+		t.Errorf("output = %q, want %q", output, "retried answer")
+	}
+	if got := sessionCalls.Load(); got != 2 {
+		t.Errorf("CreateSession calls = %d, want 2 (attempt + retry)", got)
+	}
+}
+
+// TestRunOneServer_RetryOnce_SecondFailureSurfaces verifies the hard-
+// fail behavior: both attempts hit transport failures, retry-once does
+// NOT escalate to a third attempt, and the second attempt's error is
+// surfaced to the caller. Spec C4 — no fallback to spawn mode.
+func TestRunOneServer_RetryOnce_SecondFailureSurfaces(t *testing.T) {
+	var sessionCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/session" {
+			sessionCalls.Add(1)
+			hj, _ := w.(http.Hijacker)
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 88888)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	_, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected hard error after 2 failed attempts")
+	}
+	if got := sessionCalls.Load(); got != 2 {
+		t.Errorf("CreateSession calls = %d, want exactly 2 (no third attempt)", got)
+	}
+}
+
+// TestRunOneServer_NoRetryOnApplicationError verifies retry-once does
+// NOT fire on a non-transport failure (here, 400 Bad Request from
+// CreateSession). Retry budget must be reserved for crashes — burning
+// it on application errors burns latency for no recovery benefit.
+func TestRunOneServer_NoRetryOnApplicationError(t *testing.T) {
+	var sessionCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != supervisorAuthUsername || p != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/session" {
+			sessionCalls.Add(1)
+			http.Error(w, `{"error":"directory missing"}`, http.StatusBadRequest)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	sup := primedSupervisor(srv.URL, "secret", 77777)
+	r := &Runner{
+		opencodeCfg: config.OpencodeConfig{Mode: config.OpencodeModeServer},
+		supervisor:  sup,
+	}
+
+	_, err := r.runOneServer(
+		context.Background(),
+		slog.Default(),
+		config.AgentConfig{Command: "opencode"},
+		"/tmp/work",
+		"prompt",
+		RunOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected error from 400 CreateSession")
+	}
+	if got := sessionCalls.Load(); got != 1 {
+		t.Errorf("CreateSession calls = %d, want 1 (no retry on 4xx)", got)
+	}
+}
+
+// TestIsRecoverableSupervisorCrash exhaustively covers the classifier
+// matrix used by retry-once in runOneServer. The supervisor state hook
+// is tested via direct field mutation rather than a real crash; the
+// error-signature fallback is tested with the canonical error chains.
+func TestIsRecoverableSupervisorCrash(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		state     supervisorState
+		want      bool
+	}{
+		{"nil-err", nil, stateRunning, false},
+		{"state-crashed-any-err", errors.New("does not matter"), stateCrashed, true},
+		{"econnrefused-typed", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), stateRunning, true},
+		{"econnrefused-string", errors.New("Post http://x: dial tcp 127.0.0.1:5000: connection refused"), stateRunning, true},
+		{"eof-typed", fmt.Errorf("post: %w", io.EOF), stateRunning, true},
+		{"unexpected-eof-typed", fmt.Errorf("read: %w", io.ErrUnexpectedEOF), stateRunning, true},
+		{"eof-string", errors.New("Post http://x: EOF"), stateRunning, true},
+		{"broken-pipe-string", errors.New("write tcp: broken pipe"), stateRunning, true},
+		{"4xx-no-retry", errors.New("create-session status 400: bad input"), stateRunning, false},
+		{"ctx-canceled-no-retry", context.Canceled, stateRunning, false},
+		{"ctx-deadline-no-retry", context.DeadlineExceeded, stateRunning, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sup := &Supervisor{}
+			sup.state = tc.state
+			got := isRecoverableSupervisorCrash(tc.err, sup)
+			if got != tc.want {
+				t.Errorf("isRecoverableSupervisorCrash(%v, state=%s) = %v, want %v", tc.err, tc.state, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/worker/agent/server_supervisor.go
+++ b/worker/agent/server_supervisor.go
@@ -19,16 +19,21 @@ import (
 	"time"
 )
 
-// Server supervisor for `opencode serve`. Stage 2 is always-on: Start is
-// called at worker boot, Stop on worker shutdown. Lazy lifecycle (spawn on
-// first job, idle-stop, sync.Once boot lock) is deferred to plan Task
-// 3.2-8 / Stage 3.
+// Server supervisor for `opencode serve`. Stage 3 makes the lifecycle
+// lazy: worker boot no longer Starts the server. The first job to call
+// `Acquire` triggers spawn; when `activeCount` drops to zero an idle
+// timer auto-stops the child after `IdleTimeout`. The existing `Start`
+// method is preserved for tests and any eager-spawn caller; production
+// boot path uses Acquire/Release instead.
 
 const (
 	supervisorStartTimeout   = 10 * time.Second
 	supervisorStopGrace      = 5 * time.Second
 	supervisorHealthInterval = 200 * time.Millisecond
 	supervisorHealthRequest  = 2 * time.Second
+	supervisorStopTimeout    = 10 * time.Second
+	supervisorDrainBudget    = 30 * time.Second
+	supervisorAbortRequest   = 5 * time.Second
 	supervisorAuthUsername   = "opencode"
 )
 
@@ -39,11 +44,46 @@ const (
 // pickFreePort → exec.Start race window).
 var supervisorListenLine = regexp.MustCompile(`opencode server listening on (https?://\S+)`)
 
-// SupervisorConfig is the supervisor's constructor input.
+// supervisorState is the supervisor's internal lifecycle phase. Single-
+// writer transitions under s.mu; readers may inspect via `State()` for
+// retry-once decisions (Stage 3 Task 3.2-9). Not a stable contract — the
+// enum is internal-but-exported only because the retry classifier in
+// `runOneServer` needs to read `stateCrashed`.
+type supervisorState int
+
+const (
+	stateIdle supervisorState = iota
+	stateStarting
+	stateRunning
+	stateStopping
+	stateCrashed
+)
+
+func (s supervisorState) String() string {
+	switch s {
+	case stateIdle:
+		return "idle"
+	case stateStarting:
+		return "starting"
+	case stateRunning:
+		return "running"
+	case stateStopping:
+		return "stopping"
+	case stateCrashed:
+		return "crashed"
+	}
+	return "unknown"
+}
+
+// SupervisorConfig is the supervisor's constructor input. IdleTimeout is
+// the auto-stop window after activeCount → 0 in lazy mode; zero disables
+// idle stop (server stays up until Drain). Stage 2's always-on caller
+// (eager `Start`) ignores IdleTimeout entirely.
 type SupervisorConfig struct {
-	BinaryPath string
-	StorageDir string
-	Logger     *slog.Logger
+	BinaryPath  string
+	StorageDir  string
+	IdleTimeout time.Duration
+	Logger      *slog.Logger
 }
 
 // Supervisor holds the long-running `opencode serve` child process for a
@@ -51,38 +91,522 @@ type SupervisorConfig struct {
 // the same BaseURL/Password via per-request `x-opencode-directory` header
 // isolation (see spec § Code Style and § Boundaries Always: server-pool
 // mapping = 1:N).
+//
+// Lifecycle (Stage 3, lazy):
+//
+//	idle → starting (first Acquire triggers spawn under boot lock)
+//	starting → running (spawn done, /health green)
+//	running → running (Acquire bumps activeCount; Release decrements;
+//	                   activeCount==0 starts idle timer)
+//	running → stopping (idle timer fires OR Drain called)
+//	stopping → idle (clean child exit)
+//	running → crashed (cmd.Wait returns unexpectedly; retry-once re-
+//	                   spawns via the same Acquire path Stage 3 Task
+//	                   3.2-9 wires)
+//	crashed → starting (next Acquire triggers re-spawn)
+//
+// shuttingDown is a one-shot latch flipped by Drain so post-Drain Acquires
+// fail loud rather than re-spawning during process teardown.
 type Supervisor struct {
 	cfg SupervisorConfig
 
-	mu       sync.Mutex
+	mu           sync.Mutex
+	state        supervisorState
+	activeCount  int
+	idleTimer    *time.Timer
+	shuttingDown bool
+	// spawnReady is closed when the in-flight spawn settles (success or
+	// failure). Stage 3 Acquire coalesces concurrent first-job goroutines
+	// onto this channel rather than spinning a sync.Cond — channel close
+	// is broadcast-safe and composes with ctx.Done in a select.
+	spawnReady chan struct{}
+	spawnErr   error
+	// activeSessions tracks the in-flight session IDs so Drain can issue
+	// POST /session/{id}/abort to each. Maintained by SetActiveSession /
+	// ClearActiveSession from runOneServer once a session is created.
+	activeSessions map[string]struct{}
+
 	cmd      *exec.Cmd
 	cancel   context.CancelFunc
 	baseURL  string
 	password string
 	pid      int
-	started  bool
-	waitErr  chan error
+	// exitCh is closed by the spawn's wait goroutine after cmd.Wait
+	// returns. waitErr captures that return value and is safe to read
+	// only after exitCh has closed. Two readers (internalStop and
+	// idleStop / Drain via internalStop) coordinate via the close-as-
+	// broadcast pattern — no chan-receive race.
+	exitCh  chan struct{}
+	waitErr error
 }
 
-// NewSupervisor constructs a Supervisor; call Start to spawn the child.
+// NewSupervisor constructs a Supervisor; call Acquire (lazy) or Start
+// (eager) to spawn the child.
 func NewSupervisor(cfg SupervisorConfig) *Supervisor {
-	return &Supervisor{cfg: cfg}
+	return &Supervisor{
+		cfg:            cfg,
+		state:          stateIdle,
+		activeSessions: make(map[string]struct{}),
+	}
 }
 
-// Start spawns `opencode serve --port 0 --hostname 127.0.0.1` with an
-// isolated XDG_DATA_HOME (spec § Boundaries Always: storage isolation) and
-// a random OPENCODE_SERVER_PASSWORD. Blocks until the child prints its
-// listen URL AND GET /health returns 200, both within
-// supervisorStartTimeout. Returns an error if the binary is missing,
-// crashes before becoming ready, or never reports healthy in time.
+// Start spawns the opencode serve child immediately and transitions the
+// supervisor to `running` without bumping activeCount. Stage 3 worker
+// boot does NOT call this — the lazy path via Acquire is preferred so
+// idle workers don't hold an opencode process. Kept for tests and any
+// caller that needs to confirm the binary is launchable at boot.
+//
+// Returns an error if the binary is missing, crashes before becoming
+// ready, or if Start is called on a supervisor not in `idle` state.
 func (s *Supervisor) Start(ctx context.Context) error {
 	s.mu.Lock()
-	if s.started {
+	if s.shuttingDown {
 		s.mu.Unlock()
-		return errors.New("supervisor already started")
+		return errors.New("supervisor shutting down")
 	}
+	if s.state != stateIdle {
+		curr := s.state
+		s.mu.Unlock()
+		return fmt.Errorf("supervisor already started (state=%s)", curr)
+	}
+	s.state = stateStarting
+	s.spawnReady = make(chan struct{})
 	s.mu.Unlock()
 
+	err := s.spawn(ctx)
+
+	s.mu.Lock()
+	if err != nil {
+		s.state = stateIdle
+		s.spawnErr = err
+		close(s.spawnReady)
+		s.mu.Unlock()
+		return err
+	}
+	s.state = stateRunning
+	close(s.spawnReady)
+	s.mu.Unlock()
+	return nil
+}
+
+// Acquire reserves one slot on the supervisor for an in-flight job. If
+// the supervisor is `idle` (or `crashed`), the caller becomes the
+// spawner; concurrent Acquires coalesce on `spawnReady`. Cancels any
+// pending idle timer on success.
+//
+// Returns an error if the supervisor is shutting down (Drain has been
+// called) or if the spawn ultimately fails.
+func (s *Supervisor) Acquire(ctx context.Context) error {
+	s.mu.Lock()
+	for {
+		if s.shuttingDown {
+			s.mu.Unlock()
+			return errors.New("supervisor shutting down")
+		}
+		switch s.state {
+		case stateRunning:
+			s.activeCount++
+			if s.idleTimer != nil {
+				s.idleTimer.Stop()
+				s.idleTimer = nil
+			}
+			s.mu.Unlock()
+			return nil
+		case stateStarting:
+			readyCh := s.spawnReady
+			s.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-readyCh:
+			}
+			s.mu.Lock()
+			// Re-evaluate state after spawn settles.
+			continue
+		case stateStopping:
+			// Either idle-timer stop or Drain. For idle stop, wait until
+			// stopping completes (transitions to idle), then retry. For
+			// drain, shuttingDown=true so the next iteration of this loop
+			// will surface the error.
+			readyCh := s.spawnReady
+			if readyCh == nil {
+				// stopping without a paired ready channel means the stop
+				// was initiated outside of Acquire's view; fall back to
+				// brief sleep + re-check.
+				s.mu.Unlock()
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(50 * time.Millisecond):
+				}
+				s.mu.Lock()
+				continue
+			}
+			s.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-readyCh:
+			}
+			s.mu.Lock()
+			continue
+		case stateIdle, stateCrashed:
+			s.state = stateStarting
+			s.spawnReady = make(chan struct{})
+			s.mu.Unlock()
+			err := s.spawn(ctx)
+			s.mu.Lock()
+			if err != nil {
+				s.state = stateIdle
+				s.spawnErr = err
+				close(s.spawnReady)
+				s.spawnReady = nil
+				s.mu.Unlock()
+				return err
+			}
+			s.state = stateRunning
+			s.activeCount++
+			close(s.spawnReady)
+			s.spawnReady = nil
+			s.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// Release decrements activeCount. When the count reaches zero the idle
+// timer is armed (`cfg.IdleTimeout`) to auto-stop the child. Safe to call
+// on a supervisor in any non-idle state; a no-op if activeCount is
+// already zero (defensive — should not happen in correct usage).
+func (s *Supervisor) Release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeCount <= 0 {
+		return
+	}
+	s.activeCount--
+	if s.activeCount != 0 || s.state != stateRunning || s.shuttingDown {
+		return
+	}
+	if s.cfg.IdleTimeout <= 0 {
+		return
+	}
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+	}
+	s.idleTimer = time.AfterFunc(s.cfg.IdleTimeout, s.idleStop)
+}
+
+// State returns the current supervisor lifecycle phase. Reserved for
+// the retry-once classifier in Task 3.2-9 (`runOneServer` reads
+// `stateCrashed` to decide whether to spawn-and-retry vs. fail loud).
+// Not a stable cross-package contract.
+func (s *Supervisor) State() supervisorState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// SetActiveSession registers a session ID for drain bookkeeping. Called
+// from runOneServer after CreateSession succeeds; Drain reads this set
+// to know which abort endpoints to hit.
+func (s *Supervisor) SetActiveSession(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeSessions[sessionID] = struct{}{}
+}
+
+// ClearActiveSession is the runOneServer-side counterpart to
+// SetActiveSession. Called from the same defer that calls Release.
+func (s *Supervisor) ClearActiveSession(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.activeSessions, sessionID)
+}
+
+// idleStop is the idle-timer callback. Runs on a fresh goroutine; takes
+// the supervisor lock to confirm the stop conditions are still valid and
+// hands off to internalStop. If state has moved away from `running` by
+// the time the timer fires (e.g. a new Acquire raced ahead), the stop
+// is silently skipped.
+func (s *Supervisor) idleStop() {
+	s.mu.Lock()
+	if s.state != stateRunning || s.activeCount != 0 || s.shuttingDown {
+		s.mu.Unlock()
+		return
+	}
+	s.state = stateStopping
+	s.spawnReady = make(chan struct{})
+	cancelRun := s.cancel
+	exitCh := s.exitCh
+	pid := s.pid
+	s.mu.Unlock()
+
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("opencode serve 進入 idle stop",
+			"phase", "處理中",
+			"pid", pid,
+			"idle_timeout", s.cfg.IdleTimeout,
+		)
+	}
+
+	s.internalStop(context.Background(), cancelRun, exitCh, pid)
+
+	s.mu.Lock()
+	s.state = stateIdle
+	s.idleTimer = nil
+	close(s.spawnReady)
+	s.spawnReady = nil
+	s.mu.Unlock()
+}
+
+// Stop signals SIGTERM to the child and waits up to grace + 2s for it
+// to exit. Provided as a backstop / always-on tear-down (e.g. for tests).
+// Production worker shutdown should call Drain, which aborts active
+// sessions first. Idempotent.
+func (s *Supervisor) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	if s.state != stateRunning {
+		s.mu.Unlock()
+		return nil
+	}
+	s.state = stateStopping
+	s.spawnReady = make(chan struct{})
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+		s.idleTimer = nil
+	}
+	cancelRun := s.cancel
+	exitCh := s.exitCh
+	pid := s.pid
+	s.mu.Unlock()
+
+	err := s.internalStop(ctx, cancelRun, exitCh, pid)
+
+	s.mu.Lock()
+	s.state = stateIdle
+	close(s.spawnReady)
+	s.spawnReady = nil
+	s.mu.Unlock()
+	return err
+}
+
+// Drain is the worker-shutdown teardown. Snapshots active session IDs,
+// POSTs `/session/{id}/abort` to each (subject to `supervisorDrainBudget`),
+// then SIGTERMs the child. Sets `shuttingDown=true` permanently so any
+// post-Drain Acquire fails fast rather than re-spawning during process
+// teardown.
+//
+// Returns an error only if the abort phase itself errors hard (e.g. the
+// abort budget expires with sessions still active). The teardown of
+// the child still proceeds via internalStop.
+func (s *Supervisor) Drain(ctx context.Context) error {
+	s.mu.Lock()
+	if s.shuttingDown {
+		s.mu.Unlock()
+		return nil
+	}
+	s.shuttingDown = true
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+		s.idleTimer = nil
+	}
+	if s.state != stateRunning {
+		s.mu.Unlock()
+		return nil
+	}
+	sessions := make([]string, 0, len(s.activeSessions))
+	for id := range s.activeSessions {
+		sessions = append(sessions, id)
+	}
+	baseURL := s.baseURL
+	password := s.password
+	s.state = stateStopping
+	s.spawnReady = make(chan struct{})
+	cancelRun := s.cancel
+	exitCh := s.exitCh
+	pid := s.pid
+	s.mu.Unlock()
+
+	var drainErr error
+	if len(sessions) > 0 {
+		if s.cfg.Logger != nil {
+			s.cfg.Logger.Info("opencode supervisor 開始 drain",
+				"phase", "處理中",
+				"active_sessions", len(sessions),
+				"budget", supervisorDrainBudget,
+			)
+		}
+		drainErr = s.abortSessions(ctx, baseURL, password, sessions)
+	}
+
+	stopErr := s.internalStop(ctx, cancelRun, exitCh, pid)
+
+	s.mu.Lock()
+	s.state = stateIdle
+	close(s.spawnReady)
+	s.spawnReady = nil
+	s.mu.Unlock()
+
+	if drainErr != nil {
+		return drainErr
+	}
+	return stopErr
+}
+
+// abortSessions POSTs /session/{id}/abort for each active session, in
+// parallel, with a per-call short timeout and a global budget of
+// supervisorDrainBudget. Errors are logged at warn level; the function
+// returns nil if every abort either succeeded or returned a 4xx
+// (session already gone), and returns an error if the global budget
+// expires with abort calls still pending.
+func (s *Supervisor) abortSessions(ctx context.Context, baseURL, password string, sessions []string) error {
+	if len(sessions) == 0 {
+		return nil
+	}
+	budgetCtx, cancel := context.WithTimeout(ctx, supervisorDrainBudget)
+	defer cancel()
+
+	httpClient := &http.Client{Timeout: supervisorAbortRequest}
+	base := strings.TrimRight(baseURL, "/")
+	var wg sync.WaitGroup
+	for _, id := range sessions {
+		id := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			abortURL := fmt.Sprintf("%s/session/%s/abort", base, id)
+			req, err := http.NewRequestWithContext(budgetCtx, http.MethodPost, abortURL, nil)
+			if err != nil {
+				if s.cfg.Logger != nil {
+					s.cfg.Logger.Warn("opencode 取消 session 失敗",
+						"phase", "失敗",
+						"session_id", id,
+						"error", err,
+					)
+				}
+				return
+			}
+			req.SetBasicAuth(supervisorAuthUsername, password)
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				if s.cfg.Logger != nil {
+					s.cfg.Logger.Warn("opencode 取消 session 失敗",
+						"phase", "失敗",
+						"session_id", id,
+						"error", err,
+					)
+				}
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-budgetCtx.Done():
+		return fmt.Errorf("opencode supervisor abort budget exceeded (%s)", supervisorDrainBudget)
+	}
+}
+
+// internalStop runs the SIGTERM → grace → reset sequence shared by
+// Stop, idleStop, and Drain. Caller is responsible for state transitions
+// (flipping to stopping, closing spawnReady on completion). Waits for
+// exitCh to close (signalled by spawn's wait goroutine after cmd.Wait
+// returns) rather than reading the wait error channel directly — close-
+// as-broadcast lets multiple stop initiators coexist without a race for
+// a single-receive channel value. The wait error itself is read from
+// s.waitErr via getWaitErr after exitCh has closed.
+func (s *Supervisor) internalStop(ctx context.Context, cancelRun context.CancelFunc, exitCh chan struct{}, pid int) error {
+	if cancelRun != nil {
+		cancelRun()
+	}
+
+	var err error
+	if exitCh != nil {
+		select {
+		case <-exitCh:
+			err = s.getWaitErr()
+		case <-ctx.Done():
+			err = fmt.Errorf("stop opencode serve: %w", ctx.Err())
+		case <-time.After(supervisorStopGrace + 2*time.Second):
+			err = errors.New("opencode serve did not exit within grace window")
+		}
+	}
+
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("opencode serve 已停止",
+			"phase", "完成",
+			"pid", pid,
+			"wait_err", errString(err),
+		)
+	}
+
+	s.mu.Lock()
+	s.cmd = nil
+	s.cancel = nil
+	s.baseURL = ""
+	s.password = ""
+	s.pid = 0
+	s.exitCh = nil
+	s.waitErr = nil
+	s.activeCount = 0
+	s.activeSessions = make(map[string]struct{})
+	s.mu.Unlock()
+
+	if isExpectedExitOnSignal(err) {
+		return nil
+	}
+	return err
+}
+
+// BaseURL returns the listen URL the child reported on startup, e.g.
+// "http://127.0.0.1:50000". Empty before Acquire/Start succeeds.
+func (s *Supervisor) BaseURL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.baseURL
+}
+
+// Password returns the random OPENCODE_SERVER_PASSWORD passed to the
+// child via env. Empty before Acquire/Start succeeds.
+func (s *Supervisor) Password() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.password
+}
+
+// ChildPID returns the OS process ID of the spawned `opencode serve`.
+// Zero before Acquire/Start succeeds. Returns the stale-but-dead PID
+// briefly during Stop/idleStop/Drain before internal reset; treat the
+// value as informational.
+func (s *Supervisor) ChildPID() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pid
+}
+
+// spawn is the pure fork-and-wait-ready primitive shared by Start and
+// Acquire. Does not touch state machine fields directly (caller flips
+// state before / after) — except for the unexpected-exit branch in the
+// wait goroutine, which flips `running → crashed` on its own. On
+// success, fills s.cmd / cancel / baseURL / password / pid / exitCh
+// under s.mu. On failure, ensures runCtx is cancelled so no leak.
+func (s *Supervisor) spawn(ctx context.Context) error {
 	password, err := generateSupervisorPassword()
 	if err != nil {
 		return fmt.Errorf("generate password: %w", err)
@@ -109,13 +633,35 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return fmt.Errorf("start opencode serve: %w", err)
 	}
 
-	waitErr := make(chan error, 1)
-	go func() { waitErr <- cmd.Wait() }()
+	exitCh := make(chan struct{})
+	// Wait goroutine: single owner of cmd.Wait. On exit it captures the
+	// error into s.waitErr (single-writer; readers gate on exitCh close)
+	// and flips state to `crashed` when state was still `running` —
+	// signals an unexpected death that retry-once (Task 3.2-9) can act
+	// on. When state is already `stopping`, the goroutine just observes
+	// the exit; the stop initiator owns the transition.
+	go func() {
+		werr := cmd.Wait()
+		s.mu.Lock()
+		s.waitErr = werr
+		if s.state == stateRunning {
+			s.state = stateCrashed
+			if s.cfg.Logger != nil {
+				s.cfg.Logger.Warn("opencode serve 意外退出",
+					"phase", "失敗",
+					"pid", s.pid,
+					"wait_err", errString(werr),
+				)
+			}
+		}
+		s.mu.Unlock()
+		close(exitCh)
+	}()
 
 	startCtx, cancelStart := context.WithTimeout(ctx, supervisorStartTimeout)
 	defer cancelStart()
 
-	baseURL, err := awaitSupervisorListenURL(startCtx, stdout, waitErr, s.cfg.Logger)
+	baseURL, err := awaitSupervisorListenURL(startCtx, stdout, exitCh, s.getWaitErr, s.cfg.Logger)
 	if err != nil {
 		cancelRun()
 		return err
@@ -132,8 +678,8 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	s.baseURL = baseURL
 	s.password = password
 	s.pid = cmd.Process.Pid
-	s.started = true
-	s.waitErr = waitErr
+	s.exitCh = exitCh
+	s.waitErr = nil
 	s.mu.Unlock()
 
 	if s.cfg.Logger != nil {
@@ -146,70 +692,14 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop signals SIGTERM to the child process and waits up to
-// supervisorStopGrace + 1s for it to exit. Cancellation of runCtx triggers
-// cmd.Cancel (SIGTERM); cmd.WaitDelay escalates to SIGKILL after the
-// grace window if the child is still alive. Idempotent: calling Stop on
-// a never-started or already-stopped supervisor is a no-op.
-func (s *Supervisor) Stop(ctx context.Context) error {
-	s.mu.Lock()
-	if !s.started {
-		s.mu.Unlock()
-		return nil
-	}
-	s.started = false
-	cancelRun := s.cancel
-	waitErr := s.waitErr
-	pid := s.pid
-	s.mu.Unlock()
-
-	cancelRun()
-
-	select {
-	case err := <-waitErr:
-		if s.cfg.Logger != nil {
-			s.cfg.Logger.Info("opencode serve 已停止",
-				"phase", "完成",
-				"pid", pid,
-				"wait_err", errString(err),
-			)
-		}
-		if isExpectedExitOnSignal(err) {
-			return nil
-		}
-		return err
-	case <-ctx.Done():
-		return fmt.Errorf("stop opencode serve: %w", ctx.Err())
-	case <-time.After(supervisorStopGrace + 2*time.Second):
-		return errors.New("opencode serve did not exit within grace window")
-	}
-}
-
-// BaseURL returns the listen URL the child reported on startup, e.g.
-// "http://127.0.0.1:50000". Empty before Start succeeds.
-func (s *Supervisor) BaseURL() string {
+// getWaitErr returns the wait goroutine's last captured cmd.Wait error.
+// Only valid to read after exitCh closes (single-writer pattern). Used
+// by awaitSupervisorListenURL on the early-exit branch to surface the
+// child's exit error before listen URL is printed.
+func (s *Supervisor) getWaitErr() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.baseURL
-}
-
-// Password returns the random OPENCODE_SERVER_PASSWORD passed to the
-// child via env. Empty before Start succeeds.
-func (s *Supervisor) Password() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.password
-}
-
-// ChildPID returns the OS process ID of the spawned `opencode serve`.
-// Zero before Start succeeds. Returns the stale-but-dead PID after
-// Stop completes — Stop does not reset internal fields. Treat the
-// value as informational (registry display, span attrs); do not use
-// it to send signals or check liveness after Stop.
-func (s *Supervisor) ChildPID() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.pid
+	return s.waitErr
 }
 
 func generateSupervisorPassword() (string, error) {
@@ -229,7 +719,7 @@ func buildSupervisorEnv(password, storageDir string) []string {
 	return env
 }
 
-func awaitSupervisorListenURL(ctx context.Context, stdout io.ReadCloser, waitErr <-chan error, logger *slog.Logger) (string, error) {
+func awaitSupervisorListenURL(ctx context.Context, stdout io.ReadCloser, exitCh <-chan struct{}, getWaitErr func() error, logger *slog.Logger) (string, error) {
 	urlCh := make(chan string, 1)
 	scanDone := make(chan error, 1)
 	go func() {
@@ -262,8 +752,8 @@ func awaitSupervisorListenURL(ctx context.Context, stdout io.ReadCloser, waitErr
 			return "", fmt.Errorf("opencode serve stdout 讀取失敗: %w", err)
 		}
 		return "", errors.New("opencode serve stdout 結束但未印出 listen URL")
-	case err := <-waitErr:
-		return "", fmt.Errorf("opencode serve 啟動失敗 (process exited): %w", err)
+	case <-exitCh:
+		return "", fmt.Errorf("opencode serve 啟動失敗 (process exited): %w", getWaitErr())
 	case <-ctx.Done():
 		return "", fmt.Errorf("opencode serve 啟動逾時 (%s): %w", supervisorStartTimeout, ctx.Err())
 	}

--- a/worker/agent/server_supervisor.go
+++ b/worker/agent/server_supervisor.go
@@ -27,14 +27,14 @@ import (
 // boot path uses Acquire/Release instead.
 
 const (
-	supervisorStartTimeout   = 10 * time.Second
-	supervisorStopGrace      = 5 * time.Second
-	supervisorHealthInterval = 200 * time.Millisecond
-	supervisorHealthRequest  = 2 * time.Second
-	supervisorStopTimeout    = 10 * time.Second
-	supervisorDrainBudget    = 30 * time.Second
-	supervisorAbortRequest   = 5 * time.Second
-	supervisorAuthUsername   = "opencode"
+	supervisorStartTimeout       = 10 * time.Second
+	supervisorStopGrace          = 5 * time.Second
+	supervisorHealthInterval     = 200 * time.Millisecond
+	supervisorHealthRequest      = 2 * time.Second
+	supervisorDrainBudget        = 30 * time.Second
+	supervisorDrainSettleBudget  = 10 * time.Second
+	supervisorAbortRequest       = 5 * time.Second
+	supervisorAuthUsername       = "opencode"
 )
 
 // supervisorListenLine matches opencode serve's startup line printed
@@ -119,8 +119,11 @@ type Supervisor struct {
 	// failure). Stage 3 Acquire coalesces concurrent first-job goroutines
 	// onto this channel rather than spinning a sync.Cond — channel close
 	// is broadcast-safe and composes with ctx.Done in a select.
+	// On spawn failure waiters re-check state under the lock and may
+	// retry spawn themselves; deliberate, since the failure could be
+	// transient (e.g. fake-binary-misconfigured-then-corrected) and
+	// caching the error here would block legitimate retry.
 	spawnReady chan struct{}
-	spawnErr   error
 	// activeSessions tracks the in-flight session IDs so Drain can issue
 	// POST /session/{id}/abort to each. Maintained by SetActiveSession /
 	// ClearActiveSession from runOneServer once a session is created.
@@ -178,7 +181,6 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	s.mu.Lock()
 	if err != nil {
 		s.state = stateIdle
-		s.spawnErr = err
 		close(s.spawnReady)
 		s.mu.Unlock()
 		return err
@@ -258,11 +260,31 @@ func (s *Supervisor) Acquire(ctx context.Context) error {
 			s.mu.Lock()
 			if err != nil {
 				s.state = stateIdle
-				s.spawnErr = err
 				close(s.spawnReady)
 				s.spawnReady = nil
 				s.mu.Unlock()
 				return err
+			}
+			// Drain may have flipped shuttingDown while spawn was
+			// running. If so, the spawn-completion path owns the
+			// teardown — Drain's `state == stateStarting` wait
+			// observes our spawnReady close, but Drain itself never
+			// learns about the child unless we hand it off. Tear
+			// it down inline rather than transitioning to running.
+			if s.shuttingDown {
+				cancelRun := s.cancel
+				exitCh := s.exitCh
+				pid := s.pid
+				s.state = stateStopping
+				readyCh := s.spawnReady
+				s.mu.Unlock()
+				_ = s.internalStop(context.Background(), cancelRun, exitCh, pid)
+				s.mu.Lock()
+				s.state = stateIdle
+				close(readyCh)
+				s.spawnReady = nil
+				s.mu.Unlock()
+				return errors.New("supervisor shutting down (spawn raced with drain)")
 			}
 			s.state = stateRunning
 			s.activeCount++
@@ -417,6 +439,29 @@ func (s *Supervisor) Drain(ctx context.Context) error {
 		s.idleTimer.Stop()
 		s.idleTimer = nil
 	}
+	// Wait out transient states (starting / stopping). shuttingDown
+	// latch above tells the Acquire spawn-completion path to tear its
+	// new child down rather than transition to running; idle stop in
+	// flight just runs to completion. After this loop state is one of
+	// {idle, running, crashed} — no orphan-child risk.
+	for s.state == stateStarting || s.state == stateStopping {
+		readyCh := s.spawnReady
+		s.mu.Unlock()
+		if readyCh == nil {
+			select {
+			case <-time.After(50 * time.Millisecond):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		} else {
+			select {
+			case <-readyCh:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		s.mu.Lock()
+	}
 	if s.state != stateRunning {
 		s.mu.Unlock()
 		return nil
@@ -444,6 +489,12 @@ func (s *Supervisor) Drain(ctx context.Context) error {
 			)
 		}
 		drainErr = s.abortSessions(ctx, baseURL, password, sessions)
+
+		// Wait for in-flight runOneServer attempts to observe the
+		// abort and clear their session slots. Capped at
+		// supervisorDrainSettleBudget; on timeout we proceed to
+		// SIGTERM anyway and the warn surfaces stragglers.
+		s.waitActiveSessionsCleared(ctx)
 	}
 
 	stopErr := s.internalStop(ctx, cancelRun, exitCh, pid)
@@ -458,6 +509,40 @@ func (s *Supervisor) Drain(ctx context.Context) error {
 		return drainErr
 	}
 	return stopErr
+}
+
+// waitActiveSessionsCleared spins up to supervisorDrainSettleBudget
+// polling for the activeSessions map to empty. Bound is intentionally
+// shorter than the abort budget — POST aborts already had their own
+// 30s window; this is just letting the in-flight runOneServer
+// goroutines unwind their defers (ClearActiveSession + Release). On
+// timeout we proceed to SIGTERM; the warn log surfaces remaining
+// session IDs so an operator can correlate.
+func (s *Supervisor) waitActiveSessionsCleared(ctx context.Context) {
+	settleCtx, cancel := context.WithTimeout(ctx, supervisorDrainSettleBudget)
+	defer cancel()
+	for {
+		s.mu.Lock()
+		remaining := len(s.activeSessions)
+		s.mu.Unlock()
+		if remaining == 0 {
+			return
+		}
+		select {
+		case <-settleCtx.Done():
+			s.mu.Lock()
+			remaining = len(s.activeSessions)
+			s.mu.Unlock()
+			if s.cfg.Logger != nil && remaining > 0 {
+				s.cfg.Logger.Warn("opencode supervisor drain settle 超時，仍有 in-flight session",
+					"phase", "處理中",
+					"remaining", remaining,
+				)
+			}
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
 // abortSessions POSTs /session/{id}/abort for each active session, in

--- a/worker/agent/server_supervisor_test.go
+++ b/worker/agent/server_supervisor_test.go
@@ -571,6 +571,67 @@ func TestSupervisor_KillChildFlipsToCrashed_ThenRespawn(t *testing.T) {
 	sup.Release()
 }
 
+// TestSupervisor_MultiInstancePortIsolation verifies that N supervisors
+// started concurrently in the same process each get distinct listen
+// URLs and each /health probe succeeds. Stage 3 Task 3.2-12. The real
+// kernel-assigned port behavior comes from `opencode serve --port 0`;
+// fake binaries point at independent httptest servers (each on its own
+// kernel-assigned port via httptest.NewServer), which is the local
+// stand-in. Successful Start implies /health returned green for that
+// supervisor — Start blocks on the probe before returning nil.
+func TestSupervisor_MultiInstancePortIsolation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	const N = 4
+	var (
+		servers     [N]*httptest.Server
+		supervisors [N]*Supervisor
+	)
+	for i := 0; i < N; i++ {
+		servers[i] = newFakeHealthServer(t, "")
+		binPath := writeFakeOpencodeServeBinary(t, servers[i].URL, "sleep")
+		supervisors[i] = NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	}
+	defer func() {
+		for _, sup := range supervisors {
+			_ = sup.Stop(context.Background())
+		}
+		for _, srv := range servers {
+			srv.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = supervisors[i].Start(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	seenURL := make(map[string]int)
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("supervisor[%d].Start: %v", i, errs[i])
+			continue
+		}
+		url := supervisors[i].BaseURL()
+		if url == "" {
+			t.Errorf("supervisor[%d] BaseURL = empty", i)
+			continue
+		}
+		seenURL[url]++
+	}
+	if len(seenURL) != N {
+		t.Errorf("supervisor URLs not unique across %d instances: %v", N, seenURL)
+	}
+}
+
 func TestSupervisor_Acquire_RejectedDuringShutdown(t *testing.T) {
 	sup := NewSupervisor(SupervisorConfig{BinaryPath: "/never-spawned"})
 	sup.mu.Lock()

--- a/worker/agent/server_supervisor_test.go
+++ b/worker/agent/server_supervisor_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -245,6 +246,286 @@ func TestSupervisor_Stop_Idempotent(t *testing.T) {
 	sup := NewSupervisor(SupervisorConfig{BinaryPath: "/never-started"})
 	if err := sup.Stop(context.Background()); err != nil {
 		t.Errorf("Stop on never-started supervisor: %v", err)
+	}
+}
+
+// Stage 3 lazy lifecycle tests. The supervisor in Stage 3 boots in
+// `idle` state; the first Acquire triggers spawn. Release decrements
+// the active count and arms an idle timer (when IdleTimeout > 0).
+
+func TestSupervisor_Acquire_LazySpawnAndRelease(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	defer func() { _ = sup.Stop(context.Background()) }()
+
+	if got := sup.State(); got != stateIdle {
+		t.Errorf("pre-Acquire State = %s, want idle", got)
+	}
+	if pid := sup.ChildPID(); pid != 0 {
+		t.Errorf("pre-Acquire ChildPID = %d, want 0", pid)
+	}
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if got := sup.State(); got != stateRunning {
+		t.Errorf("post-Acquire State = %s, want running", got)
+	}
+	if sup.ChildPID() == 0 {
+		t.Error("post-Acquire ChildPID = 0")
+	}
+	if sup.BaseURL() != srv.URL {
+		t.Errorf("BaseURL = %q, want %q", sup.BaseURL(), srv.URL)
+	}
+
+	sup.Release()
+	if got := sup.State(); got != stateRunning {
+		t.Errorf("post-Release State = %s, want running (no IdleTimeout)", got)
+	}
+}
+
+func TestSupervisor_Acquire_ConcurrentCoalesceSingleSpawn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	defer func() { _ = sup.Stop(context.Background()) }()
+
+	const N = 8
+	var wg sync.WaitGroup
+	pids := make([]int, N)
+	urls := make([]string, N)
+	errs := make([]error, N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := sup.Acquire(context.Background())
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			pids[i] = sup.ChildPID()
+			urls[i] = sup.BaseURL()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var firstPID int
+	var firstURL string
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Errorf("Acquire[%d]: %v", i, errs[i])
+			continue
+		}
+		if firstPID == 0 {
+			firstPID = pids[i]
+			firstURL = urls[i]
+			continue
+		}
+		if pids[i] != firstPID {
+			t.Errorf("Acquire[%d] PID = %d, want %d (coalescence broken — multiple spawns)", i, pids[i], firstPID)
+		}
+		if urls[i] != firstURL {
+			t.Errorf("Acquire[%d] URL = %q, want %q", i, urls[i], firstURL)
+		}
+	}
+
+	// Drain all Releases to confirm activeCount tracks correctly.
+	for i := 0; i < N; i++ {
+		sup.Release()
+	}
+	sup.mu.Lock()
+	got := sup.activeCount
+	sup.mu.Unlock()
+	if got != 0 {
+		t.Errorf("activeCount after N Releases = %d, want 0", got)
+	}
+}
+
+func TestSupervisor_Acquire_IdleStopThenRespawn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{
+		BinaryPath:  binPath,
+		IdleTimeout: 100 * time.Millisecond,
+	})
+	defer func() { _ = sup.Stop(context.Background()) }()
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire 1: %v", err)
+	}
+	pid1 := sup.ChildPID()
+	if pid1 == 0 {
+		t.Fatal("PID is 0 after first Acquire")
+	}
+	sup.Release()
+
+	// Idle timer fires after 100ms; internal stop adds another ~50ms
+	// for the sleep child to die. 3s is plenty of headroom.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sup.State() == stateIdle {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if sup.State() != stateIdle {
+		t.Fatalf("supervisor state = %s, want idle after IdleTimeout", sup.State())
+	}
+	if alive, _ := processAlive(pid1); alive {
+		t.Errorf("PID %d still alive after idle stop", pid1)
+	}
+	if sup.ChildPID() != 0 {
+		t.Errorf("ChildPID = %d after idle stop, want 0", sup.ChildPID())
+	}
+
+	// Re-acquire must trigger fresh spawn — different PID.
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire 2: %v", err)
+	}
+	pid2 := sup.ChildPID()
+	if pid2 == 0 {
+		t.Fatal("PID is 0 after second Acquire")
+	}
+	if pid2 == pid1 {
+		t.Errorf("re-Acquire produced same PID %d (no respawn)", pid2)
+	}
+	sup.Release()
+}
+
+func TestSupervisor_Drain_RejectsPostDrainAcquire(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	pid := sup.ChildPID()
+	sup.Release()
+
+	if err := sup.Drain(context.Background()); err != nil {
+		t.Errorf("Drain: %v", err)
+	}
+	if alive, _ := processAlive(pid); alive {
+		t.Errorf("PID %d still alive after Drain", pid)
+	}
+
+	err := sup.Acquire(context.Background())
+	if err == nil {
+		t.Fatal("Acquire after Drain succeeded")
+	}
+	if !strings.Contains(err.Error(), "shutting down") {
+		t.Errorf("Acquire post-Drain error = %v, want 'shutting down' substring", err)
+	}
+}
+
+func TestSupervisor_Drain_AbortsActiveSessions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+
+	var (
+		abortedMu sync.Mutex
+		aborted   []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != supervisorAuthUsername || p == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"healthy":true,"version":"fake"}`))
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/abort") {
+			parts := strings.Split(r.URL.Path, "/")
+			if len(parts) >= 4 {
+				abortedMu.Lock()
+				aborted = append(aborted, parts[2])
+				abortedMu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	pid := sup.ChildPID()
+	sup.SetActiveSession("ses_1")
+	sup.SetActiveSession("ses_2")
+	sup.SetActiveSession("ses_3")
+
+	if err := sup.Drain(context.Background()); err != nil {
+		t.Errorf("Drain: %v", err)
+	}
+	if alive, _ := processAlive(pid); alive {
+		t.Errorf("PID %d still alive after Drain", pid)
+	}
+
+	abortedMu.Lock()
+	got := append([]string(nil), aborted...)
+	abortedMu.Unlock()
+	if len(got) != 3 {
+		t.Fatalf("aborted = %v, want 3 abort calls", got)
+	}
+	seen := map[string]bool{}
+	for _, id := range got {
+		seen[id] = true
+	}
+	for _, want := range []string{"ses_1", "ses_2", "ses_3"} {
+		if !seen[want] {
+			t.Errorf("session %q never aborted (got %v)", want, got)
+		}
+	}
+}
+
+func TestSupervisor_Acquire_RejectedDuringShutdown(t *testing.T) {
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: "/never-spawned"})
+	sup.mu.Lock()
+	sup.shuttingDown = true
+	sup.mu.Unlock()
+
+	err := sup.Acquire(context.Background())
+	if err == nil {
+		t.Fatal("Acquire on shuttingDown supervisor succeeded")
+	}
+	if !strings.Contains(err.Error(), "shutting down") {
+		t.Errorf("error = %v, want 'shutting down'", err)
 	}
 }
 

--- a/worker/agent/server_supervisor_test.go
+++ b/worker/agent/server_supervisor_test.go
@@ -514,6 +514,65 @@ func TestSupervisor_Drain_AbortsActiveSessions(t *testing.T) {
 	}
 }
 
+// TestSupervisor_Drain_DuringSpawn verifies the cross-review pr fix
+// for the Drain-vs-Acquire race. Acquire enters stateStarting and
+// blocks inside spawn (the fake binary sleeps before printing the
+// listen URL). Drain fires while state is still stateStarting; per
+// the fix, Drain waits for spawn to settle and the spawn-completion
+// path in Acquire detects shuttingDown and tears the new child down
+// before transitioning to running.
+func TestSupervisor_Drain_DuringSpawn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "opencode")
+	// Delay the listen URL by 500ms so Drain races into stateStarting.
+	script := fmt.Sprintf("#!/bin/sh\nsleep 0.5\necho \"opencode server listening on %s\"\nexec sleep 600\n", srv.URL)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write delayed fake binary: %v", err)
+	}
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: bin})
+
+	acquireErrCh := make(chan error, 1)
+	go func() {
+		acquireErrCh <- sup.Acquire(context.Background())
+	}()
+
+	// Let Acquire enter stateStarting and cmd.Start the child.
+	time.Sleep(100 * time.Millisecond)
+	if sup.State() != stateStarting {
+		t.Fatalf("supervisor state = %s, want starting (test timing race)", sup.State())
+	}
+
+	drainErr := sup.Drain(context.Background())
+	if drainErr != nil {
+		t.Errorf("Drain returned error: %v", drainErr)
+	}
+
+	select {
+	case acquireErr := <-acquireErrCh:
+		if acquireErr == nil {
+			t.Error("Acquire racing Drain should have errored")
+		}
+		if acquireErr != nil && !strings.Contains(acquireErr.Error(), "shutting down") {
+			t.Errorf("Acquire error = %v, want substring 'shutting down'", acquireErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Acquire did not return within 5s after Drain")
+	}
+
+	if sup.State() != stateIdle {
+		t.Errorf("post-Drain state = %s, want idle", sup.State())
+	}
+	if sup.ChildPID() != 0 {
+		t.Errorf("post-Drain ChildPID = %d, want 0 (child cleaned up)", sup.ChildPID())
+	}
+}
+
 func TestSupervisor_KillChildFlipsToCrashed_ThenRespawn(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sh script not supported on windows")
@@ -571,15 +630,20 @@ func TestSupervisor_KillChildFlipsToCrashed_ThenRespawn(t *testing.T) {
 	sup.Release()
 }
 
-// TestSupervisor_MultiInstancePortIsolation verifies that N supervisors
+// TestSupervisor_MultiInstanceWiring verifies that N supervisors
 // started concurrently in the same process each get distinct listen
-// URLs and each /health probe succeeds. Stage 3 Task 3.2-12. The real
-// kernel-assigned port behavior comes from `opencode serve --port 0`;
-// fake binaries point at independent httptest servers (each on its own
-// kernel-assigned port via httptest.NewServer), which is the local
-// stand-in. Successful Start implies /health returned green for that
-// supervisor — Start blocks on the probe before returning nil.
-func TestSupervisor_MultiInstancePortIsolation(t *testing.T) {
+// URLs and each /health probe succeeds. Stage 3 Task 3.2-12.
+//
+// This is *not* a real kernel-port-collision stress test — the fake
+// binaries each point at their own httptest server (which already gets
+// a kernel-assigned port), so the per-instance URL distinction is a
+// foregone conclusion. What this test actually pins down is the
+// supervisor's per-instance wiring (BaseURL/Password/state) under
+// concurrent Start. The real `opencode serve --port 0` kernel-port
+// allocation lives in opencode itself and is out of scope for unit
+// tests; Manifest §1.7 and spec §F6 explicitly delegate collision
+// safety to the kernel.
+func TestSupervisor_MultiInstanceWiring(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sh script not supported on windows")
 	}

--- a/worker/agent/server_supervisor_test.go
+++ b/worker/agent/server_supervisor_test.go
@@ -514,6 +514,63 @@ func TestSupervisor_Drain_AbortsActiveSessions(t *testing.T) {
 	}
 }
 
+func TestSupervisor_KillChildFlipsToCrashed_ThenRespawn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh script not supported on windows")
+	}
+	srv := newFakeHealthServer(t, "")
+	defer srv.Close()
+
+	binPath := writeFakeOpencodeServeBinary(t, srv.URL, "sleep")
+	sup := NewSupervisor(SupervisorConfig{BinaryPath: binPath})
+	defer func() { _ = sup.Stop(context.Background()) }()
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	pid := sup.ChildPID()
+	if pid == 0 {
+		t.Fatal("PID is 0 after Acquire")
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill child: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sup.State() == stateCrashed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if sup.State() != stateCrashed {
+		t.Fatalf("supervisor state = %s, want crashed after SIGKILL", sup.State())
+	}
+
+	// Release the slot we acquired before the crash so re-Acquire's
+	// idle-timer reset path is clean. (activeCount was 1; the wait
+	// goroutine doesn't touch activeCount on unexpected exit, so we
+	// still hold the slot — release is necessary even though the
+	// child is dead.)
+	sup.Release()
+
+	if err := sup.Acquire(context.Background()); err != nil {
+		t.Fatalf("re-Acquire after crash: %v", err)
+	}
+	newPID := sup.ChildPID()
+	if newPID == 0 {
+		t.Error("post-crash respawn PID is 0")
+	}
+	if newPID == pid {
+		t.Errorf("post-crash respawn PID = %d, want a different PID (no actual respawn)", newPID)
+	}
+	if sup.State() != stateRunning {
+		t.Errorf("post-respawn state = %s, want running", sup.State())
+	}
+	sup.Release()
+}
+
 func TestSupervisor_Acquire_RejectedDuringShutdown(t *testing.T) {
 	sup := NewSupervisor(SupervisorConfig{BinaryPath: "/never-spawned"})
 	sup.mu.Lock()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -30,6 +30,12 @@ var (
 	Date    = "unknown"
 )
 
+// opencodeSupervisorDrainTimeout caps the supervisor Drain operation
+// on worker shutdown. Has to cover the 30s active-session abort budget
+// plus the ~10s SIGTERM grace inside Supervisor.Drain; 60s gives
+// headroom for an upstream slowdown to settle.
+const opencodeSupervisorDrainTimeout = 60 * time.Second
+
 // Run starts the worker process: initializes logging, connects Redis, builds
 // the pool, and waits for SIGTERM/SIGINT. Returns on clean shutdown or error.
 func Run(cfg *config.Config) error {
@@ -117,25 +123,29 @@ func Run(cfg *config.Config) error {
 			"required", agent.MinimumOpencodeVersion,
 		)
 
-		// Spawn the long-running `opencode serve` child. Always-on at
-		// Stage 2 (lazy lifecycle stays Task 3.2-8 / Stage 3). Worker
-		// pool's N goroutines share the single supervisor via per-
+		// Wire the supervisor in lazy mode (Stage 3): worker boot does
+		// NOT spawn the `opencode serve` child. First Acquire by
+		// runOneServer triggers spawn; pool idle for IdleTimeout
+		// auto-stops the child. Worker SIGTERM goes through Drain,
+		// which aborts active sessions before SIGTERM-ing the child.
+		// Pool's N goroutines share the single supervisor via per-
 		// request `x-opencode-directory` header isolation.
 		serverLogger := logging.ComponentLogger(slog.Default(), "OpencodeServer")
 		supervisor := agent.NewSupervisor(agent.SupervisorConfig{
-			BinaryPath: opencodeAgent.Command,
-			StorageDir: cfg.Opencode.StorageDir,
-			Logger:     serverLogger,
+			BinaryPath:  opencodeAgent.Command,
+			StorageDir:  cfg.Opencode.StorageDir,
+			IdleTimeout: cfg.Opencode.IdleTimeout,
+			Logger:      serverLogger,
 		})
-		if err := supervisor.Start(context.Background()); err != nil {
-			return fmt.Errorf("start opencode supervisor: %w", err)
-		}
 		agentRunner.SetOpencodeSupervisor(supervisor)
 		defer func() {
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer stopCancel()
-			if err := supervisor.Stop(stopCtx); err != nil {
-				appLogger.Warn("opencode supervisor stop 失敗",
+			// Drain budget is 30s for active-session aborts + ~10s
+			// SIGTERM grace; 60s gives headroom for the abort phase to
+			// settle even when an upstream is slow.
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), opencodeSupervisorDrainTimeout)
+			defer drainCancel()
+			if err := supervisor.Drain(drainCtx); err != nil {
+				appLogger.Warn("opencode supervisor drain 失敗",
 					"phase", "失敗",
 					"error", err,
 				)


### PR DESCRIPTION
## Summary

Stage 3 of the opencode server-mode rollout. Builds on Stage 1 (#259, config + dispatcher) and Stage 2 (#260, always-on supervisor + happy path). Adds the resilience layer spec §F3–F7 promised: lazy lifecycle, crash recovery + retry-once, SIGTERM drain teardown, Bug A silent-drop detection, multi-worker port safety.

Stage 4 (perf benchmarks + docs/init template — plan tasks 3.2-13/14) lands separately.

## Commits

| Hash | Subject | Plan task |
|---|---|---|
| 12499cb | feat(worker/agent): lazy opencode serve lifecycle + SIGTERM drain teardown | 3.2-8 + 3.2-10 |
| cebb064 | feat(worker/agent): retry-once on opencode server crash mid-job | 3.2-9 |
| f996a2a | feat(worker/agent): detect opencode silent-drop signature on finish-other empty stream | 3.2-11 |
| dd103fe | test(worker/agent): verify N concurrent supervisors get distinct ports | 3.2-12 |
| c27b310 | fix(worker/agent): address cross-review pr findings on stage 3 supervisor | cross-review |

## Lifecycle changes

### Lazy supervisor (Task 3.2-8)
Worker boot no longer eagerly spawns `opencode serve`. New state machine: `idle / starting / running / stopping / crashed`. First Acquire coalesces N concurrent goroutines onto one spawn via mutex + spawnReady channel. Release decrements activeCount and arms `cfg.Opencode.IdleTimeout` to auto-stop the child when the pool quiesces. Subsequent jobs respawn fresh.

### SIGTERM drain (Task 3.2-10)
Worker SIGTERM goes through `Supervisor.Drain` instead of `Stop`: snapshot active session IDs, POST `/session/{id}/abort` to each within 30s budget, wait 10s for in-flight runOneServer goroutines to unwind, then SIGTERM + 5s grace + SIGKILL fallback. Drain flips a one-shot `shuttingDown` latch so post-Drain Acquires fail loudly instead of re-spawning during teardown.

### Retry-once on crash (Task 3.2-9)
runOneServer split into a retry shell + per-attempt body. Transport-layer crashes (state==crashed, ECONNREFUSED, EOF, broken pipe) trigger one retry against a freshly-spawned server. Second failure within retry escalates to a hard failure; no third attempt, no spawn-mode fallback (spec C4). Application errors (4xx, ctx cancel) skip retry entirely.

### Bug A detection (Task 3.2-11)
Three-condition AND-gate `finish=other && tokens.output=0 && !SawTextPart` returns sentinel `errOpencodeEmptyStream` whose message is the spec's user-facing copy verbatim: `LLM 回應為空，請稍後再試或改用 @bot issue`. Bug A short-circuits the retry shell (application outcome, not transport).

**§2.2 Manifest trade-off**: Slack-visible failure render currently shows `:x: 思考失敗：all agents failed: opencode: LLM 回應為空，請稍後再試或改用 @bot issue`. Spec § Boundaries Ask first forbids widening scope to `app/` without approval; a follow-up PR can clean up the wrapping prefix by special-casing the sentinel in `app/workflow/ask.go HandleResult`. If reviewer prefers cleaner copy now, can patch in-PR.

### Multi-worker port test (Task 3.2-12)
Test asserts N=4 concurrent supervisors get distinct listen URLs and pass /health. Spec §F6 delegates port-collision safety to `opencode serve --port 0` kernel-assigned ports; test pins per-instance wiring, not the kernel allocation itself.

## Cross-review findings addressed

Cross-review of the draft surfaced two critical races + several majors. All addressed in c27b310:

- 🔴 Drain returning nil during stateStarting/stateStopping left orphan child risk → Drain now waits for spawnReady; pinned by `TestSupervisor_Drain_DuringSpawn`
- 🔴 Acquire didn't re-check shuttingDown after spawn completed → spawn-completion path now tears the new child down inline when Drain has raced ahead
- 🟡 OnStarted gated on `attempt == 0` skipped firing on retry-success → CompareAndSwap on per-call atomic flag; pinned by `TestRunOneServer_OnStarted_FiresOnFirstSuccessfulAcquire`
- 🟡 SawTextPart flipped true for zero-byte text deltas → gate on `ev.TextBytes > 0`
- 🟡 Drain didn't honor §1.5 "wait for activeSessions to clear" step → added `waitActiveSessionsCleared` with 10s settle budget
- 🟢 EOF substring match too broad → anchored to `: EOF` and `unexpected EOF`
- 🟢 Unused `supervisorStopTimeout`, `spawnErr` removed; `TestSupervisor_MultiInstancePortIsolation` renamed to `TestSupervisor_MultiInstanceWiring` with honest doc comment

## Test plan

- [x] `go -C worker test ./... -count=1` — green
- [x] `go -C worker test ./... -count=1 -race` — no data races
- [x] `go test ./test/... -count=1` — import direction green
- [x] commitlint passes on all 5 commits
- [x] Uncertainty Manifest at `.claude/manifest/opencode-server-mode-stage-3.md` covers §1-§6 substantively
- [x] Cross-review pr completed; critical findings resolved in c27b310
- [ ] Reviewer: confirm whether the Bug A Slack copy noise (`all agents failed: opencode:` prefix) is acceptable for this PR or should be cleaned in `app/`

## Refs

- Spec: `docs/specs/opencode-server-mode.md`
- Plan: `docs/specs/opencode-server-mode-plan.md`
- ADR: `docs/adr/0005-opencode-server-mode.md`
- POC report: `docs/specs/opencode-server-mode-poc-report.md`
- Stage 1 PR: #259 (merged)
- Stage 2 PR: #260 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)