### PR TITLE
fix(worker/agent/opencode_http): unbound SSE line reader (#272)

### DIFF
--- a/worker/agent/opencode_http.go
+++ b/worker/agent/opencode_http.go
@@ -341,47 +341,53 @@ func (c *Client) subscribeEvents(ctx context.Context, directory string, events c
 		defer resp.Body.Close()
 		defer emitTerminal()
 
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.HasPrefix(line, clientSSEDataLinePrefix) {
-				continue
+		// bufio.Reader instead of Scanner: a single opencode bus event
+		// can exceed 1 MB (kimi-k2.6 message.part.updated snapshots
+		// with full text / base64-bearing tool I/O), and Scanner's
+		// per-token size cap aborted the consumer mid-stream. Reader
+		// grows its buffer on demand and has no token size cap; worker
+		// connects only to localhost `opencode serve`, so the
+		// unbounded-line risk is bounded by what opencode emits (#272).
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if strings.HasPrefix(line, clientSSEDataLinePrefix) {
+				raw := []byte(strings.TrimRight(strings.TrimPrefix(line, clientSSEDataLinePrefix), "\r\n"))
+				ev, ok, decErr := decodeOpencodeBusEvent(raw)
+				if decErr != nil {
+					trySendErr(sseErrCh, fmt.Errorf("decode SSE event: %w", decErr))
+					return
+				}
+				if ok && ev.Type == "result" {
+					cumInputTokens += ev.InputTokens
+					cumOutputTokens += ev.OutputTokens
+					cumCostUSD += ev.CostUSD
+					hasStepFinish = true
+				} else if ok {
+					// Track that a non-empty text part landed via SSE;
+					// Stage 3 Task 3.2-11's Bug A detector AND-gates on
+					// the absence of any *meaningful* text part.
+					// Empty-text deltas (TextBytes == 0) don't disqualify
+					// Bug A — opencode occasionally emits zero-byte text
+					// updates that carry no answer payload (cross-review
+					// pr finding).
+					if ev.Type == "message_delta" && ev.TextBytes > 0 && sawText != nil {
+						sawText.Store(true)
+					}
+					select {
+					case events <- ev:
+					case <-ctx.Done():
+						return
+					}
+				}
 			}
-			raw := []byte(strings.TrimPrefix(line, clientSSEDataLinePrefix))
-			ev, ok, decErr := decodeOpencodeBusEvent(raw)
-			if decErr != nil {
-				trySendErr(sseErrCh, fmt.Errorf("decode SSE event: %w", decErr))
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				trySendErr(sseErrCh, fmt.Errorf("scan SSE stream: %w", readErr))
 				return
 			}
-			if !ok {
-				continue
-			}
-			if ev.Type == "result" {
-				cumInputTokens += ev.InputTokens
-				cumOutputTokens += ev.OutputTokens
-				cumCostUSD += ev.CostUSD
-				hasStepFinish = true
-				continue
-			}
-			// Track that a non-empty text part landed via SSE; Stage 3
-			// Task 3.2-11's Bug A detector AND-gates on the absence of
-			// any *meaningful* text part. Empty-text deltas (TextBytes
-			// == 0) don't disqualify Bug A — opencode occasionally
-			// emits zero-byte text updates that carry no answer
-			// payload (cross-review pr finding).
-			if ev.Type == "message_delta" && ev.TextBytes > 0 && sawText != nil {
-				sawText.Store(true)
-			}
-			select {
-			case events <- ev:
-			case <-ctx.Done():
-				return
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			trySendErr(sseErrCh, fmt.Errorf("scan SSE stream: %w", err))
-			return
 		}
 		// SSE close without ctx cancellation: surface as informational
 		// SSE error. Wait() does NOT abort on these; runOneServer logs

--- a/worker/agent/opencode_http_test.go
+++ b/worker/agent/opencode_http_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -387,6 +388,107 @@ func TestClient_SendPrompt_EmptySessionID(t *testing.T) {
 	_, err := c.SendPrompt(context.Background(), "", "/tmp/work", "x")
 	if err == nil {
 		t.Fatal("expected error on empty sessionID")
+	}
+}
+
+// TestClient_SendPrompt_LargeSSELine_DoesNotOverflow guards issue #272:
+// a single `data: ...` SSE line whose JSON payload exceeds the previous
+// 1 MB bufio.Scanner cap aborted the consumer mid-stream with
+// `scan SSE stream: bufio.Scanner: token too long`. Reproduced 100% on
+// 2026-05-15 in ai-tools with kimi-k2.6 ask jobs whose
+// message.part.updated snapshot blew past 1 MB.
+//
+// The POST handler holds its response until the SSE collector signals
+// that the big delta has been consumed. Wait()'s deferred Close cancels
+// the SSE context; without this barrier the cancel would sever a
+// mid-2 MB read and confuse "we couldn't read the line" with "the line
+// is too big to scan". The barrier isolates this test to the line-size
+// concern.
+func TestClient_SendPrompt_LargeSSELine_DoesNotOverflow(t *testing.T) {
+	bigText := strings.Repeat("x", 2*1024*1024)
+	bigEvent := fmt.Sprintf(
+		`{"id":"e2","type":"message.part.updated","properties":{"part":{"type":"text","text":%q}}}`,
+		bigText,
+	)
+	sseDrained := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/event":
+			writeSSELines(w, r, []string{
+				`{"id":"e1","type":"server.connected","properties":{}}`,
+				bigEvent,
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/message"):
+			select {
+			case <-sseDrained:
+			case <-time.After(5 * time.Second):
+				t.Error("timed out waiting for SSE collector to drain big delta")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"info":{"finish":"stop","tokens":{"input":1,"output":1}},"parts":[{"type":"text","text":"final"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "secret", nil)
+	run, err := c.SendPrompt(context.Background(), "ses_001", "/tmp/work", "huge")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	var (
+		sawCorrectDelta bool
+		biggestBytes    int
+		sseErrs         []error
+		drainOnce       sync.Once
+	)
+	collectDone := make(chan struct{})
+	go func() {
+		defer close(collectDone)
+		for {
+			select {
+			case ev, ok := <-run.Events:
+				if !ok {
+					return
+				}
+				if ev.Type == "message_delta" {
+					if ev.TextBytes > biggestBytes {
+						biggestBytes = ev.TextBytes
+					}
+					if ev.TextBytes == len(bigText) {
+						sawCorrectDelta = true
+						drainOnce.Do(func() { close(sseDrained) })
+					}
+				}
+			case err, ok := <-run.SSEErrors:
+				if !ok {
+					continue
+				}
+				sseErrs = append(sseErrs, err)
+			}
+		}
+	}()
+
+	text, err := run.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if text != "final" {
+		t.Errorf("final text = %q, want %q", text, "final")
+	}
+	<-collectDone
+
+	if !sawCorrectDelta {
+		t.Errorf("expected message_delta with TextBytes=%d; biggest seen=%d; sseErrs=%v", len(bigText), biggestBytes, sseErrs)
+	}
+	for _, e := range sseErrs {
+		if strings.Contains(e.Error(), "token too long") {
+			t.Fatalf("SSE consumer aborted on > 1 MB line: %v", e)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Swap `bufio.Scanner` (1 MB hardcoded cap) for `bufio.NewReader` + `ReadString('\n')` in the server-mode SSE consumer at `worker/agent/opencode_http.go:344` — no more per-token size cap.
- Add `TestClient_SendPrompt_LargeSSELine_DoesNotOverflow` that drives a 2 MB SSE `data:` line through a mock server with a barrier on the POST response so `Wait()`'s deferred cancel does not sever the mid-2 MB read; verifies full TextBytes arrives and `token too long` never fires.

Closes #272.

## Root cause

`opencode_http.go:344-345` (pre-fix):

```go
scanner := bufio.NewScanner(resp.Body)
scanner.Buffer(make([]byte, 1024*1024), 1024*1024)  // 1 MB max
```

On 2026-05-15 ai-tools, kimi-k2.6 ask jobs hit the cap 100% of the time. `message.part.updated` snapshots carry the full assistant text (plus any base64-bearing tool I/O), and a single line crossed 1 MB. Scanner aborted with `scan SSE stream: bufio.Scanner: token too long`, jobs still completed via the POST authoritative path, but every job logged the warning + paid an SSE reconnect.

## Fix

`bufio.NewReader` + `ReadString('\n')` grows the internal buffer on demand and has no per-token cap. The worker only ever connects to localhost `opencode serve`, so the unbounded-line risk is bounded by what opencode itself emits.

## Test plan

- [x] `go test ./agent/...` inside `worker/` — 35s, all pass including the new test.
- [x] `go test ./test/...` at repo root — `import_direction_test` still green.
- [x] `go vet ./...` clean.
- [x] `commitlint --last` clean.
- [ ] After merge: release-please cuts 4.0.4 patch, image rebuilds, ai-tools rollout, observe 20 consecutive `@bot ask` jobs for absence of `token too long` (AC #1 from #272).

## Notes

- Single-PR scope: only `worker/agent/opencode_http.go` + sibling `_test.go`. No spec / ADR / agent-args changes — those are orthogonal follow-ups.
- HTTP fallback path in `runner.go` is untouched (AC #3 from #272).