### PR TITLE
revert: fix(image) bump opencode 1.14.41→1.15.0 (#266)

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -17,7 +17,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @openai/code
 # "RipgrepExtractionFailedError" that plagued skill loading on 1.4.3 (that
 # version downloaded a platform ripgrep binary at startup and failed to
 # extract it inside the alpine runtime — see opencode PRs #21703 and #22436).
-ARG OPENCODE_VERSION=1.15.0
+ARG OPENCODE_VERSION=1.14.41
 RUN curl -sL https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-musl.tar.gz | \
     tar xzf - -C /usr/local/bin opencode
 


### PR DESCRIPTION
## Why revert

opencode 1.15.0 ships a different `--format json` stdout contract from 1.14.41. In production today (Slack-triggered job `20260515-091328-06d83058`), the in-pod opencode log showed:

| event type | count |
|---|---|
| `message.part.delta` | **1001** |
| `message.part.updated` | 17 |
| `message.updated` | 8 |
| `session.deleted` | 1 |

LLM responded normally, tokens streamed, session completed — but **0 bytes** reached stdout. agentdock's `ReadStreamJSONOpencode` (in `shared/queue/stream.go`) reads stdout, sees nothing, and the worker surfaces "all agents failed" on every job.

Tracing the upstream `packages/opencode/src/cli/cmd/run.ts` emit loop, the stdout `emit()` call only fires when **all three** conditions hold simultaneously:

```ts
event.type === "message.part.updated"  // ✓ 17 times
&& part.type === "text"                // ?
&& part.time?.end                      // ?
```

The 17 `message.part.updated` events never satisfy the latter two together, so stdout stays empty. The agentdock-side parser was written against 1.14.41's contract and predates this change.

## What's in this PR

One-line revert of `Dockerfile.release:20` from `1.15.0` back to `1.14.41`. Nothing else.

Equivalent to reverting merge commit `26efaed` (PR #266).

## What's NOT in this PR (out of scope)

- ConfigMap NBSP fix already applied directly to the cluster ConfigMap (orthogonal — that bug existed silently for 3 weeks under 1.14.41 too, just got surfaced when 1.15.0's stricter JSONC parser refused to load).
- agentdock parser upgrade to handle 1.15.0's delta-based event flow — needs separate spec/plan work against `~/local_file/source-code-library/opencode/packages/opencode/src/cli/cmd/run.ts` to map the new event schema.

## Test plan

- [ ] CI build (`docker build -f Dockerfile.release`) succeeds and the resulting image runs `opencode --version` → `1.14.41`.
- [ ] Deploy to `ai-tools` namespace (or wait for release-please to cut a patch tag), rollout-restart `agentdock-worker-opencode`.
- [ ] Send a Slack `@bot ask` to Niuma in `#測試ai-bot` with a real question (image attachment optional) and verify the bot returns an answer instead of "all agents failed".
- [ ] Tail `kubectl logs -n ai-tools -l role=worker-opencode -c worker` — confirm `output_len` > 0 and `status=completed` reflects an actual answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)