### PR TITLE
fix(image): bump opencode 1.14.41→1.15.0

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -17,7 +17,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @openai/code
 # "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
 # version downloaded a platform ripgrep binary at startup and failed to
 # extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
-ARG OPENCODE_VERSION=1.14.41
+ARG OPENCODE_VERSION=1.15.0
 RUN curl -sL https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-musl.tar.gz | \
     tar xzf - -C /usr/local/bin opencode
 


### PR DESCRIPTION
## Summary

- Bumps `Dockerfile.release` `ARG OPENCODE_VERSION` from `1.14.41` → `1.15.0` (latest upstream, published 2026-05-15).
- v1.15.0 adds an Effect-based core event system, restores missing JS SDK event types, and tolerates invalid exports in custom tool modules. The intervening 10 patches accumulate bugfixes — notably 1.14.50, which restores HTTP event streams after the initial connect event and repairs the SSE-close regression that previously gated us at 1.14.41 (see `.claude/manifest/bump-opencode-floor-version-1-14-41.md` for the history).
- Server mode was reverted in #264, so the SSE-close behaviour does not load-bear for current production (spawn mode). The bump still clears that gate for any future server-mode revisit.

## Scope

Single-line change in `Dockerfile.release`. `.goreleaser.yaml` does not pass `--build-arg`, so the `ARG` default is the only knob. No deploy yaml is touched — cluster rollout happens when the next release tag is cut and `deploy/worker-opencode.yaml` `image:` is bumped (out of scope here).

## Test plan

- [ ] CI Docker build succeeds with the new `OPENCODE_VERSION` (verifies the `anomalyco/opencode` v1.15.0 `linux-x64-musl` asset URL is reachable and the tarball lays out as expected).
- [ ] After release tag is cut, smoke-test one Slack `@bot` triage on staging to confirm spawn-mode `opencode run` still completes against an existing repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)